### PR TITLE
Add WhoScored player IDs

### DIFF
--- a/Master.csv
+++ b/Master.csv
@@ -2137,6 +2137,7 @@ code,first_name,second_name,web_name,16-17,17-18,18-19,19-20,20-21,21-22,22-23,2
 494541,Kamari,Doyle,Doyle,,,,,,,769,,,,65983e4d,11582,864480,475756
 494543,Dominic,Ballard,Ballard,,,,,,,770,,,,ed8d597c,11583,864496,454751
 494551,Jayden,Moore,Moore,,,,,,,,,804,,ed23d14e,13648,1122027,538254
+494556,Ollie,Shield,Shield,,,,,,,,,,819,16173169,14483,1211262,
 494595,Florian,Wirtz,Wirtz,,,,,,,,,,382,e7fcf289,8397,598577,394786
 494779,Albert,Grønbæk,Grønbæk,,,,,,,,,734,,0da5076f,12880,503866,424809
 494960,Quilindschy,Hartman,Hartman,,,,,,,,,,192,39e1138f,13727,514285,444739
@@ -2403,6 +2404,7 @@ code,first_name,second_name,web_name,16-17,17-18,18-19,19-20,20-21,21-22,22-23,2
 552425,Sydie,Peck,Peck,,,,,,,,759,,,767d9605,12251,745851,464732
 552427,Will,Lankshear,Lankshear,,,,,,,,,609,598,92df535b,13127,879768,468091
 553299,Takai,Kōta,Takai,,,,,,,,,,577,9f59ff55,,671108,560833
+553742,Finlay,Herrick,Herrick,,,,,,,,,,825,8a764f73,,848439,
 553746,Leo,Shahar,Shahar,,,,,,,,,,765,5536f008,13572,940858,535754
 554194,Jahmai,Simpson-Pusey,Simpson-Pusey,,,,,,,,,672,,383b10fd,13185,942497,534072
 554197,Chris,Rigg,Rigg,,,,,,,,,,551,35741fe2,13719,947411,469645
@@ -2437,6 +2439,8 @@ code,first_name,second_name,web_name,16-17,17-18,18-19,19-20,20-21,21-22,22-23,2
 569577,Triston,Rowe,Rowe,,,,,,,,,,701,3fcc22d5,13869,984593,540464
 570241,Kim,Ji-soo,Ji-soo,,,,,,,,725,96,117,f4065d9e,12136,709767,492686
 570526,Lucas,Bergvall,Bergvall,,,,,,,,,481,586,a109e5c8,12912,866246,505295
+570929,Jack,Whittaker,Whittaker,,,,,,,,,,821,33ea39be,,1018830,
+571087,Jaydon,Jones,Jones,,,,,,,,,,822,3ad7599b,,1018837,
 572702,Keiber,Lamadrid,Lamadrid,,,,,,,,,,802,5903eca2,,1004203,600774
 573062,Martial,Godo,Godo,,,,,,,641,,605,333,e0eea46f,11164,992686,454749
 573808,Jack,Grieves,Grieves,,,,,,734,,,,,2cf03378,10593,974327,438304
@@ -2472,6 +2476,7 @@ code,first_name,second_name,web_name,16-17,17-18,18-19,19-20,20-21,21-22,22-23,2
 586268,Ármin,Pécsi,Pécsi,,,,,,,,,,368,46206cf7,,933215,519492
 586309,Thierno,Barry,Barry,,,,,,,,,,310,52c3244b,12916,937941,537713
 587178,Yasin,Özcan,Yasin,,,,,,,,,,46,3c841afd,,1043003,
+587433,Conor,McManus,McManus,,,,,,,,,,824,d80e9e0e,,1008162,
 588555,Elyh,Harrison,Harrison,,,,,,,,,761,433,6175ebf8,13410,1013690,492376
 588793,Maldini,Kacurri,Kacurri,,,,,,,,,657,14,7be4311f,13081,903189,539715
 588796,Ismeal,Kabia,Kabia,,,,,,,,,659,28,6b15cf32,13082,964561,539716
@@ -2540,6 +2545,7 @@ code,first_name,second_name,web_name,16-17,17-18,18-19,19-20,20-21,21-22,22-23,2
 612534,Benjamin,Fredrick,Fredrick,,,,,,,,797,786,115,fde367e5,12397,1071138,513405
 612855,Ibrahim,Osman,I.Osman,,,,,,,,,127,,acdfe835,13792,1110406,
 613120,Spike,Brits,Brits,,,,,,,,,704,,d5837248,13299,1080903,549309
+613232,James,Wilson,Wilson,,,,,,,,,,818,e9cd8e92,14462,1041600,
 613467,Wes,Okoduwa,Okoduwa,,,,,,,,832,711,,58469e7c,12500,1115502,517909
 613804,El Hadji Malick,Diouf,Diouf,,,,,,,,,,603,bd5eb2e5,13723,1111589,479288
 614574,Alex,Tóth,Tóth.A,,,,,,,,,,801,5e18c6f4,14374,998101,476166
@@ -2578,6 +2584,7 @@ code,first_name,second_name,web_name,16-17,17-18,18-19,19-20,20-21,21-22,22-23,2
 643135,Fer,López González,Fer López,,,,,,,,,,645,675cacff,13200,1064471,544982
 643426,Dean,Benamar,Benamar,,,,,,,,,,773,b047bb3b,14278,1285021,574690
 643473,Airidas,Golambeckis,Golambeckis,,,,,,,,,,752,59149473,14179,1108668,572171
+644593,Kian,McMahon-Brown,McMahon-Brown,,,,,,,,,,820,643dadae,,1165131,
 645618,Bradley,Burrowes,Burrowes,,,,,,,,,,702,802ee5ca,13870,1202361,550064
 646243,Andre,Harriman-Annous,Harriman-Annous,,,,,,,,,,711,2d14071d,14000,1237740,571995
 646754,Lander,Emery,Emery,,,,,,,,866,,,b5f7fd45,12632,1237073,527644
@@ -2587,6 +2594,7 @@ code,first_name,second_name,web_name,16-17,17-18,18-19,19-20,20-21,21-22,22-23,2
 647850,Charalampos,Kostoulas,Kostoulas,,,,,,,,,,181,816010c4,14118,1060087,533923
 647960,Oliver,Pimlott,Pimlott,,,,,,,,,,776,b928f19e,14282,1214634,581382
 649208,Jeremy,Monga,Monga,,,,,,,,,792,,4c168d3a,13579,1245948,552366
+649240,Joshua,Stephenson,Stephenson,,,,,,,,,,823,c9c4c85d,,967342,
 651426,Jaydee,Canvot,Canvot,,,,,,,,,,723,3684108d,13091,1006411,531676
 653481,Alysson Edward Franco,da Rocha dos Santos,Alysson,,,,,,,,,,792,99b63a82,,1005583,520919
 658013,Charlie,Stevens,Stevens,,,,,,,,,,799,6c2a4c10,14367,1122668,606358
@@ -2597,5 +2605,5 @@ code,first_name,second_name,web_name,16-17,17-18,18-19,19-20,20-21,21-22,22-23,2
 672492,Joél,Drakes-Thomas,Drakes-Thomas,,,,,,,,,,762,1bd530e8,14263,1348941,603933
 678552,Malcom,DaCosta,DaCosta,,,,,,,,,,756,c96b1407,14215,1323654,602543
 685628,Jerome,Abbey,Abbey,,,,,,,,,,809,4f504fcc,14394,1370903,607348
-699989,Djiamgone Jocelin Ta,Bi,Jocelin.T,,,,,,,,,,800,,,1322090,606073
+699989,Djiamgone Jocelin Ta,Bi,Jocelin.T,,,,,,,,,,800,1f019509,14460,1322090,606073
 704232,George,Brierley,Brierley,,,,,,,,,,784,a57a4ea8,14292,1352710,584317

--- a/Master.csv
+++ b/Master.csv
@@ -1,2609 +1,2601 @@
-code,first_name,second_name,web_name,16-17,17-18,18-19,19-20,20-21,21-22,22-23,23-24,24-25,25-26,fbref,understat,transfermarkt
-1243,Robert,Green,Green,,547,,,,,,,,,a350680b,4390,11680
-1616,Alexander,Manninger,Manninger,524,,,,,,,,,,eb55b1bc,277,5278
-1632,Gareth,Barry,Barry,137,151,,,,,,,,,7dbbe367,590,3291
-1718,John,Terry,Terry,75,,,,,,,,,,68517cfd,917,3160
-1801,Paul,Robinson,Robinson,472,75,,,,,,,,,3515ba56,1667,3630
-1822,Shay,Given,Given,315,,,,,,,,,,0db918ff,889,3146
-2404,Michael,Carrick,Carrick,259,276,,,,,,,,,ab7263c1,654,3878
-2513,Jamie,Murphy,Murphy,,69,,,,,,,,,6c96b263,6052,51730
-3201,Stuart,Taylor,Taylor,597,506,,,,,,,,,30871c08,5580,3190
-3736,John,O'Shea,O'Shea,342,,,,,,,,,,7c1f4685,729,3540
-3773,Peter,Crouch,Crouch,336,347,590,,,,,,,,73d9bdc7,872,4072
-5288,Gerhard,Tremmel,Tremmel,682,,,,,,,,,,4370cecc,1062,488
-5589,Dean,Whitehead,Whitehead,,178,,,,,,,,,a32204c9,6328,13683
-6744,Lee,Grant,Grant,574,329,520,237,604,,,,,,9dab6e3b,1742,13460
-7525,Steven,Pienaar,Pienaar,533,,,,,,,,,,8056f6e6,924,4321
-7551,Joleon,Lescott,Lescott,635,,,,,,,,,,62393d3b,664,4241
-7638,Mark,Hudson,Hudson,,170,,,,,,,,,e4e3de44,,3640
-7645,Phil,Jagielka,Jagielka,127,140,158,444,529,,,,,,3233eefd,587,13520
-7906,Damien,Delaney,Delaney,107,121,,,,,,,,,210d9ecb,511,36861
-7958,Jermain,Defoe,Defoe,355,52,46,,,,,,,,f1e8372d,735,3875
-8380,James,Collins,Collins,452,441,,,,,,,,,c61f1719,655,12691
-8432,José,Reina,Reina,,,,603,,,,,,,e358587b,1374,7825
-9047,Glen,Johnson,Johnson,325,335,,,,,,,,,8cceca90,944,3881
-9089,Ben,Foster,Foster,430,421,445,366,,376,,,,,d0b3ceb9,803,13572
-9110,Shaun,Maloney,Maloney,162,,,,,,,,,,0558e236,1692,9508
-9808,Zlatan,Ibrahimovic,Ibrahimovic,272,523,,,,,,,,,4cde5509,1741,3455
-10318,Maarten,Stekelenburg,Stekelenburg,124,137,155,149,,,,,,,fefce889,846,4311
-10460,Grant,Leadbitter,Leadbitter,284,,,,,,,,,,516f7fc1,5542,13796
-10589,Brian,Murphy,Brian Murphy,,,537,,,,,,,,47e0ce24,4459,4190
-11037,Rickie,Lambert,Lambert,447,,,,,,,,,,495de82c,816,49655
-11334,Petr,Cech,Cech,2,2,1,,,,,,,,71672fa0,491,5658
-11352,Bruno,Saltor Grau,Bruno,,58,50,,,,,,,,78803d03,6046,51528
-11467,Billy,Jones,Jones,343,,,,,,,,,,aa3cb1ad,742,36866
-11554,Julian,Speroni,Speroni,99,116,136,,,,,,,,8e65a5e5,523,12814
-11735,Steve,Sidwell,Sidwell,,65,,,,,,,,,ed083afd,1007,13427
-11829,Wayne,Routledge,Routledge,369,360,,,,,,,,,1d387eee,719,14066
-11854,Daryl,Murphy,Murphy,,304,,,,,,,,,ac99973f,,31312
-11948,Andy,Lonergan,Lonergan,,,,530,639,571,760,579,,,165cf989,7821,14044
-11974,Eldin,Jakupovic,Jakupović,147,473,214,169,,573,627,,,,1148323a,1697,2857
-12002,Stewart,Downing,Downing,282,,,,,,,,,,b13c4620,1712,4063
-12086,Boaz,Myhill,Myhill,429,420,,,,,,,,,7ca2d989,820,3838
-12150,Glenn,Whelan,Whelan,329,339,,,,,,,,,d5bd56a5,862,12124
-12390,Allan,McGregor,McGregor,146,,,,,,,,,,f3a97d02,4409,9422
-12413,Robert,Huth,Huth,173,194,,,,,,,,,0bd1ea64,747,2998
-12496,Víctor,Valdés,Valdés,274,,,,,,,,,,e029e404,1705,7589
-12679,Michael,Dawson,Dawson,150,,,,,,,,,,4771114f,1744,9988
-12744,David,Nugent,Nugent,291,,,,,,,,,,f9b5e5bd,1753,33963
-12745,Leighton,Baines,Baines,125,138,156,145,,,,,,,b18095b6,588,13507
-12813,Jonathan,Walters,Walters,330,89,81,,,,,,,,0356cf4f,863,3306
-13017,Wayne,Rooney,Rooney,269,161,,,,,,,,,f07be45a,629,3332
-13152,Andy,King,King,178,201,,480,,,,,,,d790907f,784,56872
-14075,Patrice,Evra,Evra,,626,,,,,,,,,51a3caf1,1298,5285
-14295,Darren,Fletcher,Fletcher,439,346,,,,,,,,,184e4970,809,3547
-14664,Gnegneri Yaya,Touré,Yaya Touré,231,249,,,,,,,,,c204f844,878,13091
-14927,Greg,Halford,Halford,,,97,,,,,,,,06d45e81,,42062
-14937,Cristiano Ronaldo,dos Santos Aveiro,Ronaldo,,,,,,579,326,,,,dea698d9,2371,8198
-15033,Wes,Morgan,Morgan,167,191,215,165,216,,,,,,80c31c97,748,10003
-15109,Tom,Huddlestone,Huddlestone,160,,,,,,,,,,464cbbc9,1695,13465
-15114,Leon,Britton,Britton,370,361,,,,,,,,,b92dd711,830,40043
-15137,Liam,Rosenior,Rosenior,,60,,,,,,,,,8b0d6fe9,4462,15166
-15144,David,Marshall,Marshall,554,,,,,,,,,,4d93d433,1684,9500
-15149,Simon,Francis,Francis,31,32,26,62,,,,,,,1e0b6a73,456,13573
-15157,James,Milner,Milner,208,222,254,200,241,221,274,142,134,170,2f90f6b8,489,3333
-15208,Bastian,Schweinsteiger,Schweinsteiger,265,,,,,,,,,,ccc22fea,907,2514
-15237,Andrew,Surman,Surman,39,41,35,80,,,,,,,7d41b619,460,29975
-15276,Joey,Barton,Barton,626,,,,,,,,,,93bfa675,4430,3292
-15633,Alex,Baptiste,Baptiste,522,,,,,,,,,,7b72f0b6,1783,16660
-15749,Joe,Hart,Hart,218,479,490,95,482,352,,,,,cb4f24c6,609,40204
-15885,Adam,Federici,Federici,30,31,,,,,,,,,e5ea8be7,469,4233
-15944,Michael,Kightly,Kightly,66,,,,,,,,,,26e5c484,1668,25366
-15982,Dean,Marney,Marney,64,83,,,,,,,,,b3379356,1658,4055
-16045,Ben,Watson,Watson,418,486,,,,,,,,,df540668,571,14081
-17127,Per,Mertesacker,Mertesacker,4,5,,,,,,,,,5be28712,507,6710
-17336,Gaël,Clichy,Clichy,223,,,,,,,,,,450ad405,613,7449
-17339,Steven,Davis,Davis,305,316,337,,,,,,,,cf15bbb1,883,28973
-17349,Aaron,Lennon,Lennon,142,153,83,430,,575,,,,,2ff964a0,593,14221
-17476,Vincent,Kompany,Kompany,222,244,263,,,,,,,,d2bff301,612,9594
-17601,Scott,Carson,Carson,,,,562,608,593,502,347,344,,3e1550ee,8158,14555
-17740,Jesús,Navas,Navas,232,,,,,,,,,,3f10bd22,616,15956
-17745,Kasper,Schmeichel,Schmeichel,165,189,213,168,217,200,248,,,,53af52f3,745,16911
-17761,James,Tarkowski,Tarkowski,59,79,72,84,81,98,199,265,236,291,15ea812b,1665,173504
-17878,Cesc,Fàbregas,Fàbregas,83,105,123,,,,,,,,33508c78,686,8806
-17997,Phil,Bardsley,Bardsley,323,334,75,86,82,99,,,,,1ae30132,857,15773
-18006,Martin,Cranie,Cranie,,168,,,,,,,,,9e53837d,6344,27659
-18008,James,Morrison,Morrison,441,428,,,,,,,,,21a66e33,990,27614
-18073,Mark,Noble,Noble,458,450,411,396,427,406,,,,,ff527768,533,31835
-18155,Mathieu,Flamini,Flamini,576,,,,,,,,,,148d4105,895,17396
-18440,Leon,Clarke,Clarke,,,,547,,,,,,,91c975a0,8061,36859
-18499,Michael,McGovern,McGovern,,,,281,,313,,,,,51a19d04,8022,29391
-18507,Diego,Da Silva Costa,Diego Costa,97,114,,,,,625,,,,a190d597,802,44779
-18656,Heurelho da Silva,Gomes,Gomes,407,397,373,513,,,,,,,d596e193,564,105112
-18665,Alexander,Tettey,Tettey,,,,289,,,,,,,75566759,791,12384
-18726,Artur,Boruc,Boruc,29,30,25,73,,,,,,,34ccf6fa,455,15220
-18759,Álvaro,Arbeloa,Arbeloa,568,,,,,,,,,,6dc73abd,1704,28260
-18805,Joe,Ledley,Ledley,113,,,,,,,,,,c221f149,517,34409
-18832,Richard,Stearman,Stearman,,,,296,,,,,,,9a3a436e,7989,34349
-18867,Billy,Sharp,Sharp,,,,298,343,,,,,,e8c9f4e9,7712,49542
-18892,Ashley,Young,Young,260,277,293,224,,52,538,588,238,,be927d03,631,14086
-18987,Robert,Snodgrass,Snodgrass,155,448,489,393,428,,,,,,9f4647e9,1691,22614
-19057,Sebastian,Larsson,Larsson,349,,,,,,,,,,b26efc36,740,31720
-19071,Uwe,Hünemeier,Hünemeier,,57,,,,,,,,,f42456eb,4258,10503
-19101,Dimitrios,Konstantopoulos,Konstantopoulos,273,,,,,,,,,,05778dfe,1767,50552
-19115,Curtis,Davies,Davies,149,,,,,,,,,,607fb965,1686,18227
-19151,Chris,Brunt,Brunt,438,434,,,,,,,,,ec7e6ad1,904,36814
-19159,Ashley,Williams,Williams,359,143,159,,,,,,,,a498e276,709,67355
-19188,Scott,Dann,Dann,104,118,139,127,486,,,,,,52105203,512,62688
-19194,David,Martin,Martin,,,,553,429,,,,,,07666c20,8082,15930
-19197,Jason,Puncheon,Puncheon,110,125,146,,,,,,,,fd3f57ce,514,47995
-19236,John,Ruddy,Ruddy,,,421,412,453,452,,,414,753,da8b19e2,785,29712
-19272,Gareth,McAuley,McAuley,436,425,,,,,,,,,ac7d7378,806,40567
-19342,Ikechi,Anya,Anya,419,,,,,,,,,,c55e973d,577,107427
-19419,Gary,Cahill,Cahill,78,98,114,503,125,,,,,,7914b9fe,699,27511
-19520,Ryan,Babel,Babel,,,575,,,,,,,,6438d426,5176,16135
-19523,Sol,Bamba,Bamba,,,91,,,,,,,,5534217d,4027,28984
-19524,Santiago,Cazorla,Cazorla,15,17,,,,,,,,,e2e9c250,965,15799
-19556,David,Jones,Jones,61,,,,,,,,,,2f0edbe7,1787,24634
-19568,Ibrahim,Afellay,Afellay,332,341,,,,,,,,,9a8c6673,864,15760
-19624,João Filipe Iria,Santos Moutinho,Moutinho,,,475,415,454,426,503,,,,f5a00fa4,3422,29364
-19687,Alex,Bruce,Bruce,154,,,,,,,,,,102ed2b2,4411,37957
-19760,Fernando,Llorente,Llorente,500,371,371,,,,,,,,82dbf623,1728,35564
-19812,Dusan,Kuciak,Kuciak,517,,,,,,,,,,c78c8c27,1772,31886
-19838,Robert,Elliot,Elliot,,286,307,573,,574,,,,,b1b25949,763,39037
-20037,Marc,Pugh,Pugh,38,40,34,,,,,,,,9aacb284,466,36939
-20046,Stefano,Okaka,Okaka,552,418,397,,,,,,,,601ef102,1763,35249
-20047,Jordan,Rhodes,Rhodes,292,,,,,,,,,,3b8b641c,1714,48950
-20066,Wayne,Hennessey,Hennessey,100,115,135,132,126,480,518,448,721,,76eca7e2,509,45494
-20145,Adrian,Mariappa,Mariappa,556,405,382,356,,,,,,,8aa5f52c,524,38145
-20208,Charlie,Adam,Adam,328,338,,,,,,,,,aff418dc,873,28990
-20310,Willy,Caballero,Caballero,219,96,112,112,101,641,424,,,,a179d516,624,19948
-20399,Antonio,Barragán,Barragán,477,,,,,,,,,,487d9b09,1706,32522
-20452,Shane,Long,Long,313,325,347,315,361,519,,,,,9f472354,839,37304
-20467,Theo,Walcott,Walcott,13,15,164,153,148,332,400,,,,1ecb65be,503,33713
-20480,Tim,Krul,Krul,,540,,280,,314,,665,,,f23f9d20,982,33027
-20481,Stephen,Ireland,Ireland,327,590,,,,,,,,,bcf30f17,867,34838
-20487,Vito,Mannone,Mannone,339,,,,,,,,,,c4173f1a,726,33781
-20529,Glenn,Murray,Murray,,71,62,44,53,,,,,,f2f29dda,882,45693
-20658,Pablo,Zabaleta,Zabaleta,221,447,405,379,,,,,,,6813ac34,610,20007
-20664,David,Silva,David Silva,230,248,271,219,,,,,,,e2716bd0,617,35518
-20669,Shaun,MacDonald,MacDonald,41,,,,,,,,,,fdcff59c,471,10375
-20695,Antonio,Valencia,Valencia,250,267,288,,,,,,,,08aa17d0,627,33544
-21083,Nathan,Dyer,Dyer,376,366,,,,,,,,,6dfd5af0,783,37011
-21123,Valon,Behrami,Behrami,420,410,,,,,,,,,d3d758d8,570,21905
-21205,Tom,Heaton,Heaton,54,74,67,94,28,509,348,384,374,434,a6de6361,1651,34130
-21246,Lewis,Grabban,Grabban,51,,,,,,,,,,1a857282,467,35413
-26719,Rene,Gilmartin,Gilmartin,683,,,,,,,,,,f1b7c957,969,66518
-26901,Kevin,Mirallas,Mirallas,133,148,469,,,,,,,,aa51343f,595,33639
-26921,Arouna,Koné,Koné,144,,,,,,,,,,f9a72ca4,601,8552
-27334,Mathieu,Debuchy,Debuchy,8,564,,,,,,,,,92232aad,967,27306
-27335,Stephan,Lichtsteiner,Lichtsteiner,,,11,,,,,,,,99b1d0e6,1303,2865
-27341,Yohan,Cabaye,Cabaye,118,129,,,,,,,,,ad7b19ef,516,29434
-27436,David,McGoldrick,McGoldrick,,,,303,344,,,,,,dbe56a33,7711,35416
-27462,Jesús,Gámez Duarte,Gámez,,293,,,,,,,,,bd1d1cbb,2329,29055
-27698,Matthew,Connolly,Connolly,,,93,,,,,,,,2797fc1d,7237,34559
-27707,Darron,Gibson,Gibson,138,,,,,,,,,,f0e72e1c,921,42413
-27770,Birkir,Bjarnason,Bjarnason,,,,33,,,,,,,da13074e,8269,34453
-27789,Fernando,Luiz Rosa,Fernandinho,233,250,272,221,266,453,,,,,101da2b5,614,26267
-28082,Ralf,Fahrmann,Fahrmann,,,,449,,,,,,,1e43fad8,330,39015
-28147,Mohamed,Diamé,Diamé,159,298,319,,,,,,,,b7d082af,4471,70950
-28160,Mario,Suárez,Suárez,423,,,,,,,,,,7106f0a0,576,37337
-28244,George,Boyd,Boyd,62,,,,,,,,,,0a9048ce,1656,45623
-28411,Keylor,Navas,Navas,,,,,,,729,,,,ecada4fc,2243,79422
-28448,Lee,Cattermole,Cattermole,348,,,,,,,,,,538e77d5,738,37363
-28462,Sam,Baldock,Baldock,,73,64,,,,,,,,9d597f08,6430,67211
-28468,Craig,Gardner,Gardner,440,,,,,,,,,,1117b9ff,812,37171
-28495,John Obi,Mikel,Mikel,89,,,,,,,,,,424d5f72,685,30739
-28541,Fraizer,Campbell,Campbell,121,,,,,,,,,,81d63375,634,42411
-28554,Samir,Nasri,Nasri,229,,569,,,,,,,,165bed61,877,18935
-28593,Victor,Anichebe,Anichebe,575,,,,,,,,,,4aed5c19,818,39532
-28609,Adam,Legzdins,Legzdins,,545,,,,,,,,,f5b114ca,6302,43858
-28654,Martin,Olsson,Olsson,633,358,,,,,,,,,2f72f79e,798,38073
-28690,Pablo,Hernández Domínguez,Hernández,,,,,193,182,,,,,c0398aca,2164,46220
-32259,Darren,Randolph,Randolph,451,439,,606,430,407,571,80,,,6385ebfb,540,51321
-32318,Marc,Wilson,Marc Wilson,319,,,,,,,,,,c325c010,945,30456
-33148,Claudio,Bravo,Bravo,541,241,261,213,267,,,,,,10072610,1731,40423
-33871,Ragnar,Klavan,Klavan,474,220,244,,,,,,,,008a6e6d,265,26669
-34654,Lukas,Jutkiewicz,Jutkiewicz,69,,,,,,,,,,3943a06f,1664,33507
-36903,Gareth,Bale,Bale,,,,,543,,,,,,a58bb1e1,2251,39381
-37002,Rouwen,Hennings,Hennings,71,,,,,,,,,,17611373,7060,16311
-37096,Lukasz,Fabianski,Fabianski,356,350,400,388,431,408,455,533,521,738,9328b835,706,29692
-37265,Alexis,Sánchez,Sánchez,12,14,295,240,,,,,,,2c0f8e9e,498,40433
-37339,Ahmed,El Mohamady,El Mohamady,158,,,22,29,,,,,,615ef733,1685,66333
-37388,Marcin,Wasilewski,Wasilewski,170,,,,,,,,,,24249219,760,16947
-37402,Christian,Fuchs,Fuchs,168,192,216,163,218,,,,,,a67a09fb,749,6636
-37572,Sergio,Agüero,Agüero,239,257,280,210,268,,,,,,4d034881,619,26399
-37605,Mesut,Özil,Özil,14,16,13,15,1,,,,,,16380240,499,35664
-37614,Mario,Vrancic,Vrancic,,,,282,,,,,,,16fa6881,12,39372
-37642,Jonny,Evans,Evans,431,423,222,162,219,201,249,703,371,,f8fcd2a5,807,42412
-37742,Younes,Kaboul,Kaboul,341,398,375,,,,,,,,3680d723,736,27114
-37748,Bacary,Sagna,Sagna,224,,,,,,,,,,6ef56efd,625,26764
-37869,Ryan,Shawcross,Shawcross,318,330,,,,,,,,,285a3d44,886,45861
-37901,Dimitri,Payet,Payet,461,,,,,,,,,,58ae47b2,536,37647
-37915,Hugo,Lloris,Lloris,380,375,351,340,383,353,425,502,,,8f62b6ee,637,17965
-37998,Bafétimbi,Gomis,Gomis,377,,,,,,,,,,3d6686f9,717,22388
-38038,Ben,Hamer,Hamer,583,190,190,,,,,,,,d822a850,1759,67283
-38290,Danny,Rose,Rose,383,378,354,332,384,377,,,,,89d10e53,641,50174
-38411,Nacho,Monreal,Monreal,10,10,5,6,,,,,,,d4cb83cc,495,43003
-38419,Loïc,Remy,Remy,98,,,,,,,,,,5c2da10f,690,45121
-38439,Etienne,Capoue,Capoue,416,409,389,373,,,,,,,5acc4a10,572,63494
-38454,Dejan,Lovren,Lovren,191,215,239,186,,,,,,,1a2935f6,602,37838
-38490,Beram,Kayal,Kayal,,64,57,56,,,,,,,26679cdf,6409,44741
-38499,Tomer,Hemed,Hemed,,72,63,,,,,,,,27d7453c,4046,112668
-38533,Rui Pedro,dos Santos Patrício,Patrício,,,454,411,455,427,,,,,79b0d6a0,6849,45026
-38580,Jose,Fonte,Fonte,297,440,,,,,,,,,90f87966,834,33829
-38588,Gaetano,Berardi,Berardi,,,,,685,,,,,,5348aada,9423,43084
-38716,Lee,Peltier,Peltier,,,95,,600,,,,,,af341b88,6822,38094
-39104,Mousa,Dembélé,Dembélé,391,385,362,,,,,,,,f7ee69fb,642,19368
-39155,Adam,Lallana,Lallana,205,228,250,195,54,53,101,138,463,,99813635,486,43530
-39158,Scott,Arfield,Arfield,63,82,,,,,,,,,b1313ec4,1659,55291
-39167,Andrea,Ranocchia,Ranocchia,638,,,,,,,,,,539230cf,1522,44327
-39187,Jeremain,Lens,Lens,351,,,,,,,,,,6f1721f0,781,38497
-39194,Jan,Vertonghen,Vertonghen,385,380,355,330,,,,,,,ba23a904,640,43250
-39215,Michel,Vorm,Vorm,381,376,352,555,,,,,,,1bebde9d,651,26276
-39253,Jonas,Olsson,Olsson,432,,,,,,,,,,48844a9b,805,25248
-39270,Marvin,Emnes,Emnes,378,,,,,,,,,,a5900d91,829,37787
-39472,Dieumerci,Mbokani,Mbokani,569,,,,,,,,,,d9847696,795,44624
-39476,Sokratis,Papastathopoulos,Sokratis,,,12,5,2,,,,,,b682dcf6,371,34322
-39487,Erik,Pieters,Pieters,321,332,,447,83,100,,,,,1ef37668,887,43763
-39725,Anders,Lindegaard,Lindegaard,,554,485,,,,,,,,636f1a28,950,22491
-39790,Francisco,Casilla Cortés,Casilla,,,,,194,183,,,,,58bc7d18,2259,27486
-39847,Steven,Defour,Defour,525,85,77,99,,,,,,,73489527,1657,33866
-40002,Matteo,Darmian,Darmian,251,268,289,230,,,,,,,96e0490d,557,54906
-40142,Andy,Carroll,Carroll,468,457,418,520,320,,,,,,b581987a,537,48066
-40145,Jack,Cork,Cork,367,90,82,102,84,101,,163,,,74e12f1e,712,40613
-40146,Ryan,Bertrand,Bertrand,296,307,330,305,362,473,250,,,,01226327,835,40611
-40202,George,Friend,Friend,276,,,,,,,,,,4f97147d,1708,77544
-40232,Gonzalo,Higuaín,Higuaín,,,579,,,,,,,,8a08491a,1293,39153
-40276,Bojan,Krkic Perez,Bojan,335,344,,,,,,,,,9fa0a0b8,871,44675
-40346,Erwin,Mulder,Mulder,,576,,,,,,,,,b3576b7c,6431,56631
-40349,Asmir,Begovic,Begovic,74,29,24,72,,481,176,,624,,7b4de647,694,33873
-40383,Fraser,Forster,Forster,294,306,329,317,523,333,426,498,488,782,c3e39f12,831,52570
-40386,Chris,Basham,Basham,,,,423,345,,,474,,,1aa84968,7704,52495
-40387,Dan,Gosling,Gosling,43,43,37,81,,378,,,,,7fec31a0,462,44983
-40399,Sam,Vokes,Vokes,67,91,84,,,,,,,,1d6ac165,1661,48078
-40451,Anthony,Pilkington,Pilkington,,,103,,,,,,,,b31af577,,67322
-40555,Joe,Allen,Allen,202,337,,,,,,,,,9feb8f24,480,51452
-40559,Fabricio,Agosto Ramírez,Fabri,,,474,,171,,,,,,af245161,2587,45882
-40564,Henri,Lansbury,Lansbury,,,,35,30,,,,,,fe8e6fa1,7727,44794
-40616,Stephen,Ward,Ward,57,78,71,,,,,,,,3831b9fe,1655,34691
-40669,Angelo,Ogbonna,Ogbonna,456,444,403,377,432,409,456,577,,,74b2cd7e,528,48002
-40694,Roberto,Jimenez Gago,Roberto,,,,450,433,,,,,,ba3ca78f,5087,37403
-40720,Edinson,Cavani,Cavani,,,,,569,269,,,,,527f063d,3294,48280
-40725,Danny,Simpson,Simpson,172,193,217,,,,,,,,3201b03d,746,37442
-40755,Daniel,Sturridge,Sturridge,214,236,472,,,,,,,,1b7ec703,483,47082
-40772,Gökhan,Inler,Inler,180,,,,,,,,,,3200c583,761,19041
-40784,Mamadou,Sakho,Sakho,190,221,143,125,127,,,,,,87935cf3,485,47713
-40833,Jérémy,Pied,Pied,492,312,,,,,,,,,a634b9d2,1784,60583
-40836,Vicente,Guaita,Guaita,,,137,131,128,146,152,227,,,ab13a5aa,2190,64399
-40845,Dale,Stephens,Stephens,,63,56,57,55,102,,,,,653ee42d,6051,49755
-40868,José,Holebas,Holebas,411,401,378,353,,,,,,,12aa7661,568,41112
-41135,Branislav,Ivanovic,Ivanovic,76,,,,530,,,,,,85f8571a,682,36827
-41184,Marouane,Fellaini,Fellaini,257,275,298,,,,,,,,87575fd9,630,39679
-41251,Eduardo,dos Reis Carvalho,Eduardo,663,95,,,,,,,,,81b906e7,5561,34159
-41270,David,Luiz Moreira Marinho,David Luiz,570,101,116,106,3,,,,,,c0e27d1a,1676,46741
-41320,Charlie,Daniels,Daniels,33,34,28,60,,,,,,,9d107085,459,61819
-41321,Yohan,Benalouane,Benalouane,174,195,218,,,,,,,,8309b068,974,50477
-41328,César,Azpilicueta,Azpilicueta,77,97,113,105,102,119,127,189,,,53cad200,681,57500
-41338,Craig,Cathcart,Cathcart,408,399,376,358,,379,,,,,89e4b358,581,59606
-41464,Marko,Arnautovic,Arnautovic,331,340,417,385,,,,,,,00459419,865,41384
-41674,Kevin,Long,Long,594,80,73,88,85,103,,,,,5a4280b1,1747,111114
-41705,Bradley,Guzan,Guzan,490,,,,,,,,,,d899e3bf,662,39471
-41725,Troy,Deeney,Deeney,425,417,396,362,,380,,,,,82e34b69,574,65477
-41727,Ryan,Bennett,Bennett,,,427,404,456,,,,,,0bad4516,787,67252
-41733,Georginio,Wijnaldum,Wijnaldum,485,232,252,199,243,,,,,,eb58eef0,771,49499
-41792,Aaron,Ramsey,Ramsey,16,18,14,,,,,,,,ef619b0b,504,50057
-41823,Fabian,Delph,Delph,227,246,269,205,149,163,,,,,111c3236,876,50362
-41926,Almen,Abdi,Abdi,417,,,,,,,,,,8d425d84,569,9966
-41945,Sebastian,Prödl,Prödl,409,400,377,361,,,,,,,f5e6d08d,566,37981
-42427,Kieran,Gibbs,Gibbs,7,8,,,407,,,,,,46ee5234,545,44792
-42493,Mario,Balotelli,Balotelli,215,,,,,,,,,,8ff07990,1817,45146
-42525,Stephen,Henderson,Henderson,,,,556,578,,,,,,f234c188,8095,52191
-42564,Eric Maxim,Choupo-Moting,Choupo-Moting,,497,,,,,,,,,0e6bc38c,339,45660
-42583,Sébastien,Pocognoli,Pocognoli,434,,,,,,,,,,cc41eec1,893,17804
-42593,Aleksandar,Kolarov,Kolarov,220,243,,,,,,,,,eda40760,621,46156
-42727,Yoan,Gouffran,Gouffran,,297,,,,,,,,,a28d181a,916,23825
-42738,Juan,Zuñiga,Zuñiga,479,,,,,,,,,,06b34f37,1722,37941
-42748,Gaëtan,Bong,Bong,,59,51,41,,,,,,,cfd5e123,6105,36291
-42774,Morgan,Schneiderlin,Schneiderlin,264,154,167,158,,,,,,,51b41c5c,551,56818
-42786,Eden,Hazard,Hazard,82,104,122,,,,,,,,a39bb753,701,50202
-42824,Carlos,Sánchez,Carlos Sánchez,,,518,397,,,,,,,50b51fac,667,51226
-42892,Álvaro,Negredo,Negredo,478,,,,,,,,,,63b0ca6b,1715,18644
-42899,Sergio,Romero,Romero,243,261,283,236,289,,,,,,1e26e376,560,30690
-42996,Angel,Rangel,Rangel,361,353,,,,,,,,,93ee387c,707,66550
-43020,Javier,Hernández Balcázar,Chicharito,,487,419,386,,,,,,,189cee7b,191,50935
-43191,Leiva,Lucas,Lucas,200,224,,,,,,,,,4c78b5ed,475,41414
-43250,Tom,Cleverley,Cleverley,135,408,388,371,,381,,,,,6cdd8245,596,73484
-43252,James,Chester,Chester,437,,,23,,,,,,,a772eba6,819,73482
-43521,Henri,Saivet,Saivet,,516,,,,,,,,,f3709655,778,51540
-43626,Håvard,Nordtveit,Nordtveit,465,,593,,,,,,,,6cafd68d,202,42234
-43670,Juan,Mata,Mata,256,274,297,242,290,459,,,,,29733c72,554,44068
-43693,Martín,Cáceres,Cáceres,652,,,,,,,,,,e94d79e3,1942,54935
-43808,Markus,Suttner,Suttner,,461,52,,,,,,,,7391c2d9,379,31514
-44302,Adlène,Guédioura,Guédioura,415,,,,,,,,,,f75825e3,583,74768
-44336,Sofiane,Feghouli,Feghouli,466,455,,,,,,,,,691f64f5,1674,57162
-44343,Bakary,Sako,Sako,119,130,148,,,,,,,,381d7d54,520,46791
-44346,Olivier,Giroud,Giroud,25,25,133,110,103,120,,,,,16ceb862,502,82442
-44413,Steve,Mandanda,Mandanda,102,,,,,,,,,,1d2d5cc8,1670,23951
-44604,Nordin,Amrabat,Amrabat,422,412,,,,,,,,,7c2a398c,575,55619
-44683,Jay,Rodriguez,Rodriguez,311,437,,451,86,104,,177,,,4ab53cdb,844,53360
-44699,Ashley,Barnes,Barnes,70,93,85,90,87,105,,,,218,2691c772,4422,63200
-45034,Ivan,Perišić,Perišić,,,,,,,448,507,,,6fe90922,448,42460
-45076,Lamine,Koné,Koné,346,,,,,,,,,,a46472d0,728,57420
-45124,André,Ayew,A.Ayew,374,449,,,,,734,,,,5dbefa9d,713,45403
-45196,Gary,Madine,Madine,,,109,,,,,,,,e3e6502a,6829,66994
-45220,Alex,Smithies,Smithies,,,89,,,,581,,,,bb91617c,6832,33754
-45268,Moussa,Sissoko,Sissoko,572,393,369,349,385,354,,,,,2acd49b9,772,46001
-46483,Adrien,Silva,Silva,,589,231,,220,,,,,,d6f88a1d,6464,56810
-46695,Ritchie,de Laet,de Laet,171,,,,,,,,,,dc234f98,955,55687
-47247,John,Fleck,Fleck,,,,301,346,,,481,,,b63e789d,7709,54383
-47390,Neil,Taylor,Taylor,360,,,24,31,,,,,,c2f9d19f,710,67416
-47431,Willian,Borges da Silva,Willian,86,106,124,113,478,3,614,591,772,,8b9ebd03,700,52769
-48332,Orestis,Karnezis,Karnezis,,536,,,,,,,,,85b011bb,1138,16408
-48615,Harry,Arter,Arter,37,39,33,,,,378,435,,,2f4c5a52,881,55742
-48717,Winston,Reid,Reid,453,442,401,383,,410,,,,,562eed5c,529,37526
-48760,Mathias,Jorgensen,Zanka,,171,195,,,594,595,121,112,,0db5d2c8,6030,52059
-48771,Emilio,Nsue Lopez,Nsue,279,,,,,,,,,,1c9bc4fa,1757,59558
-48773,Siem,de Jong,de Jong,,466,,,,,,,,,cf2a6ace,774,45509
-48844,David,Ospina,Ospina,1,1,,,,,,,,,82b1198a,505,73396
-48860,Niki,Mäenpää,Mäenpää,,53,,,,,,,,,14a96e1c,6053,12359
-49013,Victor,Moses,Moses,92,102,117,,,,,,,,e726e11e,541,59866
-49083,Luke,Freeman,Freeman,,,,441,477,,,322,,,636b64cd,7713,66923
-49195,Jefferson,Montero,Montero,373,364,,,,,,,,,fa6561bf,715,77932
-49202,Sean,Scannell,Scannell,,180,,,,,,,,,7ab42a5e,,61549
-49207,Rudy,Gestede,Gestede,629,,,,,,,,,,822b3ef9,671,39908
-49262,Jason,Steele,Steele,,,439,,528,54,102,148,142,138,28300a16,7235,73564
-49277,Leroy,Fer,Fer,375,365,,,,,,,,,3cefa66a,711,63342
-49382,Bruno,Ecuele Manga,Ecuele Manga,,,92,,,,,,,,72a0fb65,4883,60990
-49384,Jack,Rodwell,Rodwell,350,,,591,,,,,,,a07579ee,733,57079
-49413,James,Tomkins,Tomkins,103,117,138,124,129,147,153,241,,,e7ca0439,530,61592
-49438,Jordon,Mutch,Mutch,115,552,,,,,,,,,37c408cc,632,57207
-49440,Hal,Robson-Kanu,Robson-Kanu,571,436,,,408,,,,,,fb2dec57,1738,65976
-49464,Cristhian,Stuani,Stuani,293,,,,,,,,,,220c11f1,1709,59323
-49539,Kyle,Naughton,Naughton,358,352,,,,,,,,,e860c42f,718,66219
-49579,Pedro,Rodríguez Ledesma,Pedro,90,109,125,114,,,,,,,3ca7254a,687,65278
-49688,Alfred,N'Diaye,N'Diaye,644,,,,,,,,,,7789bf63,2144,77737
-49696,Mauro,Zárate,Zárate,636,419,,,,,,,,,cc18ff4c,939,26456
-49773,Albert,Adomah,Adomah,281,,,,,,,,,,c7174e81,1782,83430
-49806,David Junior,Hoilett,Hoilett,,,99,,,,,,,,33af5b9e,4395,58993
-49845,Aron,Gunnarsson,Gunnarsson,,,102,,,,,,,,e2533c20,7199,63821
-49944,Jake,Livermore,Livermore,157,426,,,409,,,,,,b98570d1,1689,61832
-49957,Kamil,Grosicki,Grosicki,647,,,,410,,,,,,81d8091f,3231,37920
-49982,Sean,Morrison,Morrison,,,90,,,,,,,,09fec029,6823,79723
-50089,Geoff,Cameron,Cameron,320,331,,,,,,,,,1a160ea3,859,31642
-50093,David,Button,Button,,,179,48,56,,,,,,e608ed4c,6843,61814
-50175,Danny,Welbeck,Welbeck,26,26,21,512,588,447,103,154,148,178,ce5143da,501,67063
-50229,Matt,Phillips,Phillips,446,432,,,411,,,,,,7bb5f40e,1737,77274
-50232,Jonjo,Shelvey,J.Shelvey,,296,318,269,321,291,349,463,,,3727dd3c,769,71292
-50471,James,McArthur,McArthur,114,127,147,138,130,148,154,,,,cee31595,633,41416
-50472,James,McCarthy,McCarthy,136,150,166,157,131,,,,,,64b08de7,589,45333
-51090,Thiago,Emiliano da Silva,T.Silva,,,,,490,121,128,217,,,86e7deaf,3288,29241
-51344,Rajiv,van La Parra,van La Parra,,173,200,,,,,,,,1931bde9,6036,77001
-51507,Laurent,Koscielny,Koscielny,3,4,3,7,,,,,,,f5efb153,494,76277
-51917,Diego,Cavalieri,Cavalieri,,633,,,,,,,,,84e6ea11,6620,53231
-51927,Ben,Mee,Mee,56,77,70,83,88,106,526,109,100,,8df7a2fb,1654,74810
-51934,Ron-Robert,Zieler,Zieler,166,,,,,,,,,,a0606ae8,91,21327
-51938,Marc,Albrighton,Albrighton,177,200,224,174,221,202,251,,,,b827d5b3,753,61560
-51940,David,De Gea Quintana,De Gea,242,260,282,235,291,270,327,,,,7ba6d84e,546,59377
-51943,Václav,Hladký,Hladký,,,,,,,,,,185,6658971d,,95795
-52153,Miguel,Britos,Britos,413,402,379,,,,,,,,356a9a62,567,76799
-52287,Evandro,Goebel,Evandro,630,,,,,,,,,,67dbadfc,5550,53359
-52484,Leon,Balogun,Balogun,,,54,40,,,,,,,78e68b4d,394,56100
-52538,Fernando Francisco,Reges,Fernando,234,251,,,,,,,,,41f32541,615,51174
-52775,Nicolas,Nkoulou,Nkoulou,,,,,,618,,,,,93cf32a8,,60577
-52940,Daryl,Janmaat,Janmaat,540,404,381,359,,,,,,,45da6694,764,60744
-53371,David,Meyler,Meyler,161,,,,,,,,,,8ea6417a,1693,68183
-54102,Jack,Wilshere,Wilshere,17,24,447,394,434,,,,,,9c318325,1036,74223
-54284,Chris,Löwe,Löwe,,165,193,,,,,,,,c6896eab,6032,55125
-54316,Leonardo,Ulloa,Ulloa,185,210,,,,,,,,,eed56f6c,756,54890
-54421,Floyd,Ayité,Ayité,,,186,,,,,,,,fd5888a0,3328,77974
-54469,Adam,Smith,Smith,34,35,29,63,,,57,84,81,73,20b104bc,825,61841
-54484,Francisco,Femenía Far,Femenía,,407,383,357,,382,,,,,e5d01ecf,5043,76467
-54513,Vicente,Iborra,Iborra,,208,228,,,,,,,,ad1ffcfd,2065,65467
-54527,Loïc,Damour,Damour,,,104,,,,,,,,074d8166,7215,81190
-54694,Pierre-Emerick,Aubameyang,Aubameyang,,616,23,11,4,4,617,188,,,d5dd5f1f,318,58864
-54738,Thomas,Kaminski,Kaminski,,,,,,,,614,,,1caa93a5,11712,77757
-54756,Victor,Wanyama,Wanyama,400,389,366,348,,,,,,,e0900238,836,77760
-54764,Jonathan,Kodjia,Kodjia,,,,26,,,,,,,ecf44e09,7725,88971
-54771,Fabio Pereira,da Silva,Fabio,527,,,,,,,,,,bc7b4580,1752,61891
-54861,Christian,Benteke,Benteke,213,134,152,129,132,149,155,,,,ab070c55,606,50201
-54908,Nacer,Chadli,Chadli,392,427,,,,,,,,,5b54bf3b,648,59631
-55037,Cheikhou,Kouyaté,Kouyaté,459,451,412,139,133,150,583,451,,,8d3c902d,532,66934
-55038,Kevin,McDonald,McDonald,,,183,,172,,,,,,71a08f97,6836,36529
-55313,Franck,Tabanou,Tabanou,364,,,,,,,,,,15e1afd5,980,66413
-55317,Bernardo,Espinosa Zúñiga,Bernardo,280,,,,,,,,,,4242011c,1716,64598
-55422,Gylfi,Sigurdsson,Sigurdsson,368,359,172,151,150,164,,,,,76dd1480,714,90466
-55452,Yannick,Bolasie,Bolasie,109,147,165,,,,,,,,715fc0fe,518,75471
-55459,Aaron,Cresswell,Cresswell,454,443,402,376,435,411,457,530,517,,4f974391,534,92571
-55494,Joel,Ward,Ward,105,119,441,126,134,474,156,242,215,,8a7ff278,510,92572
-55605,Toby,Alderweireld,Alderweireld,382,377,353,331,386,355,,,,,f7d50789,639,42710
-55829,Claudio,Yacob,Yacob,442,429,,,,,,,,,bda6ffd4,808,45330
-55909,Chris,Smalling,Smalling,244,263,284,223,292,,,,,,b6964eb6,628,103427
-55914,Liam,Cooper,Cooper,,,,,195,184,221,,,,dc64b8b3,8816,75067
-56192,Rhu-endly,Martina,Cuco Martina,302,464,163,577,,,,,,,22551915,832,91251
-56377,Andriy,Yarmolenko,Yarmolenko,,,453,392,436,412,,,,,849c826a,6274,69015
-56827,Costel,Pantilimon,Pantilimon,406,396,,,,,,,,,d24e154c,580,47659
-56864,Francis,Coquelin,Coquelin,20,20,,,,,,,,,a6951bf8,497,74869
-56872,Junior,Stanislas,Stanislas,42,42,36,77,,,58,,,,6992791d,463,87672
-56917,Steve,Cook,Cook,32,33,27,58,,,379,441,,,3e5e4e63,458,90836
-56979,Jordan,Henderson,Henderson,201,225,249,198,244,222,275,299,,124,935e6b8f,605,61651
-56981,Joe,Bennett,Bennett,,,94,,,,,,,,dc936144,959,90964
-56983,Matt,Ritchie,Ritchie,,295,317,251,322,292,350,425,,,71ef519e,461,92469
-57001,Wilfried,Bony,Bony,240,542,,,,,,,,,61abe9b6,622,81808
-57112,Eliaquim,Mangala,Mangala,225,502,,,,,,,,,f520049f,626,90681
-57127,Teemu,Pukki,Pukki,,,,278,,315,,,,,0745b37d,7696,46972
-57134,Salomón,Rondón,Rondón,449,435,493,,,591,177,,,,b318a643,813,80197
-57145,Federico,Fernández,Fernández,363,354,516,254,323,465,351,,,,f25b010f,708,85475
-57187,Giedrius,Arlauskis,Arlauskis,639,,,,,,,,,,1858bbf7,949,69001
-57249,Henrikh,Mkhitaryan,Mkhitaryan,268,281,18,16,,,,,,,dd0daf32,317,55735
-57328,Nathaniel,Clyne,Clyne,193,217,241,,577,493,157,222,196,263,0442183b,603,85177
-57410,Nicolás,Otamendi,Otamendi,226,245,264,208,269,,,,,,0d267745,611,54781
-57513,Jonas,Lössl,Lössl,,163,191,479,151,673,,,,,939bc634,3468,48870
-57531,Michail,Antonio,Antonio,464,454,415,389,437,413,458,523,512,,ac05f970,531,104124
-57586,Luciano,Narsingh,Narsingh,632,369,,,,,,,,,977ffc24,5554,72462
-57647,Lyle,Taylor,Lyle Taylor,,,,,,,380,,,,3e80e04e,10762,104495
-57736,Jan,Kirchhoff,Kirchhoff,347,,,,,,,,,,a14d04e3,232,49734
-57913,Barry,Douglas,Douglas,,,424,,196,,,,,,c859705e,,91854
-58376,Alex,McCarthy,McCarthy,101,305,328,318,363,334,401,,469,,36c2ca73,635,95976
-58476,Rui Pedro,da Rocha Fonte,Fonte,,,188,,,,,,,,6ff8ef56,7145,9335
-58498,Odion,Ighalo,Ighalo,426,,,624,293,,,,,,03622183,573,62121
-58621,Kyle,Walker,Walker,384,379,265,203,270,249,299,369,363,187,86dd77d1,638,95424
-58771,Jack,Colback,Colback,,299,,482,,,381,,,,963a9201,767,61644
-58786,Martin,Kelly,Kelly,106,120,140,128,135,151,,,,,d7492450,525,78959
-58791,Ryan,Mason,Mason,396,,,,,,,,,,c8fac933,649,61834
-58822,Cédric,Alves Soares,Cédric,301,310,332,486,5,5,1,2,,,839c14e1,847,112988
-58845,Ciaran,Clark,Clark,,289,311,259,324,293,352,,,,2b91cf8e,875,98240
-58877,Daley,Blind,Blind,254,270,290,,,,,,,,691bef82,548,12282
-58893,Marcos,Rojo,Rojo,248,266,287,227,294,,,,,,e0991c04,550,93176
-59044,Adam,Clayton,Clayton,283,,,,,,,,,,45b59689,1717,73067
-59115,Mile,Jedinak,Jedinak,112,,,,,,,,,,22fd2214,515,28336
-59125,Connor,Wickham,Wickham,122,133,444,130,136,,,,,,41cc19c2,519,95435
-59614,Mark,Duffy,Duffy,,,,300,,,,,,,d86ccbc9,,105565
-59735,Karl,Darlow,Darlow,,287,308,263,325,294,353,408,,341,cde3309f,780,99397
-59741,Max,Gradel,Gradel,44,44,,,,,,,,,c5a500ca,464,28140
-59779,Pedro,Obiang,Obiang,460,452,413,400,,,,,,,ba1e04b3,542,101213
-59796,Gökhan,Töre,Töre,467,,,,,,,,,,51960957,1703,82130
-59846,Ander,Herrera,Herrera,262,278,299,,,,,,,,436a9dd0,552,99343
-59856,Abel,Hernández,Hernández,163,,,,,,,,,,a36da810,1698,76608
-59859,İlkay,Gündoğan,Gündoğan,236,253,274,222,271,250,300,,625,420,819b3158,314,53622
-59940,Kyle,Bartley,Bartley,,485,,,412,,,,,,18e96f64,964,67421
-59949,Séamus,Coleman,Coleman,126,139,157,144,152,165,178,247,221,294,0420d84f,585,68390
-59966,Alexandre,Lacazette,Lacazette,,28,22,12,6,6,,,,,9dbb75ca,3277,93720
-60025,James,Rodríguez,James,,,,,508,166,,,,,715bf047,2249,88103
-60165,Wahbi,Khazri,Khazri,352,,,,,,,,,,2677a1de,734,103565
-60232,Craig,Dawson,Dawson,433,424,,439,576,414,459,551,542,,3e9e06cb,804,121477
-60252,Andros,Townsend,Townsend,120,131,149,135,137,482,179,727,,,b28bbd58,775,61842
-60270,Simone,Zaza,Zaza,550,,,,,,,,,,9592289a,1642,96828
-60307,Pascal,Groß,Groß,,70,59,49,57,55,104,134,125,783,8aec0537,239,82873
-60551,Ashley,Westwood,Westwood,641,88,80,101,89,107,,,,,495945ef,669,91317
-60586,Jóhann Berg,Gudmundsson,Gudmundsson,473,84,76,96,90,108,,170,,,f72293fc,1663,89231
-60598,Aleksandar,Dragovic,Dragovic,,541,,,,,,,,,6fd8a334,5219,59032
-60689,Chris,Wood,Wood,,518,87,91,91,109,354,468,447,525,4e9a0555,4456,108725
-60706,Adrián,San Miguel del Castillo,Adrián,450,438,399,526,245,223,497,289,,,f76e6b4e,527,71271
-60772,Thibaut,Courtois,Courtois,73,94,111,,,,,,,,1840e36d,680,108390
-60794,Adam,Matthews,Matthews,345,,,,,,,,,,d8bffa70,1034,108878
-60914,Joel,Matip,Matip,199,219,243,185,246,224,276,305,,,b217ef29,332,82105
-61256,Carlos Henrique,Casimiro,Casemiro,,,,,,,593,376,368,457,4d224fe8,2248,16306
-61262,Oscar,dos Santos Emboaba Junior,Oscar,84,,,,,,,,,,57fe98dd,692,85314
-61302,Ryan,Allsop,Allsop,600,,,,,,,,,,af615123,1050,111073
-61316,Jose Luis,Mato Sanmartín,Joselu,338,488,327,261,,,,,,,6265208f,866,81999
-61366,Kevin,De Bruyne,De Bruyne,235,252,273,215,272,251,301,349,345,,e46012d4,447,88755
-61538,Callum,McManaman,McManaman,443,,,,,,,,,,1a5dbcc2,880,61711
-61548,Manolo,Gabbiadini,Gabbiadini,643,327,349,,,,,,,,8f866fe8,1383,112343
-61558,Thiago,Alcántara do Nascimento,Thiago,,,,,531,225,277,310,,,77e84962,229,60444
-61566,Roberto,Pereyra,Pereyra,539,415,391,369,,,,,,,75f2c59f,1723,112302
-61595,Marc,Muniesa,Muniesa,322,333,,,,,,,,,4db76f57,860,74228
-61600,Romaine,Sawyers,Sawyers,,,,,413,,,,,,77bb1522,8757,113036
-61603,Daniel,Drinkwater,Drinkwater,179,202,128,120,,,,,,,2649ff32,752,73491
-61604,Matty,James,James,602,474,229,177,222,,,,,,ebd0a048,4441,73522
-61739,Maxime,Le Marchand,Le Marchand,,,455,,173,,,,,,321a71a7,3304,60558
-61760,Kristoffer,Nordfeldt,Nordfeldt,357,351,,,,,,,,,78549904,722,75890
-61810,Pontus,Jansson,Jansson,,,,,,76,78,,,,172e52d8,1801,125314
-61858,Mame Biram,Diouf,Diouf,337,348,,,,,,,,,7f4f3e49,868,62049
-61916,Stefan,Johansen,Johansen,,,185,,174,,,,,,a48da055,6838,62008
-61933,Shane,Duffy,Duffy,,56,49,37,58,56,105,,,,7314bba4,6047,119269
-62398,Nemanja,Matic,Matic,87,107,296,247,295,271,,,,,eb7822d7,697,74683
-62399,Dusan,Tadic,Tadic,308,318,,,,,,,,,2475dcc6,840,36139
-62974,Erik,Lamela,Lamela,393,386,363,346,387,356,,,,,abe66106,644,111630
-63370,James,McClean,McClean,444,430,,,,,,,,,53538b39,814,85935
-63426,Enda,Stevens,Stevens,,,,291,347,,,,,,17d4507a,7707,85706
-66242,Davy,Pröpper,Pröpper,,490,60,54,59,57,,,,,fdd85f94,6050,79027
-66247,Marvin,Zeegelaar,Zeegelaar,,537,384,,,,,,,,8abd0c03,6303,92899
-66588,Luke,Ayling,Ayling,,,,,197,185,222,,,,420d7c7d,8716,67420
-66733,Juan,Cuadrado,Cuadrado,85,,,,,,,,,,0ab1f153,1089,91970
-66749,Romelu,Lukaku Bolingoli,Lukaku,143,285,306,232,,529,,207,175,,5eae500a,594,96341
-66797,Simon,Mignolet,Mignolet,188,213,237,190,,,,,,,d436eb94,487,50219
-66838,Cenk,Tosun,Tosun,,592,177,146,153,622,,,,,9a104dee,6477,45671
-66842,André,Schürrle,Schürrle,,,478,,,,,,,,ecbb3fdf,154,58205
-66975,Luka,Milivojevic,Milivojevic,646,132,150,134,138,152,158,,,,2ce2508a,5549,74300
-67089,Martin,Dúbravka,Dúbravka,,621,309,262,326,295,355,409,396,470,3a949a25,6532,74960
-67184,Roderick Jefferson,Gonçalves Miranda,Miranda,,,429,,,,,,,,390ab439,,87856
-67527,Allan-Roméo,Nyom,Nyom,412,422,,,,,,,,,97572117,565,111508
-68312,Xherdan,Shaqiri,Shaqiri,333,342,462,194,247,226,,,,,6421ec64,888,86792
-68983,Matthew,Lowton,Lowton,55,76,69,85,92,110,,,,,9a9c05db,1652,102258
-69140,Shkodran,Mustafi,Mustafi,555,12,7,1,7,,,,,,3f2d59fe,1699,88590
-69143,Juraj,Kucka,Kucka,,,,,,495,,,,,5aaef9ef,1123,74943
-69752,Norberto,Murara Neto,Neto,,,,,,,574,77,73,66,a9dc785c,1297,111819
-69960,Philipp,Wollscheid,Wollscheid,324,,,,,,,,,,c4cca587,858,53173
-71738,Marco,Stiepermann,Stiepermann,,,,285,,316,,,,,b606638c,7694,45760
-72147,Marco,Bizot,M.Bizot,,,,,,,,,,33,3d214e5f,9614,124884
-72222,Mateusz,Klich,Klich,,,,,198,186,223,,,,282679b4,4381,92738
-72681,Denis,Odoi,Odoi,,,181,,525,,,,,,f7750aa0,7077,59641
-73314,Willian José,Da Silva,Willian José,,,,,642,,,,,,d87e2cae,2361,122155
-73426,Andre,Gray,Gray,68,92,395,364,,383,,,,,c24dba2a,1660,120565
-73459,Ashley Darel Jazz,Richards,Jazz Richards,,,96,,,,,,,,afef14da,4467,120241
-73494,Grzegorz,Krychowiak,Krychowiak,,533,,,,,,,,,580d52dd,2414,45184
-73889,Diafra,Sakho,Sakho,470,458,,,,,,,,,57c433c8,656,120610
-74033,Sam,Clucas,Clucas,156,519,,,,,,,,,987718f5,1690,122223
-74208,Paul,Pogba,Pogba,503,282,302,238,296,272,,,,,867239d3,1740,122153
-74230,Patrick,van Aanholt,van Aanholt,344,124,142,123,139,,,,,,5f09991f,730,52119
-74297,Leandro,Bacuna,Bacuna,,,589,,,,,,,,9dc69d38,674,126014
-74375,Ezequiel,Schelotto,Schelotto,,538,53,546,,,,,,,a6e316c1,3873,119164
-74471,Aaron,Mooy,Mooy,,172,199,516,60,,,,,,47b7e3af,6033,123951
-74854,Simon,Moore,Moore,,,,436,348,,,,,529,e7434f04,7715,123536
-74944,Sam,Morsy,Morsy,,,,,,,,,278,,a23c0949,12748,123551
-75115,Callum,Wilson,Wilson,49,48,43,67,506,296,356,433,421,671,c596fcb0,468,123682
-75773,Chung-yong,Lee,Lee Chung-yong,117,128,,,,,,,,,49b05a83,526,81801
-75826,Danny,Ward,Ward,,,105,,,,,,,,cfb29823,6830,124172
-75880,Daniel,Ayala,Ayala,275,,,,,,,,,,302560a0,1718,78966
-76306,Lukas,Rupp,Rupp,,,,602,,317,,,,,3faa1780,62,82863
-76357,Tom,Cairney,Cairney,,,182,,175,,200,268,243,331,a8748947,6835,123275
-76359,Phil,Jones,Jones,245,264,285,231,297,632,328,,,,def899bd,951,117996
-76360,Nathaniel,Mendez-Laing,Mendez-Laing,,,100,,,,,,,,b4b2f632,6824,125409
-76542,Sung-yueng,Ki,Ki Sung-yueng,372,363,324,268,,,,,,,1d8c99b0,723,81796
-77359,Florian,Lejeune,Lejeune,,294,314,257,327,,,,,,6eaed4eb,5073,127108
-77454,Fabio,Borini,Borini,354,,,,,,,,,,ef5b337e,737,96754
-77610,Danny,Batth,Batth,,,428,,,,,,,,f1d0fa63,,129049
-77760,Cristian,Gamboa,Gamboa,435,,,,,,,,,,f27680d9,855,121686
-77762,Bryan,Oviedo,Oviedo,140,,,,,,,,,,31faf295,598,124983
-77777,Ahmed El-Sayed,Hegazy,Hegazi,,468,,,414,,,,,,5540c9dc,3979,111524
-77794,Kieran,Trippier,Trippier,387,382,357,334,,678,357,430,418,478,21512407,652,95810
-77818,James,Shea,Shea,,,,,,,,335,,,ee7c0a5e,11724,91340
-78007,Joshua,King,King,48,51,45,68,651,468,,,,,43458538,465,91059
-78056,Oriol,Romeu Vidal,Romeu,310,320,339,328,364,335,402,,,,4b511457,842,66100
-78091,Gastón,Ramírez,Ramírez,491,,,,,,,,,,2c851997,952,123742
-78315,Joel,Robles,Robles,123,136,,,,,578,,,,cda0b317,584,101118
-78356,Charlie,Austin,Austin,314,326,348,312,415,,,,,,8d228291,848,129627
-78412,Shinji,Okazaki,Okazaki,186,211,235,,,,,,,,68796d61,754,79642
-78607,Kenny,McLean,McLean,,,,286,,318,,,,,471f16b3,7693,126600
-78830,Harry,Kane,Kane,403,394,372,338,388,357,427,500,,,21a66f6a,647,132098
-78911,Kadeem,Harris,Harris,,,535,,,,,,,,24396398,7120,136501
-78916,Dan,Burn,Burn,,,582,475,61,58,358,407,395,476,b2d31e83,7382,134270
-79228,Pape,Souaré,Souaré,108,122,443,,,,,,,,46b5375e,513,125868
-79602,Daniel,Bentley,Bentley,,,,,,,717,546,536,629,68db6358,11361,136401
-79619,Jonathan,Hogg,Hogg,,174,201,,,,,,,,9306d5ea,6301,61573
-79733,Scott,Malone,Malone,,462,196,,,,,,,,f15a50e8,6040,101682
-79852,Jed,Steer,Steer,,,,429,32,28,,,,,a8a3d139,4475,110867
-79934,Oliver,Norwood,Norwood,,68,,302,349,,,488,,,43439614,7710,73547
-80146,Jordan,Ayew,J.Ayew,642,373,505,468,140,153,159,221,192,,da052c14,672,108354
-80179,Adam,Forshaw,Forshaw,286,,,,199,552,224,,,,9f1938ab,1711,121257
-80183,Luke,Garbutt,Garbutt,,629,,,,,,,,,41017ad5,4437,110860
-80201,Bernd,Leno,Leno,,,2,14,8,1,2,275,248,314,2628fd2b,181,72476
-80226,Serge,Aurier,Aurier,,532,360,336,389,358,628,436,,,5c2b4f07,3600,127032
-80254,Carl,Jenkinson,Jenkinson,9,9,581,9,,,,,,,874125a3,938,126321
-80447,Maya,Yoshida,Yoshida,298,308,331,310,,,,,,,caffaf5a,845,81789
-80498,Eunan,O'Kane,O'Kane,40,,,,,,,,,,b7f8b1fc,472,61583
-80607,Christian,Eriksen,Eriksen,394,387,364,343,,699,519,379,370,,980522ec,646,69633
-80711,Yaya,Sanogo,Sanogo,27,,,,,,,,,,11ced928,4402,127194
-80755,Danny,Williams,Williams,,184,204,,,,,,,,ec9a28ce,6037,38383
-80788,Daniel,Lafferty,Lafferty,502,,,,,,,,,,cfc41f7a,4428,85928
-80789,Jordi,Amat,Amat,362,,,,,,,,,,d70a2141,721,85289
-80792,Greg,Cunninghamm,Cunningham,,,467,,,,,,,,dc10b26c,6831,114093
-80801,Idrissa Gana,Gueye,Gana,488,155,168,156,,,611,254,222,302,72c812f3,668,126665
-80935,Papy,Djilobodji,Djilobodji,499,,,,,,,,,,083525e5,1071,136610
-80954,Rodrigo,Moreno,Rodrigo,,,,,492,187,225,,,,1fb1c435,2381,131505
-81012,Ryan,Fredericks,Fredericks,,,408,380,438,415,59,68,,,c067631c,6891,140191
-81048,Josip,Drmic,Drmic,,,,434,,,,,,,15ea94de,209,140579
-81061,Michael,Simões Domingues,Mika,577,,,,,,,,,,d74a54d1,1721,138285
-81183,Matej,Vydra,Vydra,483,,495,92,93,111,,,,,0d4ceb32,1017,101500
-81205,Mislav,Orsic,Orsic,,,,,,,692,,,,ee950928,11298,119150
-81441,Mark,Gillespie,Gillespie,,,,,488,514,776,411,,471,e32958b7,8729,142389
-81880,Alex,Oxlade-Chamberlain,Chamberlain,18,19,248,193,248,227,278,,,,38c7feef,966,143424
-82078,Kenneth,Zohore,Zohore,,,107,,416,,,,,,5e508d0d,6928,135213
-82143,Wes,Foderingham,Foderingham,,,,,350,,,482,522,601,96cf7b61,8776,61697
-82257,Raphael,Spiegel,Spiegel,591,,,,,,,,,,050b9803,1005,111428
-82263,Marcos,Alonso,Alonso,561,100,115,103,104,122,129,,,,f4290206,1621,112515
-82403,Wilfried,Zaha,Zaha,111,126,151,133,141,154,160,,,,b2bc3b1f,522,145988
-82428,Marten,de Roon,de Roon,290,,,,,,,,,,2a1beb34,1710,133179
-82514,Tim,Ream,Ream,,,180,,176,,201,281,253,,28b40c9c,7184,145466
-82660,Marco,Van Ginkel,Van Ginkel,93,,,,,,,,,,47681787,946,147034
-82691,George,Baldock,Baldock,,,,294,351,,,473,,,394854c4,7706,146690
-82738,Luke,Berry,Berry,,,,,,,,317,,,2aaadf33,11722,125685
-82771,Markus,Henriksen,Henriksen,573,,,,,,,,,,26acecd2,1696,122011
-83091,Borja,González Tomás,Bastón,507,,,623,,,,,,,8c44e37b,1701,85324
-83283,Nathan,Redmond,Redmond,304,324,343,320,365,336,403,600,,,ab651565,790,129078
-83299,Lewis,Dunk,Dunk,,55,48,42,62,59,106,129,120,146,282f75f3,6048,148153
-83312,Ben,Gibson,Gibson,278,,491,89,94,456,,,,,bcfb0142,1707,128904
-83314,Jeff,Hendrick,Hendrick,560,86,78,100,485,297,375,414,,,989d5705,1746,148262
-83427,Jack,Robinson,Robinson,,,,611,352,,,576,,,7399c7a8,8286,128909
-83428,Grant,Hanley,Hanley,,292,,277,,319,,,,,e9254eec,7690,121385
-83543,Anthony,Knockaert,Knockaert,,62,55,52,177,,202,273,,,6c679c6d,4497,149237
-84112,Collin,Quaner,Quaner,,186,209,,,,,,,,19b8b0b9,6035,123397
-84182,Alphonse,Areola,Areola,,,,,516,489,473,524,513,600,2f965a72,2310,120629
-84384,Timm,Klose,Klose,,,,272,,,,,,,5f1d07f6,162,65255
-84395,Florin,Gardos,Gardos,300,,,,,,,,,,70eb7e9d,4405,57423
-84450,Granit,Xhaka,Xhaka,24,23,17,18,9,7,3,30,,668,e61b8aee,204,111455
-84583,Philippe,Coutinho Correia,Coutinho,203,226,,,,681,29,38,,,0ef89a37,488,80444
-84915,Michael,Hector,Hector,,,,,178,,,,,,5f1a2f31,5274,157490
-84939,Danny,Ings,Ings,216,237,258,313,366,337,30,535,523,,07802f7f,986,134294
-85017,Tendayi,Darikwa,Darikwa,60,,,,,,,,,,beecc37c,1666,158700
-85128,Connor,Goldson,Goldson,,61,,,,,,,,,56f6f826,6299,163656
-85242,Conor,Hourihane,Hourihane,,,,28,33,29,,,,,fcab00a0,7721,61653
-85352,Bruno,Martins Indi,Martins Indi,562,513,,,,,,,,,7bc34048,1743,112052
-85368,Christopher,Schindler,Schindler,,164,192,,,,,,,,8ae9869d,6031,57842
-85624,Christian,Kabasele,Kabasele,414,403,380,354,,384,,,,,914ab9a1,1725,81512
-85633,Matz,Sels,Sels,,,,,,,,808,443,502,834b5c4c,6903,127202
-85654,Jordy,Clasie,Clasie,309,319,,,,,,,,,31c01b85,837,104223
-85955,Jorge Luiz,Frello Filho,Jorginho,,,459,118,105,123,130,9,7,,45db685d,1389,102017
-85971,Son,Heung-min,Son,402,390,367,342,390,359,428,516,503,579,92e7e919,453,91845
-86129,Kalidou,Koulibaly,Koulibaly,,,,,,,520,,,,da974c7b,1376,93128
-86153,Martín,Montoya,Montoya,,,503,38,63,,,,,,5cec2487,1950,68645
-86173,Manuel,Agudo Durán,Nolito,237,254,,,,,,,,,b2d0ec1b,1732,70934
-86176,Tom,Ince,Ince,,182,203,,,,,,,,67d23ab0,4454,157368
-86417,Jeffrey,Schlupp,Schlupp,169,123,141,137,142,155,161,240,214,,3312f911,757,157506
-86431,Brice,Dja Djédjé,Dja Djédjé,481,,,,,,,,,,d8593687,3605,93690
-86873,Benjamin,Lecomte,Lecomte,,,,,,,,,,664,2fa2a875,3451,127181
-86881,Nampalys,Mendy,Mendy,183,205,527,179,518,203,252,,,,1598599e,1785,111051
-86934,Manuel,Lanzini,Lanzini,462,453,414,391,439,416,460,,,,26f6dca8,535,135853
-87107,Cyrus,Christie,Christie,,,460,,179,,,,,,7eb67dad,6833,158623
-87121,Kieron,Freeman,Freeman,,,,292,,,,,,,c13c24c8,8046,158703
-87396,Moritz,Leitner,Leitner,,,,288,,,,,,,9460aaed,1217,82243
-87428,Elias,Kachunga,Kachunga,,181,212,,,,,,,,5bddccc9,248,49501
-87447,Muhamed,Bešić,Bešić,139,152,,522,,,,,,,7ca9f0f0,908,93905
-87835,Matt,Doherty,Doherty,,,425,401,457,360,429,598,543,632,d557d734,6852,171679
-87856,Michael,Hefele,Hefele,,167,,,,,,,,,91bdc54a,6039,102382
-87873,Stuart,Dallas,Dallas,,,,,200,188,226,,,,67ca8566,8718,158764
-88170,Jiri,Skalak,Skalak,,67,,,,,,,,,beaec218,6106,148734
-88175,Lovre,Kalinic,Kalinic,,,,474,,,,,,,3a74f92b,8253,46405
-88248,Stefan,Ortega Moreno,Ortega Moreno,,,,,,,324,361,358,400,c1242d4e,8786,85941
-88482,Álvaro,Morata,Morata,,472,134,,,,,,,,129af0db,1804,128223
-88484,Pablo,Sarabia,Sarabia,,,,,,,704,570,565,,9744ff80,2199,74230
-88498,Benik,Afobe,Afobe,52,49,,,,,,,,,b63f4077,826,110858
-88734,Neil,Etheridge,Etheridge,,,88,,,,,,,,2642bf6c,6821,61694
-88894,Ross,Barkley,Barkley,134,149,127,117,106,124,131,630,29,55,3a24769f,592,131978
-88898,Moses,Odubajo,Odubajo,151,,,,,,,,,,761bc132,,163738
-88900,Jack,Stephens,Stephens,504,313,333,308,367,338,404,,472,,6adbc307,1735,163744
-88935,Steven,Berghuis,Berghuis,421,411,,,,,,,,,713c144a,744,129554
-89068,Layvin,Kurzawa,Kurzawa,,,,,,,613,,,,41e7ef1c,3298,126710
-89076,Remo,Freuler,Freuler,,,,,,,582,446,,,98d2c2c4,1488,148252
-89085,Nathaniel,Chalobah,Chalobah,530,112,387,374,,385,203,,,,422862ea,1677,128900
-89274,José Ignacio,Peleteiro Romallo,Jota,,,,36,34,,,,,,9f351459,2132,176591
-89335,Saúl,Ñíguez,Saúl,,,,,,592,,,,,c14bc029,2266,148928
-89470,Onel,Hernández,Hernández,,,,284,,320,,,,,007b39a5,7697,109751
-89572,Denis,Suárez,Suárez,,,586,,,,,,,,12c50af5,2308,165007
-90105,Ryan,Fraser,Fraser,536,47,40,75,507,298,359,410,397,,d56543a0,1683,146795
-90152,Raphaël,Varane,R.Varane,,,,,,555,329,395,,,9f8e9423,2245,164770
-90263,James,Husband,Husband,661,,,,,,,,,,33e2d513,5576,167393
-90440,Tom,Trybull,Trybull,,,,290,,,,,,,552aa16c,7692,93831
-90517,Robbie,Brady,Brady,640,87,79,98,95,,,,,,96bb8cc2,789,128229
-90518,Ravel,Morrison,Morrison,,,,456,,,,,,,bf59c794,1883,128907
-90585,Willy,Boly,Boly,,,423,405,458,428,474,439,425,514,a4ac4b8f,6850,142310
-90714,Ahmed,Musa,Musa,187,207,,,,,,,,,b7084daf,1681,168337
-91046,Cauley,Woodrow,Woodrow,,,,,,,,340,,,d3085b49,11721,169801
-91047,Stuart,Armstrong,S.Armstrong,,,345,323,368,339,405,,,,97333cf5,6893,130765
-91126,Will,Keane,Keane,557,,,,,,,,,,fc7f8f87,1047,118535
-91651,Mateo,Kovačić,Kovačić,,,499,432,107,125,132,356,354,422,79c0821a,2254,51471
-91889,Niclas,Füllkrug,Füllkrug,,,,,,,,,589,625,4f16405e,6098,75489
-91972,Saido,Berahino,Berahino,448,349,,,,,,,,,25b166d0,811,128897
-91979,Jon,Flanagan,Flanagan,194,514,,,,,,,,,f2428fd4,490,145922
-92159,Jetro,Willems,Willems,,,,498,,,,,,,9050ddc4,6143,146258
-92170,Massadio,Haidara,Haidara,,465,,,,,,,,,5167c97e,943,170929
-92217,Roberto,Firmino,Firmino,209,235,257,187,249,228,279,,,,4c370d81,482,131789
-92259,Neeskens,Kebano,Kebano,,,187,,180,,204,,,,18b999f4,6840,111422
-92293,Omar,Elabdellaoui,Elabdellaoui,634,,,,,,,,,,4f56170e,5551,121404
-92371,Pablo,Marí Villar,Pablo Marí,,,,617,10,8,20,,,,aa54ec6f,8380,210178
-92383,Nahki,Wells,Wells,,185,86,,,,,,,,b070482d,6389,173483
-93001,Konstantinos,Stafylidis,Stafylidis,,599,,,,,,,,,861e0116,368,148967
-93100,Jannik,Vestergaard,Vestergaard,,,463,304,369,340,253,,307,,1900032e,111,99331
-93127,Jesé,Rodríguez Ruiz,Jesé,,512,,,,,,,,,4a537185,2256,134936
-93264,Eric,Dier,Dier,390,384,361,350,391,361,430,496,,,ac861941,643,175722
-93284,Florin,Andone,Andone,,,66,46,64,500,,,,,dc008610,4068,177065
-93464,Tom,Carroll,Carroll,397,367,,,,,,,,,5a1900a4,653,121279
-94147,Conor,Coady,Coady,,,430,403,459,429,475,,288,,2928dca2,6851,128901
-94245,Michy,Batshuayi,Batshuayi,96,113,592,461,108,126,,,,,2973d8ff,1678,179184
-94248,Sergio,Rico,Rico,,,509,,,,,,,,5f0241b2,2072,207302
-94924,Gerard,Deulofeu,Deulofeu,141,609,394,363,,,,,,,39583cfd,591,129476
-94926,Freddie,Ladapo,Ladapo,508,505,,,,,,,276,,da2b8db3,1778,233998
-95463,Danny,Ward,Ward,,530,457,170,223,204,254,,308,,d3ce0e89,473,203026
-95508,Fredrik,Ulvestad,Ulvestad,65,575,,,,,,,,,8f160d73,1788,158022
-95658,Harry,Maguire,Maguire,153,198,220,160,298,273,330,387,377,442,d8931174,1687,177907
-95715,Lucas,Rodrigues Moura da Silva,Lucas Moura,,617,370,345,392,362,431,,,,2b622f01,3293,77100
-96305,Jay,Fulton,Fulton,371,362,,,,,,,,,434ad289,896,171260
-96306,Stephen,Kingsley,Kingsley,365,355,,,,,,,,,488cc9c7,892,184398
-96764,M'Baye,Niang,Niang,637,,,,,,,,,,2054d037,1126,157501
-96767,Dimitri,Foulquier,Foulquier,,,,542,,,,,,,45e17712,2509,170472
-96778,Adam,Reach,Reach,285,,,,,,,,,,33a2d4dc,1768,163530
-96784,Jordan,Clark,Clark,,,,,,,,320,,,7c5fa6cf,12187,184129
-96787,Mohamed,Elyounoussi,Elyounoussi,,,346,322,,517,406,,,,68dc0dac,6894,186644
-96994,Bobby,De Cordova-Reid,De Cordova-Reid,,,110,,181,,205,270,290,,0f7533cd,6827,186186
-97032,Virgil,van Dijk,Virgil,303,311,246,183,250,229,280,313,339,373,e06683ca,833,139208
-97296,Tommie,Hoban,Hoban,480,,,,,,,,,,45045170,1002,183161
-97299,John,Stones,Stones,128,242,262,207,273,252,302,368,362,409,5eecec3d,586,186590
-97485,Kevin,Wimmer,Wimmer,388,383,,,,,,,,,faf55ce4,650,122675
-97615,Mike,van der Hoorn,van der Hoorn,366,356,,,,,,,,,25f50295,1702,187105
-97846,Alex,Cairns,Cairns,,,,,,,,,,340,1a5e36e7,,194386
-98745,Héctor,Bellerín,Bellerín,6,7,4,2,11,9,,,,,f874dd44,492,191217
-98747,Nick,Pope,Pope,471,469,68,93,96,112,376,424,413,469,4b40d9ca,5552,192080
-98770,Ørjan,Nyland,Nyland,,,,27,35,,,,,,bdedffac,250,73517
-98780,Juan Carlos,Paredes,Paredes,410,,,,,,,,,,5d8c6afd,578,100507
-98914,Guido,Carrillo,Carrillo,,607,350,,,,,,,,8f898ba8,3424,184672
-98980,Emiliano,Martínez Romero,Martinez,657,3,542,427,12,30,31,49,47,32,7956236f,4401,111873
-99127,Joel,Campbell,Campbell,23,,,,,,,,,,895ff3ca,506,131248
-99323,Lazar,Markovic,Markovic,206,,594,,,,,,,,723ba189,4406,144303
-100059,Alberto,Moreno,Moreno,192,216,240,,,,,,,,11b9265b,608,207917
-100180,Danilo Luiz,da Silva,Danilo,,483,266,209,,,,,,,94b2001f,2244,145707
-100412,André,Carrillo,Carrillo,,527,,,,,,,,,7527558b,6230,135057
-100649,Bernard,Anício Caldeira Duarte,Bernard,,,507,152,154,167,,,,,ab4b3e35,7063,175169
-101061,Philip,Heise,Heise,,,,484,,,,,,,ef66b362,70,112617
-101105,Joe,Bryan,Bryan,,,510,,182,,206,,,,af69e7f0,6834,194460
-101148,Jamaal,Lascelles,Lascelles,,290,312,258,328,299,360,419,407,480,450ab6fc,766,183318
-101178,James,Ward-Prowse,Ward-Prowse,306,317,338,321,370,341,407,664,531,614,3515d404,843,181579
-101179,Lloyd,Isgrove,Isgrove,584,,,,,,,,,,430696d5,1761,226965
-101184,Calum,Chambers,Chambers,11,480,9,467,13,10,32,37,,,dc6f5bdd,508,215118
-101188,Lucas,Digne,Digne,,,484,141,155,168,33,42,36,37,1b84dbe1,1823,126664
-101338,Marcel,Sabitzer,Sabitzer,,,,,,,728,,,,e280527c,5248,106987
-101394,Okay,Yokuslu,Yokuslu,,,,,654,,,,,,e49ce451,6932,137616
-101537,Felipe Anderson,Pereira Gomes,Felipe Anderson,,,465,390,440,,,,,,9f1893b9,1208,159372
-101582,Frederico,Rodrigues de Paula Santos,Fred,,,304,244,299,274,331,381,,,b853e0ad,6817,191614
-101668,Jamie,Vardy,Vardy,184,209,234,166,224,205,255,,306,,45963054,755,197838
-101982,Sam,Johnstone,Johnstone,,,,,417,,175,230,204,627,9e5708be,978,110864
-102057,Raúl,Jiménez Rodríguez,Raúl,,,437,409,460,430,476,558,252,337,b561db50,4105,206040
-102366,Moritz,Bauer,Bauer,,594,,,,,,,,,cfe6238d,5453,159692
-102380,Antonio,Rüdiger,Rüdiger,,103,118,104,109,127,,,,,18b896d6,1822,86202
-102549,Adam,Davies,A.Davies,,,,,,,,479,,,71894777,11733,121254
-102738,Giannelli,Imbula,Imbula,334,343,,,,,,,,,b86fe156,861,130756
-102747,Djibril,Sidibé,Sidibé,,,,511,,,,,,,4c5b714f,3357,161869
-102826,Benjamin,Mendy,Mendy,,484,267,204,274,253,,,,,5271c8f1,3389,157495
-102836,Brice,Samba,Samba,,,,,,,382,,,,60d90c55,4748,191056
-102884,Paulo,Gazzaniga Farias,Gazzaniga,295,565,536,341,393,,207,,,,63d17038,973,195488
-103025,Riyad,Mahrez,Mahrez,176,199,223,217,275,254,303,359,,,892d5bb1,750,171424
-103100,Jonathan,Williams,Williams,116,,,,,,,,,,49b8432c,1060,170322
-103123,Sébastien,Haller,Haller,,,,457,441,,,,,,ba115a40,6144,181375
-103127,Molla,Wagué,Wagué,645,197,,,,,,,,,a440d8ca,1159,129893
-103192,Kurt,Zouma,Zouma,79,99,526,459,110,128,461,544,532,,ce4246f5,935,157509
-103912,Jordon,Ibe,Ibe,46,45,38,78,,,,,,,9f736ed2,481,195652
-103914,Charlie,Taylor,Taylor,,81,74,87,97,113,,178,475,,cc2d7ad5,6044,195633
-103955,Raheem,Sterling,Sterling,228,247,270,214,276,255,304,216,186,,b400bde0,618,134425
-104047,Pelly Ruddock,Mpanzu,Mpanzu,,,,,,,,582,,,a9b1c319,11716,244338
-104073,Joe,Ralls,Ralls,,,98,,,,,,,,3730fcbc,6825,195680
-104535,Harry,Bunn,Bunn,,179,,,,,,,,,c8d840f0,,186290
-104542,Loris,Karius,Karius,189,214,238,,,,626,580,,,32e7ce92,37,85864
-104545,Tommy,Smith,Smith,,166,194,,,,,,,,e9208654,6029,121398
-104547,Dwight,Gayle,Gayle,,301,325,554,329,300,361,,,,e58a03c6,743,196522
-104953,Christian,Atsu,Atsu,,300,320,267,330,,,,,,8816329f,2344,186997
-105377,Ezgjan,Alioski,Alioski,,,,,201,,,,,,1a7fcf39,8722,129604
-105666,Jack,Butland,Butland,316,328,,,586,156,162,,,,cc70a1d5,856,128899
-105700,Davide,Zappacosta,Zappacosta,,543,120,109,,,,,,,7fe90ccd,1178,173859
-105717,Arthur,Masuaku,Masuaku,505,446,410,378,442,417,462,,,678,57df7a11,1760,181380
-106449,Kevin,Stewart,Stewart,198,,,,,,,,,,ff674795,479,200782
-106450,Alex,Pritchard,Pritchard,401,593,206,,,,,,,,ff9fcd4d,815,200777
-106468,Álex,Moreno Lopera,Alex Moreno,,,,,,,694,32,26,43,16e9d0ea,4120,193098
-106603,Ezekiel,Fryers,Fryers,580,,,,,,,,,,f58d6213,1671,141655
-106606,Massimo,Luongo,Luongo,,,,,,,,,277,,967ac6e1,12747,181687
-106611,Michael,Keane,Keane,58,146,162,143,156,169,180,257,228,295,c5b7c315,1653,118534
-106617,Patrick,Bamford,Bamford,553,,,,202,189,227,,,363,93feac6e,822,183334
-106618,Paul,Dummett,Dummett,,291,313,255,331,301,362,581,,,3fe6bd8c,853,170321
-106757,Jürgen,Locadia,Locadia,,604,65,45,,595,,,,,6cc47ae1,6542,166240
-106760,Luke,Shaw,Shaw,247,265,286,226,300,275,332,398,387,443,9c94165b,1006,183288
-106824,Memphis,Depay,Depay,258,,,,,,,,,,8f696594,555,167850
-106837,Dennis,Praet,Praet,,,,517,225,206,549,,,,86695068,1234,129588
-106899,Roque,Mesa,Mesa,,370,,,,,,,,,7c4243d4,2356,202984
-107265,Angus,Gunn,Gunn,668,,452,319,371,448,,,,675,e082af5b,5544,201574
-107613,Romain,Saïss,Saïss,,,426,407,461,431,,,,,9fbbcf39,3491,204198
-108053,Conor,Townsend,Townsend,,,,,418,,,,583,,4dc4f138,8905,146509
-108093,Luciano,Vietto,Vietto,,,513,,,,,,,,2513a588,2274,214316
-108156,Björn,Engels,Engels,,,,455,36,31,,,,,4fdf1fd9,7152,193469
-108411,Dan,Potts,Potts,,,,,,,,333,,,3595affe,12309,207037
-108413,Will,Hughes,Hughes,,416,392,370,,386,163,229,203,270,a0666d3e,6104,207014
-108416,John,Egan,Egan,,,,295,353,,,480,,,debe38a0,7703,121324
-108438,Sandro,Ramírez,Sandro,,160,470,,,,,,,,833fb62e,2537,199369
-108796,Tom,Lockyer,Lockyer,,,,,,,,575,,,37118440,11714,207742
-108813,Christian,Walton,Walton,,,,,503,,,,283,,c666574f,9251,208379
-108823,Dele,Alli,Dele,398,388,365,344,394,363,181,248,,,cea4ee8f,645,207929
-108824,Brendan,Galloway,Galloway,129,,,,,,,,,,321506b3,909,208244
-109065,Davy,Klaassen,Klaassen,,158,171,,,,,,,,15fd5593,6045,182932
-109322,Jesse,Lingard,Lingard,266,279,300,241,301,276,527,,,,810e3c74,558,141660
-109345,Solly,March,March,,66,58,55,65,60,107,140,132,159,bb5fbd2b,6049,209212
-109434,Terence,Kongolo,Kongolo,,591,198,,585,,208,274,,,1f9a3a04,6067,152651
-109528,Javier,Manquillo Gaitán,Manquillo,538,477,315,256,332,302,363,422,,,758dd7f0,1719,162029
-109533,Emerson,Palmieri dos Santos,Emerson,,614,121,107,111,539,545,532,520,604,e0bc6fdc,1245,181778
-109638,Kean,Bryan,Bryan,,,,,603,,,,,,c684d3c9,9163,214928
-109646,Tosin,Adarabioyo,Tosin,607,586,,,572,,209,286,187,232,c81d773d,5590,258878
-109745,Kepa,Arrizabalaga Revuelta,Arrizabalaga,,,498,111,112,129,133,187,152,2,28d596a0,5061,192279
-109788,João Mário,Naval Costa Eduardo,João Mário,,608,,,,,,,,,f0021247,1512,149729
-109999,Ibrahima,Cissé,Cissé,,,521,,,,,,,,be4fede9,6839,160380
-110504,Bertrand,Traoré,Traoré,91,,,,540,32,34,59,,735,c47541e0,695,131996
-110735,Adam,Webster,Webster,,,,493,66,61,108,153,147,153,c40b6180,7699,212847
-110979,Sadio,Mané,Mané,212,230,251,192,251,230,,,,,c691bfe2,838,200512
-111234,Jordan,Pickford,Pickford,340,135,154,148,157,170,182,263,235,287,4806ec67,741,130164
-111291,Fernando,Marçal,Marçal,,,,,505,432,,,,,9ae9eaea,5708,137745
-111317,David,Brooks,Brooks,,,42,76,,,60,64,62,86,dc4cae05,6820,277033
-111452,Odysseas,Vlachodimos,Odysseas,,,,,,,,710,412,472,03df04ff,375,124419
-111457,Sead,Kolasinac,Kolasinac,,13,8,3,14,11,,,,,3935e52e,342,94005
-111478,Joël,Veltman,Veltman,,,,,67,62,109,151,145,152,dad4b285,8780,111195
-111773,Emil,Krafth,Krafth,,,,519,333,303,364,417,405,479,77cf6852,1545,184528
-111782,Robin,Olsen,Olsen,,,,,573,691,35,53,51,,e7ee38c3,6962,75458
-111787,Modou,Barrow,Barrow,379,368,,,,,,,,,75783f5f,720,189070
-111847,Adama,Diomande,Diomande,164,,,,,,,,,,336dbcb2,1694,93145
-111931,Ricardo,Barbosa Pereira,Ricardo,,,221,159,226,207,256,,302,,75a72a99,3303,215876
-112139,James,Wilson,Wilson,270,,,,,,,,,,b0d786ee,992,214104
-112316,Jakob,Haugaard,Haugaard,317,569,,,,,,,,,142741bb,870,138335
-112338,Emre,Can,Can,204,227,,,,,,,,,a65ce836,604,119296
-112507,Jack,Rose,Rose,548,,,,,,,,,,eb338814,1009,186923
-112516,Isaiah,Brown,Brown,,481,,,,,,,,,bf54c8cc,4481,245805
-112520,Alex,Palmer,Palmer,601,557,,,,,,,764,,6ea97fd5,1038,245625
-113534,Matt,Macey,Macey,660,559,,646,527,,,323,,,136e7649,903,220491
-113564,Sam,Byram,Byram,457,445,404,454,,321,,,,346,1bf811d4,902,236953
-113688,Oumar,Niasse,Niasse,145,548,176,570,,,,,,,af721f98,599,209781
-114000,George,Honeyman,Honeyman,587,,,,,,,,,,84afeaff,1046,218140
-114054,Omar,Bogle,Bogle,,,108,,,,,,,,c334bcfc,,134657
-114093,Matthew,Pennington,Pennington,131,141,,,,,,,,,0ff967f7,920,220755
-114128,Jonathan,Castro Otto,J.Otto,,,483,402,462,433,477,560,,,e28868f3,2280,175446
-114241,Harry,Toffolo,Toffolo,,,,,,,523,465,444,,a105d46a,10758,198516
-114243,Jacob,Murphy,J.Murphy,,478,321,483,497,304,365,423,402,489,de112b84,6063,199527
-114245,Josh,Murphy,Murphy,,,106,,,,,,,,b30c7426,6828,199528
-114283,Jack,Grealish,Grealish,,,,29,37,33,305,354,349,419,b0b4fd3e,675,203460
-114536,Ryan,Inniss,Inniss,,,,,534,,,,,,600ae8cb,8822,183284
-115357,Mouez,Hassen,Hassen,650,,,,,,,,,,fd481f3f,3313,215677
-115382,Neal,Maupay,Maupay,,,,502,68,63,110,258,229,,4bcf39f6,3621,217115
-115556,Ben,Davies,Davies,386,381,356,329,395,364,432,495,484,571,44781702,660,192765
-115854,Duncan,Watmore,Watmore,353,,,,,,,,,,2b2bae51,919,248045
-115858,Rachid,Ghezzal,Ghezzal,,,492,173,,,,,,,dc3a9a0d,3276,118287
-115918,Rúnar Alex,Rúnarsson,Rúnarsson,,,,,547,2,,18,,,8fa8f8d2,6875,205657
-116216,Leandro,Trossard,Trossard,,,,421,69,64,111,26,23,20,38ceb24a,7698,144028
-116404,Felipe Augusto,de Almeida Monteiro,Felipe,,,,,,,730,445,,,51a3c4c8,7921,156501
-116535,Alisson,Becker,A.Becker,,,468,189,252,231,281,291,310,366,7a2e46a8,1257,105470
-116543,Valentino,Lazaro,Lazaro,,,,614,,,,,,,016ff750,6352,186368
-116594,N'Golo,Kanté,Kanté,95,111,126,119,113,130,134,,,,b9fbae28,751,225083
-116643,Fabio Henrique,Tavares,Fabinho,,,255,197,253,232,282,296,,,7f3b388c,3420,225693
-118335,Abdul Rahman,Baba,Baba,80,,,,,,,190,,,e4086af3,684,224884
-118342,Mark,Flekken,Flekken,,,,,,,,101,91,,a92ab7be,7047,125714
-118748,Mohamed,Salah,M.Salah,,234,253,191,254,233,283,308,328,381,e342ad68,1250,148455
-118884,Erik,Durm,Durm,,,461,,,,,,,,cf623c78,2640,93922
-119471,Fabian,Schär,Schär,,,482,252,334,305,366,427,415,474,c8aa95da,76,135343
-119765,Allan,Marques Loureiro,Allan,,,,,502,171,183,,,,cc700722,1379,126422
-120202,Wout,Weghorst,Weghorst,,,,,,700,701,183,,,c4e87b8b,7052,228645
-120250,André,Tavares Gomes,André Gomes,,,508,422,158,172,184,244,,,1961b2aa,2383,221025
-120447,Bradley,Smith,Brad Smith,197,37,,,,,,,,,c76c717c,477,175745
-120721,Kevin,Mbabu,Mbabu,,,,,,,532,277,250,,493924a7,983,183321
-121145,João,Cavaco Cancelo,João Cancelo,,,,518,277,256,306,346,353,,bd6351cd,2379,182712
-121160,Ederson,Santana de Moraes,Ederson M.,,240,260,212,278,257,307,352,347,399,3bb7b8b4,6054,238223
-121221,Ramiro,Funes Mori,Funes Mori,132,142,,,,,,,,,89cbc961,597,11111
-121570,Julian,Jeanvier,Jeanvier,,,,,,722,,,,,5cb215fc,10545,134277
-121599,Abdoulaye,Doucouré,A.Doucoure,482,414,390,368,512,173,185,249,217,,02b29014,1726,127187
-121709,Walter,Benítez,Benitez,,,,,,,,,,254,8a2248b4,5652,296802
-122074,Marcus,Bettinelli,Bettinelli,,,178,,183,606,635,192,155,401,0d85a4e8,7076,116648
-122342,Emerson,Hyndman,Hyndman,45,584,41,,,,,,,,3be1a627,6457,223047
-122411,Cameron,Burgess,Burgess,,,,,,,,,263,,da61ca98,12755,255788
-122775,Morgan,Sanson,Sanson,,,,,647,34,36,56,,,6e7f1353,3696,174094
-122797,Callum,Paterson,Paterson,,,101,,,,,,,,d2583bce,6826,169555
-122798,Andrew,Robertson,Robertson,152,475,247,181,255,234,284,307,335,372,2e4f5f03,1688,234803
-122806,John,McGinn,McGinn,,,,31,38,35,37,50,48,54,90f91999,7723,193116
-123125,Viktor,Fischer,Fischer,289,,,,,,,,,,b5920350,1713,95755
-123354,Kortney,Hause,Hause,,,525,25,39,36,38,45,40,,bf8fad51,6859,233124
-124165,Patrick,Roberts,Roberts,,,,435,,,,,,545,59d93937,925,225452
-124183,Hakim,Ziyech,Ziyech,,,,,114,131,135,218,,,6622454d,8992,217111
-126184,Nathan,Aké,Aké,36,38,31,59,279,258,308,342,341,405,eaeca114,579,177476
-126187,Ruben,Loftus-Cheek,Loftus-Cheek,88,108,132,115,115,132,136,,,,e97fd090,688,202886
-126407,Nabil,Bentaleb,Bentaleb,395,,,612,,,,,,,3189f61a,914,245537
-126468,Tokelo,Rantie,Rantie,50,,,,,,,,,,7ef25942,958,198495
-128198,Sofiane,Boufal,Boufal,551,322,341,508,372,,,,,,b0c71810,1734,232271
-128295,Christian,Nørgaard,Nørgaard,,,,,,77,79,110,101,24,df0a4c90,7083,148367
-128309,Jamal,Lowe,Lowe,,,,,,,61,73,,,b2856bc0,10865,239949
-128340,Kieffer,Moore,Moore,,,,,,,62,76,,,01ce9e70,10743,275590
-128348,Ibrahim,Amadou,Amadou,,,,507,,,,,,,9260926b,3358,205503
-128389,Aleksandar,Mitrović,Mitrović,,303,480,,184,,210,278,,,3925dbd6,773,51152
-130025,Luis,Hernández,Hernández,175,,,,,,,,,,02d2c436,1680,62945
-130036,Ozan,Tufan,Tufan,,,,,,557,,,,,17d45fb2,9957,236471
-130103,Hiram,Boateng,Boateng,543,,,,,,,,,,929917ce,1059,244125
-131304,William,Troost-Ekong,Troost-Ekong,,,,,,387,,,,,7ed4921e,6996,192875
-131403,Rhys,Healey,Healey,,,573,,,,,,,,07ace8c3,7340,238185
-131897,Mathew,Ryan,Ryan,,54,47,47,70,65,,,,,4535e4bb,2385,128969
-132015,Pierre-Emile,Højbjerg,Højbjerg,312,321,340,325,396,365,433,499,490,,8b04d6c1,343,167799
-133085,Lawrence,Vigouroux,Vigouroux,,,,,,,,181,,,a949d040,12196,243591
-133798,Serge,Gnabry,Gnabry,19,,,,,,,,,,88e357ef,993,159471
-133801,Jerome,Sinclair,Sinclair,428,499,398,,,,,,,,1695c659,972,236513
-133845,Emiliano,Marcondes,Marcondes,,,,,,,63,74,,,4d960fc3,10745,232964
-134383,Connor,Randall,Randall,196,,,,,,,,,,412e1445,474,262545
-135363,Andreas,Christensen,Christensen,,470,119,108,116,133,,,,,1cb49278,200,196948
-135365,Jeremie,Boga,Boga,,509,,,,,,,,,fe012aca,3544,216569
-135720,Kevin,Danso,Danso,,,,532,,,,,767,570,6e33125f,5261,263236
-138001,Tom,King,King,,,,,,,,564,556,630,5791b997,12245,215810
-138009,Sullay,Kaikai,Kaikai,494,515,477,,,,,,,,fc166e49,1070,244130
-139110,Ondrej,Duda,Duda,,,,601,,,,,,,79ca3e23,5240,232418
-140200,Thomas,Strakosha,Strakosha,,,,,,,517,116,,,339fe0e8,1214,222209
-140941,Stipe,Perica,Perica,,,,,,388,,,,,269b4638,1154,245072
-141020,Max,Meyer,Meyer,,,486,136,143,,,,,,eba42d2b,338,146164
-141569,Léo,Bonatini,Bonatini,,,438,,463,,,,,,da23d58d,6855,181781
-141746,Bruno,Borges Fernandes,B.Fernandes,,,,618,302,277,333,373,366,449,507c7bdf,1228,240306
-141921,Oluwaseyi,Ojo,Sheyi Ojo,207,229,,,,,,,,,7b9a86e6,478,236510
-143877,Alexander,Sørloth,Sørloth,,620,153,,,,,,,,e92cd3f7,6531,238407
-144485,Ivan,Toney,Toney,,,,,,78,80,117,108,,e09f279b,998,251664
-144660,Didier,Ndong,Ndong,559,618,,,,,,,,,885b7aa7,1720,210081
-145212,Clinton,N'Jie,N'Jie,404,,,,,,,,,,77f278a0,960,241119
-145235,José Ángel,Esmorís Tasende,Angeliño,498,,,440,,,,,,,30941e96,1040,277179
-146426,Oluwasemilogo Adesewo Ibidapo,Ajayi,Ajayi,,,,,419,,,,,,d6192210,4490,251912
-146610,Jack,O'Connell,O'Connell,,,,293,354,,,,,,312626c1,7705,212829
-146941,Aymeric,Laporte,Laporte,,612,268,202,280,259,309,357,,,119b9a8e,2498,176553
-147303,Laurent,Depoitre,Depoitre,,187,210,,,,,,,,aa5859cb,6038,90583
-147611,Paul,Onuachu,Onuachu,,,,,,,732,,470,,c06d1086,11360,272855
-147612,Richairo,Zivkovic,Zivkovic,,,,622,,,,,,,d2d74d9c,8472,252755
-147668,Cameron,Brannagan,Brannagan,210,,,,,,,,,,9220e731,1023,261357
-147675,Chuba,Akpom,Akpom,493,,,,,,,,,,e2b384d2,1790,197642
-148179,Enner,Valencia,Valencia,469,460,,,,,,,,,fb485406,539,139503
-148225,Anthony,Martial,Martial,267,280,301,239,303,278,345,390,,,8b788c01,553,182877
-148508,Mahmoud Ahmed,Ibrahim Hassan,Trézéguet,,,,465,40,37,,,,,3ae14ed1,7722,234189
-149016,Lynden,Gooch,Gooch,520,,,,,,,,,,1ea00b03,1027,307781
-149051,Ethan,Robson,Ethan Robson,615,,,,,,,,,,961a5164,5581,258199
-149065,José,Malheiro de Sá,José Sá,,,,,,475,478,569,554,628,903b6e8b,9740,249994
-149266,Alfie,Mawson,Mawson,558,357,487,,185,,,,,,d368feb8,1727,287431
-149468,Tyias,Browning,Browning,130,,532,,,,,,,,c4e180f0,977,156934
-149484,Tyrone,Mings,Mings,35,36,30,445,41,38,39,51,49,40,8397a50c,1024,253677
-149519,Maxwel,Cornet,Cornet,,,,,,578,575,527,515,617,beb391dd,3278,234781
-149736,Chancel,Mbemba,Mbemba,,494,316,,,,,,,,e76cb9cc,849,203348
-149828,Islam,Slimani,Slimani,567,212,,,579,,,,,,ffec9769,1682,174915
-149915,Diego,Llorente,Llorente,,,,,549,190,228,,,,bba30585,2163,246291
-149929,Wes,Burns,Burns,,,,,,,,,264,,b3fe23c6,12749,255731
-151086,Mario,Lemina,Mario Jr.,,500,344,324,493,,698,565,557,,2b471f99,1299,170934
-151119,DeAndre,Yedlin,Yedlin,389,288,310,253,335,,,,,,ae0a7ddf,727,255916
-151589,Leander,Dendoncker,Dendoncker,,,519,420,464,434,479,40,33,61,5a7301ae,7236,168157
-152015,Guillermo,Varela,Varela,246,,,,,,,,,,5c961282,547,188862
-152551,Jefferson,Lerma Solís,Lerma,,,494,82,,,64,231,206,272,9b5ce51a,2182,262980
-152590,Alex,Telles,Alex Telles,,,,,568,279,334,370,,,e73c9bb2,1828,255755
-152760,Divock,Origi,Origi,217,238,543,188,256,235,,714,,,43a166b4,484,148368
-152898,Ben,Davies,Davies,,,,,653,248,499,,,,c9009a1f,9318,257097
-153127,Isaac,Hayden,Hayden,,496,323,271,336,306,,413,400,495,c951a6df,6062,206225
-153133,Alex,Iwobi,Iwobi,21,21,15,17,159,174,186,256,247,324,6ca5ec4b,500,242631
-153256,Mohamed,Elneny,M.Elneny,22,22,16,20,526,12,4,3,,,47a34c4f,496,160438
-153366,Harrison,Reed,Reed,307,,,,373,,211,282,254,336,803ae100,910,226973
-153371,Sam,Gallagher,Gallagher,,,574,316,,,,,,,44361ade,4483,227183
-153373,Sam,McQueen,McQueen,592,314,334,,,,,,,,b27b49b4,1733,226968
-153379,Josh,Sims,Sims,604,323,342,,374,,,,,,6d6f09dc,5565,286919
-153477,Conor,Masterson,Masterson,,639,,,,,,,,,db975607,6664,293784
-153601,Carlos,De Pena,De Pena,287,,,,,,,,,,6b915aa1,,257740
-153673,Jonjoe,Kenny,Kenny,616,145,161,,160,502,,,,,099e666f,1084,258883
-153678,Chris,Long,Long,72,,,,,,,,,,52c8b203,,183298
-153682,Harry,Wilson,Wilson,653,,,505,257,,212,288,259,329,c6dc9ecd,5596,279455
-153723,John,Lundstram,Lundstram,,,,297,355,,,,,,0df2b165,7708,156941
-153772,Luke,McGee,McGee,529,,,,,,,,,,bfa6049d,1769,183301
-154043,Ainsley,Maitland-Niles,Maitland-Niles,593,546,20,4,15,13,21,,,,e3a5814e,1750,285845
-154048,Stephy,Mavididi,Mavididi,,,,,,,,,298,,30144daa,7484,340328
-154050,Olufela,Olomola,Olomola,589,,,,,,,,,,313ba4ae,911,356569
-154051,Oviemuno,Ejaria,Ejaria,582,,,,,,,,,,a801669e,1762,337284
-154131,Jack,Stacey,Stacey,,,,446,,,65,,,,558807c0,7823,249356
-154138,Tariqe,Fosu-Henry,Fosu,,,,,,79,,,,,3dcef539,10092,249873
-154296,João Maria,Lobo Alves Palhares Costa Palhinha Gonçalves,J.Palhinha,,,,,,,220,280,,673,a78ff07f,10715,257455
-154506,Daniel,Bachmann,Bachmann,,582,,,,389,,,,,1c0eea98,1025,120186
-154558,Thomas,Robson,Thomas Robson,537,,,,,,,,,,a18298ff,1079,257968
-154559,Michael,Ledger,Ledger,624,,,,,,,,,,a3354171,5591,320228
-154561,David,Raya Martín,Raya,,,,,,80,81,113,15,1,98ea5115,9676,262749
-154566,Dominic,Solanke-Mitchell,Solanke,590,239,259,69,,,66,85,82,596,e77dc3b2,1679,258889
-154976,Adnan,Januzaj,Januzaj,261,,,,,,,,,,4737cebe,323,177847
-154998,Takuma,Asano,Asano,28,,,,,,,,,,13ddc856,6087,245744
-155197,Max,Lowe,Lowe,,,,,511,,,484,,,7af88b33,8918,258885
-155405,Kalvin,Phillips,Phillips,,,,,204,191,325,364,359,429,4f565d77,8719,351749
-155408,Lewis,Cook,Cook,47,46,39,79,,,67,66,64,88,2afc7272,1789,249089
-155503,Freddie,Woodman,Woodman,,529,553,264,,513,,,,369,19e50035,852,226049
-155509,Greg,Olley,Olley,514,,,,,,,,,,784b9507,1773,257533
-155511,Adam,Armstrong,Armstrong,,,,,,525,408,,453,817,68c720b5,4419,250426
-155513,Rolando,Aarons,Aarons,,467,,499,337,,,,,,c5942695,915,258188
-155529,Marek,Rodák,Rodák,,,,,186,,213,284,,,17acc2ed,8704,186901
-155561,Ludwig,Augustinsson,Augustinsson,,,,,,,525,,,,9fec8860,6083,170646
-155569,Daniel,Amartey,Amartey,182,204,226,178,227,208,257,,,,1a4ef233,759,214056
-155651,Adam,Masina,Masina,,,386,355,,390,,,,,de0f152c,1441,286949
-155706,Dionatan do Nascimento,Teixeira,Teixeira,326,,,,,,,,,,f7f09bee,869,107617
-155851,Lucas,Pérez,Lucas,549,27,502,,,,,,,,a300ac7e,1700,73185
-156069,Liam,Gibson,Gibson,,,,610,,,,,,,b51f8aee,1076,312553
-156074,Rob,Holding,Holding,484,11,6,10,16,14,5,7,202,264,d79a8c87,1749,253341
-156658,Reece,Burke,Burke,534,596,,,,,,318,,,a681b7b7,1771,264220
-156660,Moses,Makasi,Makasi,664,580,,,,,,,,,4ae7add0,5566,242644
-156683,Pierluigi,Gollini,Gollini,,,,,,486,,,,,f0f7f62f,1841,244192
-156685,Joe,Rothwell,Rothwell,,,,,,,505,81,,,10a10454,561,183293
-156686,James,Weir,Weir,566,,,,,,,,,,c8d651c1,562,251058
-156687,Ben,Pearson,Pearson,,,,,,,68,79,,,a6b461e7,10742,183302
-156689,Andreas,Hoelgebaum Pereira,Andreas,263,476,481,246,304,511,346,267,240,327,6639e500,922,203394
-156690,Joshua,Harrop,Harrop,674,,,,,,,,,,00e1cf8f,5597,289844
-156700,Carlton,Morris,Morris,,,,,,,,326,,,2da834f1,11717,246963
-157665,Filip,Lesniak,Lesniak,671,,,,,,,,,,5348fe7c,5571,186383
-157668,Harry,Winks,Winks,513,391,368,347,397,366,434,,309,,2f7acede,971,249126
-157775,Ken,Sema,Sema,,,446,372,,391,,,,,1770bd68,6841,252345
-157882,Takumi,Minamino,Minamino,,,,590,258,236,,,,,f833a830,8239,165793
-158074,Gabriel Armando,de Abreu,Gabriel,5,6,,,,,,,,,b7ca5c51,493,149498
-158499,Ryan,Christie,Christie,,,,,,,69,65,63,87,26ce2263,10744,188077
-158534,Kyle,Walker-Peters,Walker-Peters,,498,358,337,375,342,409,,476,659,984a5a64,885,341051
-158544,Jake,Hesketh,Hesketh,586,,,,,,,,,,4c83c9f8,1755,315185
-158983,Endo,Wataru,Endo,,,,,,,,668,320,392,c149016b,8808,146310
-159039,Antonio,Barreca,Barreca,,,588,,,,,,,,6a189491,1181,241889
-159506,Ola,Aina,Aina,487,,,,562,,,604,422,507,246d153b,725,236490
-159533,Adama,Traoré Diarra,Adama,563,,500,417,465,435,491,662,239,326,9a28eba4,900,204103
-160190,Kasey,Palmer,Palmer,,183,,,,,,,,,453f566a,705,258216
-160729,Jason,Denayer,Denayer,476,,,,,,,,,,47af88b8,1039,277114
-160816,Donald,Love,Love,506,,,,,,,,,,160599ed,1048,179451
-160817,Patrick,McNair,McNair,249,,,,,,,,,,8ac454b5,559,167268
-160987,Jean-Philippe,Gbamin,Gbamin,,,,497,161,504,187,251,,,6bd603db,4764,182894
-162344,Philip,Zinckernagel,Zinckernagel,,,,,,392,,,,,a5ea254c,,271098
-162651,Samir,Caetano de Souza Santos,Samir,,,,,,677,,,,,92b4758e,1142,255744
-163463,Papa Alioune,Ndiaye,Badou Ndiaye,,619,,,,,,,,,960acc0a,6525,211325
-163526,Edimilson,Fernandes,Fernandes,542,456,416,,,,,,,,3bb625ac,1673,247555
-163776,Erdal,Rakip,Rakip,,606,,,,,,,,,e150254d,6541,230746
-163793,Matt,Miazga,Miazga,81,,,,,,,,,,9fc0f253,683,245893
-164011,Mbaye,Diagne,Diagne,,,,,648,,,,,,dda3969e,9290,271966
-164484,Zack,Steffen,Steffen,,,,,538,260,310,367,,,42130443,7817,221624
-164511,Yerry,Mina,Mina,,,506,142,162,175,188,,,,6d5701f2,6521,289446
-164555,Vladimír,Coufal,Coufal,,,,,558,418,463,528,516,,fdf3cb77,8965,157672
-165152,Glen,Rea,Rea,,,,,,,,334,,,5c3f2f39,,337640
-165153,Timo,Werner,Werner,,,,,117,134,137,776,509,,49fe9070,65,170527
-165183,Amari'i,Bell,Bell,,,,,,,,316,,,399e9474,11713,278166
-165210,Alireza,Jahanbakhsh,Jahanbakhsh,,,476,50,71,66,,,,,08452314,6842,213268
-165659,Diego Carlos,Santos Silva,Diego Carlos,,,,,,,50,41,35,,b4a014b1,5712,329145
-165808,Hélder Wander,Sousa de Azevedo e Costa,Costa,,,435,418,205,192,,,,,f13d02a6,3428,173900
-165809,Bernardo,Mota Veiga de Carvalho e Silva,Bernardo,,256,276,218,281,261,311,344,342,416,3eb22ec9,3635,241641
-165911,Bartosz,Kapustka,Kapustka,497,,,,,,,,,,7364c4d1,1786,246579
-165990,Vincent,Janssen,Janssen,405,395,614,339,,,,,,,31dce0c8,1730,207015
-166324,Ivan,Neves Abreu Cavaleiro,I.Cavaleiro,,,434,419,187,,214,269,,,979b811d,3683,149716
-166325,Carlos,Ribeiro Dias,Cafú,,,,,,,383,,,,85322440,5646,203655
-166477,Timothy,Castagne,Castagne,,,,,498,209,258,688,244,319,197640fd,6157,262226
-166640,Fabián,Balbuena,Balbuena,,,464,382,443,,,,,,3626f7d9,6892,285548
-166989,Youri,Tielemans,Tielemans,,,591,448,228,210,259,58,57,48,56f7a928,5956,249565
-167074,Kenny,Tete,Tete,,,,,517,,215,285,257,322,77d7c96f,5973,206746
-167075,Wesley,Hoedt,Hoedt,,525,336,485,,,,,,,875898c7,1203,253765
-167191,Marcus,Myers-Harness,Harness,,,,,,,,,271,,90e9ca3d,12753,288323
-167199,Thomas,Partey,Thomas,,,,,567,15,6,15,20,,529f49ab,2328,230784
-167473,José,Izquierdo,Izquierdo,,517,61,51,72,,,,,,ca2bc3df,6231,147094
-167512,Luke,O'Nien,O'Nien,,,,,,,,,,539,8092d497,14099,282939
-167522,Jordan,Hugill,Hugill,,622,420,,444,322,,,,,a36d4785,6526,291544
-167541,Jack,Payne,Payne,,177,,,,,,,,,edfbda18,,278092
-167767,Robert Kenedy,Nunes do Nascimento,Kenedy,94,110,458,462,,690,138,,,,5eebbfdf,689,281404
-167789,Baily,Cargill,Cargill,649,,,,,,,,,,6dbe8f69,976,293450
-167878,Ben,Osborn,Osborn,,,,472,356,,,489,,,79bc4c45,7714,218087
-167887,Josh,Laurent,Laurent,,,,,,,,,,209,f0068e0f,13728,314241
-167888,Joe,Lumley,Lumley,,,,,,,,,466,,bdf3a08e,12762,336367
-168035,Fred,Onyedinma,Onyedinma,,,,,,,,329,,,387d06b2,12549,305274
-168090,Mahmoud,Dahoud,Dahoud,,,,,,,,128,119,,db4ed67b,205,191422
-168172,Joe,Lolley,Lolley,,176,,,,,384,,,,c5f13182,6139,287167
-168196,Joel Dinis,Castro Pereira,Joel Pereira,662,262,,,,,,,,,881e5db7,5575,192611
-168281,Scott,McKenna,McKenna,,,,,,,385,455,,,4e5a4cbc,10757,255906
-168287,Jonathan,Calleri,Calleri,526,,,,,,,,,,6922f806,1672,284727
-168290,Ignacio,Pussetto,Pussetto,,,,604,,,,,,,62437b4f,6997,283528
-168399,Will,Norris,Norris,,,422,413,583,114,,,,,c73ada83,7459,285033
-168547,Ethan,Horvath,Horvath,,,,,,,,449,,,3f65d5ce,11708,242284
-168566,Georges-Kévin,Nkoudou,Nkoudou,565,392,497,527,,,,,,,76c131da,1729,215679
-168580,Ayoze,Pérez,Pérez,,302,326,265,229,211,260,,,,819aa8e7,770,246968
-168636,Enes,Ünal,Enes Ünal,,,,,,,,804,65,98,f8eca1b6,6219,251106
-168717,Maksymilian,Stryjek,Stryjek,547,,,,,,,,,,bfc2e586,1770,240457
-168763,Cameron,Carter-Vickers,Carter-Vickers,501,511,,,521,,,,,,88ced02c,1758,341049
-168764,Luke,Amos,Amos,,,523,351,,,,,,,77128f7e,6819,258912
-168765,Josh,Onomah,Onomah,399,,,,188,,216,,,,6612cd8c,661,243589
-168977,Joel,Coleman,Coleman,,162,598,,,,,,,,b73e459a,6041,285551
-168991,Philip,Billing,Philip,,175,202,476,,,70,63,76,89,d328a254,6034,320411
-169061,Dael,Fry,Fry,277,,,,,,,,,,43e79bbc,5577,314140
-169102,Tiemoué,Bakayoko,Bakayoko,,463,129,,,,,,,,59bf127b,3429,182618
-169130,Joel,Taylor,Taylor,631,,,,,,,,,,3a6e34b9,5588,258310
-169141,Steve,Mounie,Mounie,,188,211,,,,,,,,19ba6c6d,3800,238639
-169187,Trent,Alexander-Arnold,Alexander-Arnold,523,223,245,182,259,237,285,290,311,,cd1acf9d,1791,314353
-169359,Matt,Targett,Targett,299,309,479,309,42,39,367,428,416,484,e514ab62,884,250478
-169432,Oliver,McBurnie,McBurnie,546,372,,501,357,,,485,,,78b8ac63,1736,298477
-169527,Joe,Williams,Joe Williams,658,,,,,,,,,,44c38f2e,5547,268185
-169528,Antonee,Robinson,Robinson,,,,,484,,217,283,255,316,289601e6,8940,349701
-169535,Julien,de Sart,de Sart,288,,,,,,,,,,33332e0b,1751,129592
-169593,Remi,Matthews,Matthews,,,,,,561,495,233,209,255,27f4f772,9834,196722
-169735,Noor,Husin,Husin,611,,,,,,,,,,9035308b,5582,320220
-169743,Connor,Mahoney,Mahoney,,585,,,,,,,,,38df681f,6458,287528
-170137,Allan,Saint-Maximin,Saint-Maximin,,,,500,338,307,368,426,,,2b16cb1a,101,272642
-170154,Pablo,Maffeo,Maffeo,528,,,,,,,,,,5db04597,1003,251876
-170271,Jean Michaël,Seri,Seri,,,456,,189,,,,,,10efd0e1,3312,178614
-170851,Josh,Robson,Josh Robson,532,,,,,,,,,,e10308d3,1781,357958
-171099,Hassane,Kamara,Kamara,,,,,,676,,,,,19a12bed,3729,290017
-171101,Clément,Lenglet,Lenglet,,,,,,,513,699,,,4f28a6ff,5050,182904
-171129,Diego,Rico,Rico,,,473,65,,,,,,,d9ba39fc,5065,249513
-171162,Charly,Musonda,Musonda,,471,,,,,,,,,62a0089e,2147,177862
-171270,Kieran,Dowell,Dowell,,,528,,,323,,,,,2f6ec02a,1032,258916
-171273,Cameron,Borthwick-Jackson,Borthwick-Jackson,252,,,,,,,,,,ff61102d,1037,258879
-171277,Demetri,Mitchell,Mitchell,669,,,,,,,,,,c286f3c2,5574,258886
-171287,Joe,Gomez,Gomez,195,218,242,184,260,238,286,298,322,376,7a11550b,987,256178
-171314,Rúben,dos Santos Gato Alves Dias,Rúben,,,,,556,262,312,350,361,408,31c69ef1,8961,258004
-171317,Rúben,da Silva Neves,Neves,,,433,414,466,436,480,,,,44bfb6c5,6853,225161
-171319,Renato,Sanches,Sanches,,535,,,,,,,,,032f894e,5228,258027
-171422,Alan,Browne,Browne,,,,,,,,,,555,25dea15a,,277697
-171771,Jan,Bednarek,Bednarek,,315,335,307,376,343,410,,455,,4115ce4e,6042,243028
-171975,Callum,Robinson,Callum Robinson,,,,453,358,,,,,,e75750a3,4476,183299
-171982,Brian,Lenihan,Lenihan,148,,,,,,,,,,7f1df59b,,241916
-172246,Florent,Hadergjonaj,Hadergjonaj,,521,197,,,,,,,,9aa186b2,5215,238809
-172453,Sam,Szmodics,Szmodics,,,,,,,,,611,,39944392,12752,292139
-172551,Callum,Roberts,Roberts,,,577,,,,,,,,8e9caf48,7347,288952
-172567,Josh,Cullen,Cullen,463,597,,,,,,165,,205,f6d7d690,1018,242606
-172632,Demarai,Gray,Gray,181,203,225,175,230,484,189,253,,,4468ec10,762,292417
-172649,Dean,Henderson,Henderson,,,,471,305,280,398,385,201,253,e5a76dfe,7702,258919
-172780,James,Maddison,Maddison,,,233,171,231,212,261,504,494,581,ee38d9c5,6818,294057
-172782,Josh,Brownhill,Brownhill,,,,620,98,115,,161,,,47369df8,8323,293569
-172841,Saïd,Benrahma,Benrahma,,,,,587,419,464,525,,,5a04fd92,3585,290532
-172850,Ben,Chilwell,Chilwell,496,196,219,161,232,135,139,195,160,,d2424d1b,782,316125
-172912,Sofyan,Amrabat,Amrabat,,,,,,,,709,,,5a2cb25d,7927,287579
-173268,Ivo,Grbic,Grbić,,,,,,,,790,,,3f034750,8923,226073
-173271,Duje,Caleta-Car,Caleta-Car,,,,,,,623,,,,94f8d10c,7007,238266
-173399,Mohamed,Dräger,Dräger,,,,,,,386,444,,,8954fddc,6476,192167
-173514,Isaac,Success Ajayi,Success,424,413,524,365,,393,,,,,f573a8bf,1724,295331
-173515,Kelechi,Iheanacho,Iheanacho,241,258,236,167,233,213,262,,,,c92e1a31,620,295330
-173792,Reece,Oxford,Oxford,455,611,407,,,,,,,,8b6e0db2,543,314295
-173804,Layton,Ndukwu,Ndukwu,,647,,,,,,,,,2219083d,6755,314284
-173807,Tom,Davies,T.Davies,512,156,169,154,163,176,190,666,,,9228b07c,1042,314210
-173809,Jonathan,Leko,Leko,445,431,,,420,,,,,,76b5cbbd,879,314266
-173810,Darnell,Johnson,Johnson,,,,662,,,,,,,8eaf6aea,8564,314372
-173818,Nathan,Broadhead,Broadhead,,,,,680,545,,,262,,43309491,9406,344009
-173821,Tyler,Roberts,Roberts,,,,,206,193,229,,,,6c17e046,1014,296986
-173879,Tammy,Abraham,Abraham,,374,496,460,118,136,,,,808,f586779e,702,331726
-173904,Davinson,Sánchez,Sánchez,,520,359,333,398,367,435,512,,,da7b447d,6249,341429
-173954,Jairo,Riedewald,Riedewald,,482,144,539,144,157,164,239,,,7a1f2c08,6027,241481
-174248,George,Thomas,Thomas,,587,,,,,,,,,7ef24097,6462,298240
-174254,Pedro,Chirivella,Chirivella,211,,,,,,,,,,68a26d51,1022,242273
-174292,Marco,Asensio,M.Asensio,,,,,,,,,762,,45af8a54,2117,296622
-174310,Elijah,Adebayo,Adebayo,,,,,,,,314,,,0480ebc7,11718,319900
-174590,Jacob,Maddox,Maddox,,,,663,,,,,,,ff97076d,8565,314268
-174592,Marcus,Edwards,Edwards,,,,,,,,,,206,57760e66,13730,314367
-174593,Kyle,Edwards,Edwards,,,,,421,,,,,,1566e437,8758,314366
-174594,Lukas,Nmecha,Nmecha,,627,,,,,,,,365,0cc5f4a5,6544,314288
-174595,Admiral,Muskwe,Muskwe,,,,,,,,327,,,ee2b9a18,,314378
-174597,Andre,Green,Green,,,,32,,,,,,,6e287b7a,874,309841
-174874,Joachim,Andersen,Andersen,,,,,571,488,165,220,191,317,e34fc66d,6314,260827
-174932,Sergi,Canós Tenés,Canós,,,,,,81,82,95,,,1137759d,1078,251845
-175351,Demeaco,Duhaney,Duhaney,,,601,,,,,,,,5ef608f7,7437,380913
-175353,Ayotomiwa,Dele-Bashiru,Dele-Bashiru,,,,563,,394,,,,,0666f848,8162,346472
-175592,Naby,Keita,Keita,,,256,196,261,239,287,,,,f25c8e3a,5247,302215
-175941,Alfie,Whiteman,Whiteman,,566,538,543,,,,521,510,,3f2587ee,6397,282823
-175946,Víctor,Camarasa,Camarasa,,,504,510,,,,,,,b2d03887,2390,263856
-176295,Matthew,Willock,Willock,655,,,,,,,,,,7e4985b2,5579,289845
-176296,Ashley,Fletcher,Fletcher,535,459,,,,395,,,,,eeb6551f,1675,289846
-176297,Marcus,Rashford,Rashford,271,284,305,233,306,281,335,396,385,451,a1d5bd30,556,258923
-176413,Christian,Pulisic,Pulisic,,,,431,119,137,140,213,,,1bf33a9a,2662,315779
-176414,Luca,De La Torre,De La Torre,,,621,,,,,,,,e9241b40,7600,315762
-176420,Darnell,Furlong,Furlong,,,,,422,,,,,,3ec9195b,4391,351755
-176706,Alfie,Jones,Jones,,,595,,,,,,,,e5c107a1,7391,340990
-177815,Dominic,Calvert-Lewin,Calvert-Lewin,595,159,175,147,164,177,191,246,220,691,59e6e5bf,5555,306024
-178173,Matt,Clarke,Clarke,,,,43,73,,543,,,,8ea2227a,,307497
-178186,Jarrod,Bowen,Bowen,516,,,626,445,420,465,526,514,624,79c84d1c,1776,314875
-178301,Ollie,Watkins,Watkins,,,,,514,40,40,60,58,64,aed3a70f,8865,324358
-178304,Lys,Mousset,Mousset,53,50,44,70,359,,,,,,d9cfca3d,1748,291422
-178867,Antonio,Martinez Lopez,Martínez,,567,,,,,,,,,f3945e07,6400,302371
-178871,Aleix,García Serrano,García,578,,,,,,,,,,a10361d2,1055,261504
-178876,Jesús,Vallejo Lázaro,Vallejo,,,,473,,,,,,,c2111b45,5234,251896
-179018,Miguel,Almirón Rejala,Almirón,,,587,266,339,308,369,402,391,,862a1c15,7420,272999
-179261,Zachary,Dearnley,Dearnley,673,,,,,,,,,,0484975a,5600,396284
-179268,Marc,Cucurella Saseta,Cucurella,,,,,,584,112,198,163,224,1daec722,7134,284857
-179276,Mathias,Normann,Normann,,,,,,581,,,,,8996350d,7470,257805
-179456,Oskar,Buur,Buur,,,,587,467,,,,,,aa6f2f2c,8227,293283
-179458,Jacob,Bruun Larsen,Bruun Larsen,,,,,,,,608,,202,4e204552,5355,293281
-179519,Orel,Mangala,Mangala,,,,,,,536,453,651,,a572e291,6088,289592
-179587,Dennis,Srbeny,Srbeny,,,,279,,,,,,,1fdec858,7822,159239
-179596,Elliott,Moore,Moore,670,,,,,,,,,,328bcff5,5570,341993
-179620,Mamadou Obbi,Oularé,Oularé,427,,,,,,,,,,9e49c320,898,314959
-179725,Carl,Stewart,Stewart,622,613,,,,,,,,,9e5c080a,5578,479945
-179829,Josh,Pask,Pask,,635,,,,,,,,,ccd1bb4d,6650,339789
-179830,Grady,Diangana,Diangana,,636,539,398,446,,,,,,f522d7ec,6651,342048
-180135,Sean,Longstaff,Longstaff,,,531,270,480,309,370,421,410,493,a2b105e0,7078,346707
-180151,Nikola,Vlašić,Vlašić,,539,173,,,582,466,543,,,aa8e289e,6276,293200
-180184,Donny,van de Beek,Van de Beek,,,,,495,282,336,400,,,50dc94ce,8821,288255
-180294,Karlan,Grant,Grant,,,585,,582,,,,,,87f7500e,7390,314183
-180736,Trevoh,Chalobah,Chalobah,,632,,,,527,141,194,159,226,5515376c,6615,346314
-180804,Axel,Tuanzebe,Tuanzebe,656,272,,481,307,283,,,282,198,2baec6ce,934,342046
-180974,Joelinton Cássio,Apolinário de Lira,Joelinton,,,,466,340,310,371,416,403,490,c17bfb65,87,333241
-181008,Albian,Ajeti,Ajeti,,,,514,447,,,,,,2b1c4abd,2673,195906
-181284,Gonçalo Manuel,Ganchinho Guedes,Guedes,,,,,,,579,554,548,647,e6bc67d7,5682,225122
-181397,Jamie,Sterry,Sterry,,,530,,,,,,,,f13d0f83,779,250431
-181489,Alex,Pike,Pike,608,,,,,,,,,,90a8927f,5589,345960
-181911,Kyle,Scott,Scott,,504,,,,,,,,,1c24aacf,6043,258888
-182156,Leroy,Sané,Sané,489,255,275,216,,,,,,,2b114be3,337,192565
-182436,Ben,Woodburn,Woodburn,603,233,,,696,553,,,,,8aadeaef,5557,344015
-182539,Daniel,Ceballos Fernández,Ceballos,,,,469,501,,,,,,c0617e2b,2446,319745
-182960,Pau,López Sabata,Pau López,564,,,,,,,,,,20b9f052,2107,286415
-183015,Cedric,Kipre,Kipre,,,,,499,,,,,,9f30e7ed,8785,364827
-183487,Nathan,Holland,Holland,665,,611,568,,,,,,,45ab2170,5567,337321
-183656,Josh,Dasilva,Dasilva,,,,,,82,83,99,90,748,60344e4f,10405,340321
-183751,Manuel,Benson Hedilazio,Benson,,,,,,,,159,,201,d7f99582,11702,322702
-184029,Martin,Ødegaard,Ødegaard,,,,,645,558,7,14,13,17,79300479,2517,316264
-184193,Jordan,Smith,Smith,,,,,,,675,,,,cfca9c4e,11245,452707
-184254,Guglielmo,Vicario,Vicario,,,,,,,,520,508,565,77d6fd4d,8858,286047
-184259,Richard,Nartey,Nartey,,,,,658,,,,,,de6cafb8,9313,396861
-184341,Mason,Mount,Mount,,,,463,120,138,142,209,382,455,9674002f,7768,346483
-184349,Ryan,Sessegnon,Sessegnon,,,184,524,399,368,436,514,579,328,6aa3e78b,6837,392775
-184386,James,Bree,Bree,,,,,43,,716,,457,,c07b7c5c,11359,324223
-184667,Victor,Lindelöf,Lindelöf,,273,292,225,308,284,337,386,376,719,f5deef4c,6080,184573
-184704,Marvelous,Nakamba,Nakamba,,,,491,44,41,41,52,,,de5b5570,8040,324882
-184754,Hwang,Hee-chan,Hee Chan,,,,,,583,481,557,550,642,169fd162,8845,292246
-185056,Mateusz,Hewelt,Hewelt,596,,,,,,,,,,d8fc24c9,5546,318547
-185253,Gustavo Henrique,Furtado Scarpa,G.Scarpa,,,,,,,681,462,,,2964fd20,11284,330085
-185431,Ali,Gabr,Gabr,,610,,,,,,,,,10331f88,6652,122980
-185478,Jarosław,Jach,Jach,,605,442,,,158,,,,,99246027,6621,327755
-189627,Dimitris,Giannoulis,Giannoulis,,,,,,457,,,,,112c495e,9745,295630
-189776,Samuel,Bastien,Bastien,,,,,,,,158,,,ec30b9c8,1343,289510
-191769,Jonathan,Benteke,Jonathan Benteke,579,,,,,,,,,,5c59bc47,1765,273773
-191866,Kristoffer,Ajer,Ajer,,,,,,483,84,90,86,108,a8c0acb7,9677,328658
-192182,Kieran,O'Hara,O'Hara,681,,,,,,,,,,80cbe60b,5599,289791
-192290,Connor,Roberts,Roberts,654,598,,,,585,,176,,186,24fae784,5568,214666
-192301,Jon Gorenc,Stankovic,Stankovic,,169,522,,,,,,,,9c74fa25,2641,245034
-192303,Christoph,Zimmermann,Zimmermann,,,,275,,324,,,,,2d5f03bf,7990,77812
-192895,Kieran,Tierney,Tierney,,,,515,17,16,8,24,21,,fce2302c,8089,300716
-193109,Callum,Slattery,Slattery,,,570,327,,,,,,,059948df,7335,332342
-193111,Todd,Cantwell,Cantwell,,,,287,,325,,,,,f63d8a4b,7695,332341
-193195,Allan,Campbell,Campbell,,,,,,,,319,,,858409be,11727,347619
-193204,Joe,Aribo,Aribo,,,,,,,512,,452,,328f7d51,10766,468198
-193488,Anwar,El Ghazi,El Ghazi,,,,30,45,42,51,,,,ffa90327,5612,183720
-193645,Robin,Koch,Koch,,,,,491,194,230,,,,ea6bc03a,6273,328784
-194010,Rico,Henry,Henry,,,,,,83,85,103,92,109,8a3c1dc7,9679,339556
-194126,Michael,Verrips,Verrips,,,,521,580,,,,,,424595d5,8169,288259
-194164,Mason,Holgate,Holgate,495,144,160,478,165,178,192,255,225,,d0042ab9,985,348623
-194190,Harry,Souttar,Souttar,,550,,,,,727,,303,,0a6cb1b1,6329,298091
-194252,Steven,Bergwijn,Bergwijn,,,,615,400,369,437,,,,a29b1131,8300,284165
-194401,Adalberto,Peñaranda,Peñaranda,,,554,648,,,,,,,4b3f2936,1548,308801
-194634,Diogo,Teixeira da Silva,Diogo J.,,,432,410,468,240,288,294,317,,178ae8f8,6854,340950
-194794,Fikayo,Tomori,Tomori,,503,,529,121,,,,,,7edfbb8a,703,303254
-194798,Bernard,Ashley-Seal,Ashley-Seal,,,,559,,,,,,,4f187520,8128,322089
-194799,Jamal,Lewis,Lewis,,,,276,513,311,372,420,408,,efb9215a,7691,346018
-195064,Mace,Goodridge,Goodridge,,,,571,551,,,,,,6abefdff,8194,382552
-195384,Mikel,Merino Zazón,Merino,,495,322,,,,,,633,22,d080ed5e,5304,338424
-195471,Anthony,Driscoll-Glennon,Driscoll-Glennon,,,615,572,536,,,,,,6a39bd42,7572,503683
-195473,Rhian,Brewster,Brewster,666,,,464,262,,,477,,,30e81a88,5569,406560
-195480,Josh,Maja,Maja,613,,,,665,,,,,,bc0bfc64,5587,453824
-195546,Emiliano,Buendía Stati,Buendía,,,,283,,43,42,35,31,50,66b76d44,2203,321247
-195728,Alex,Kral,Kral,,,,,,589,,,,,e717705a,8017,337333
-195735,Nicolas,Pépé,Pepe,,,,488,18,17,9,16,,,57e3f0c7,5656,343052
-195774,Gedson,Carvalho Fernandes,Fernandes,,,,605,401,,,,,,e2dde94c,8257,337800
-195851,Scott,McTominay,McTominay,667,283,303,248,309,285,338,392,381,,d93c2511,5560,315969
-195855,Beni,Baningime,Baningime,,563,174,557,,,,,,,ca9178af,6384,399369
-195859,Marcus,Browne,Browne,609,631,,,,,,,,,7358a89a,1052,391470
-195860,Joe,Powell,Powell,,,547,,,,,,,,a0961a90,7238,354134
-195864,Sam,Field,Field,511,433,,,423,,,,,,bd8a7d05,1013,387331
-195899,Gianluca,Scamacca,Scamacca,,,,,,,529,541,,,8790f988,6253,315867
-196100,Gustavo,Hamer,Hamer,,,,,,,,663,,,eebacc07,11839,322985
-196118,Yoshinori,Muto,Muto,,,488,260,341,,,,,,5343eb4e,47,230541
-196411,Conor,Chaplin,Chaplin,,,,,,,,,265,,4ec55b87,12750,349503
-197024,Guido,Rodríguez,G.Rodriguez,,,,,,,,,588,618,34e393f2,8267,342385
-197030,Aboubakar,Kamara,Kamara,,,189,,190,,,,,,4047c976,4866,290951
-197365,Eric,Bailly,Bailly,255,271,291,228,310,286,339,375,,,a1232f4e,1739,286384
-197464,Nathaniel,Phillips,N.Phillips,,,,589,589,241,501,306,332,,515ebe8d,8228,371814
-197469,Hamza,Choudhury,Choudhury,,571,230,180,234,214,263,,287,,7d2d3329,6418,341501
-197937,Oliver,Burke,Burke,,524,,,424,,,,,,f631c17f,5256,341317
-198044,Harry,Lewis,Lewis,623,,,548,625,637,,,,,c35e99d8,5592,341043
-198501,Sead,Haksabanovic,Haksabanovic,,526,,,,,,,,,d2fd7c14,6393,349300
-198504,Kazaiah,Sterling,Sterling,,643,578,,,,,,,,230255f5,6684,357397
-198826,Ben,Godfrey,Godfrey,,,,273,566,179,193,252,715,,9f7c837d,7689,343475
-198842,Connor,Ronan,Ronan,,,,,,,567,,,,1b804500,10753,337787
-198847,Bright,Enobakhare,Enobakhare,,,436,,,,,,,,dccefdd4,6858,345772
-198849,Lucas,Torreira di Pascua,Torreira,,,450,19,19,18,22,,,,52611641,1227,318077
-198869,Benjamin,White,White,,,559,,74,67,10,29,24,11,35e413f1,7298,335721
-199056,Gabriel,Osho,Osho,,,,,,,,330,,,cd889153,12151,364409
-199170,Moussa,Niakhaté,Niakhaté,,,,,,,507,457,,,00242715,5989,291200
-199249,Sergio,Reguilón,Reguilón,,,,,542,370,438,508,496,,3353737a,7187,282429
-199404,Tashan,Oakley-Boothe,Oakley-Boothe,,531,,,,,,,,,d73892ac,6250,406637
-199583,Dujon,Sterling,Sterling,,600,,,,,,,,,54dd7308,6491,346315
-199584,Japhet,Tanganga,Tanganga,,,,583,402,371,439,518,,,e9971f2d,8222,346478
-199598,Ethan,Ampadu,Ampadu,,558,130,121,509,139,151,185,,354,10b9fa99,6369,392771
-199670,Odsonne,Édouard,Édouard,,,,,,586,166,225,198,285,0562b7f1,3697,344152
-199796,Matty,Cash,Cash,,,,,496,44,43,36,32,36,2389cdc2,8864,425334
-199798,Ezri,Konsa Ngoyo,Konsa,,,,452,46,45,44,48,44,38,0313a347,7726,413403
-199806,Dion,Henry,Henry,,555,,,,,,,,,156bb589,6358,345899
-200088,Daniel,N'Lundulu,Nlundulu,,,,535,590,344,,,,,30040f5d,7983,346482
-200089,Joe,Willock,Willock,,634,566,490,20,19,373,432,420,494,a3b03921,6630,340329
-200370,Matt,Butcher,Butcher,,588,620,,,,,,,,b170cfa2,1069,391132
-200402,Nélson,Cabral Semedo,N.Semedo,,,,,546,437,482,572,559,,d04b94db,6163,231572
-200428,Mateusz,Lis,Lis,,,,,,,421,,465,,fd78b105,11103,345437
-200439,Che,Adams,Adams,,,,437,377,345,411,,,,f2bf1b0f,7700,346779
-200455,Julien,Ngoy,Ngoy,544,562,,,,,,,,,87449a74,1777,286005
-200600,Daniel,Castelo Podence,Podence,,,,619,469,438,483,568,562,,7fcc71d8,8291,256977
-200617,Daniel,James,James,598,,,243,311,287,231,,,353,c931d9f9,5595,319301
-200641,Reiss,Nelson,Nelson,,489,19,489,21,531,23,578,10,27,c5bdb6e3,6492,340325
-200720,Caoimhín,Kelleher,Kelleher,,,,531,560,242,289,301,325,101,62d7ef38,7904,340918
-200785,Tyler,Adams,Adams,,,,,,,506,673,60,85,2b09d998,7352,332705
-200826,Giovani,Lo Celso,Lo Celso,,,,523,403,372,,503,493,,d7553721,5681,348795
-200834,Nordi,Mukiele,Mukiele,,,,,,,,,,694,ac73ec79,5659,348026
-200878,Filip,Krovinovic,Krovinovic,,,,,555,,,,,,c2dfedeb,8966,261988
-200884,Tyrese,Campbell,Campbell,,628,,,,,,,,,38aefb74,6561,382554
-201057,Thilo,Kehrer,Kehrer,,,,,,,588,537,,,51dbeea9,2674,228948
-201084,Timothy,Fosu-Mensah,Fosu-Mensah,253,269,511,658,312,,,,,,a9142dc3,549,315131
-201410,Auston,Trusty,Trusty,,,,,,,,27,,,cddf767b,11732,389253
-201440,Hwang,Ui-jo,Ui-jo,,,,,,,,466,446,,a2d873dd,7746,260166
-201595,Lucas Estella,Perri,Perri,,,584,,,,,,,665,5dbd461a,12369,352041
-201658,Marcus,Tavernier,Tavernier,,,,,,,535,86,83,84,5c0da4a4,10741,399434
-201666,Harvey,Barnes,Barnes,,642,571,172,235,215,264,603,392,487,3ea50f67,6681,398065
-201667,Josh,Knight,Knight,,,558,,,,,,,,5c0c30cc,7294,425026
-201895,Omar,Alderete,Alderete,,,,,,,,,,683,bb08bce9,8986,353032
-202174,Greg,Luer,Luer,518,,,,,,,,,,82865517,1780,356195
-202641,André,Onana,Onana,,,,,,,,597,383,432,e9c0c1b2,10913,234509
-202993,Rodrigo,Bentancur,Bentancur,,,,,,702,440,492,480,585,3b8674e6,6108,354362
-203325,André-Frank,Zambo Anguissa,Anguissa,,,512,,191,,,,,,6bb2c084,6434,354361
-203341,Wilfred,Ndidi,Ndidi,628,206,227,176,236,216,265,,300,,6b47c5db,5545,274839
-203368,Frédéric,Guilbert,Guilbert,,,,458,47,46,56,,,,5d8d7454,3253,354352
-203389,Nathan,Tella,Tella,,,,633,524,346,412,,,,f1e94cd6,8456,340322
-204043,Arthur Henrique,Ramos de Oliveira Melo,Arthur,,,,,,,620,,,,48b3dd60,6942,362842
-204120,Olivier,Boscagli,Boscagli,,,,,,,,,,143,403f5d20,3645,318508
-204214,Pervis,Estupiñán Tenorio,Estupiñan,,,,,,,586,131,122,147,d38fdf53,5136,349599
-204216,Keshi,Anderson,Anderson,509,528,,,,,,,,,864a3eba,1779,353674
-204380,Juninho,Bacuna,Bacuna,,,208,,,,,,,,aaf1bf05,7219,348863
-204454,Isaac,Mbenza,Mbenza,,,514,,,,,,,,aa1a8c7e,5662,260806
-204480,Declan,Rice,Rice,618,510,406,395,448,421,467,540,16,21,1c7012b8,5553,357662
-204481,Tyreke,Johnson,Johnson,,,562,326,,,,,,,4701e130,7314,404586
-204580,Vitaly,Janelt,Janelt,,,,,,84,86,105,94,125,8449d35e,9680,270171
-204642,Jay-Roy,Grot,Grot,,,,,207,,,,,,9a8241af,,360517
-204646,Donyell,Malen,Malen,,,,,,,,,725,53,116c35df,9749,326029
-204676,Andi,Zeqiri,Zeqiri,,,,,574,535,,155,,,d01231f0,9099,345468
-204716,Ibrahima,Konaté,Konaté,,,,,,243,290,302,326,374,5ed9b537,6326,357119
-204727,Malang,Sarr,M.Sarr,,,,,,501,143,214,176,,4315f30d,5648,344596
-204760,Michael,Folivi,Folivi,620,581,,,,,,,,,a7b41270,5586,479939
-204814,Ben,Brereton Díaz,Brereton Díaz,,,,,,,,775,584,,57827369,11815,426192
-204819,Elliot,Embleton,Embleton,617,,,,,,,,,,e8a427a3,5564,364828
-204820,George,Marsh,Marsh,,,612,,,,,,,,49deb548,7542,431424
-204822,Omar,Richards,O.Richards,,,,,,,511,461,438,512,f9b1b7bf,9675,424881
-204863,Ryan,Manning,Manning,,,,,,,,,467,,847b53eb,13134,262300
-204936,Gianluigi,Donnarumma,Donnarumma,,,,,,,,,,736,08f5afaa,1116,315858
-204968,Ryan,Yates,Yates,,,,,,,387,470,449,522,c1fe2a48,11003,425902
-205102,Ramadan,Sobhi,Sobhi,486,345,207,,,,,,,,98be0d02,1764,312017
-205135,Samuel,Shashoua,Shashoua,672,,,,,,,,,,df855e4b,5572,387313
-205533,Eddie,Nketiah,Nketiah,,560,552,13,22,20,11,13,11,284,a53649b7,6482,340324
-205651,Gabriel,Fernando de Jesus,G.Jesus,625,259,281,211,282,263,28,8,2,31,b66315ae,5543,363205
-205836,Saman,Ghoddos,Ghoddos,,,,,,85,87,701,,,f7b1d4e0,7069,204294
-206325,Oleksandr,Zinchenko,Zinchenko,238,551,279,206,283,264,313,31,25,12,51cf8561,2958,203853
-206882,Pontus,Dahlberg,Dahlberg,,,374,367,,,,,,,2475b06e,,365544
-206915,Curtis,Jones,C.Jones,,640,597,569,263,244,291,300,324,388,4fb9c88f,6665,433188
-207189,Sander,Berge,Berge,,,,621,360,,,475,622,330,d0b6129f,8285,333014
-207270,Daniel,Iversen,Iversen,,,,,,,548,,294,,10d221cd,10808,260841
-207283,Mathias,Jensen,Jensen,,,,,,86,88,106,95,126,0f134faf,7166,319859
-207300,Mihai-Alexandru,Dobre,Dobre,,,,574,,,,,,,a1f3f5a0,8208,365770
-207722,Jack,Walton,Walton,,,,,,,,338,,,3df50652,,368629
-207725,Daniel,Agyei,Agyei,651,,,,,,,,,,5c374509,5563,367195
-208706,Bruno,Guimarães Rodriguez Moura,Bruno G.,,,,,,697,374,406,394,488,82518f62,8327,520624
-208904,Mads Juel,Andersen,Andersen,,,,,,,,315,,,f098c03e,11715,407021
-208912,Joe,Worrall,Worrall,,,,,,,388,469,448,199,a5212312,10756,415970
-208973,Francisco,Sierralta,Sierralta,,,,,,396,,,,,0f933743,7081,371436
-208987,Jeff,Reine-Adelaide,Reine-Adelaide,588,,,,,,,,,,d504b3e1,1056,326300
-208998,Zeze Steven,Sessegnon,Sessegnon,,,541,,192,,,,,,4e229bf9,7205,406558
-209035,Jonathan,Panzo,Panzo,,,,,,,389,460,441,,c795c408,7247,392777
-209036,Marc,Guéhi,Guéhi,,,624,545,,477,167,228,200,260,d0706b27,7603,392757
-209037,Zech,Medley,Medley,,,546,636,,,,,,,692e9958,7231,392761
-209040,Timothy,Eyoma,Eyoma,,,561,,,,,,,,449949f4,7311,406559
-209041,Angel,Gomes,Angel,680,,568,245,,,,,,816,645a3363,5598,392770
-209042,Oliver,Skipp,Skipp,,,540,352,404,373,441,515,501,,6250083a,7198,406638
-209043,Nya,Kirby,Kirby,,630,,588,,,,,,,96b99d13,6563,406633
-209045,Taylor,Richards,Richards,,,,,,537,121,,,,e0243d23,9735,484551
-209046,Callum,Hudson-Odoi,Hudson-Odoi,,583,131,116,122,140,144,205,434,516,15f3ec41,6456,392768
-209212,Thomas,Edwards,Edwards,648,556,,,,,,,,,1b780599,5593,430788
-209243,Jadon,Sancho,Sancho,,,,,,485,340,397,386,456,dbf053da,6345,401173
-209244,Phil,Foden,Foden,,492,277,220,284,265,314,353,348,414,ed1e53f3,6055,406635
-209288,Tom,McGill,McGill,,,,,662,688,756,141,,140,4eb2d015,9319,406556
-209289,Emile,Smith Rowe,Smith Rowe,,,545,576,23,21,12,22,19,325,17695062,7230,392765
-209293,Daiki,Hashioka,Hashioka,,,,,,,,798,,,10cb48b7,12509,387191
-209353,Patrick,Cutrone,Cutrone,,,,487,626,523,,,,,a4fe8cda,4918,265078
-209362,Bernardo,Fernandes Da Silva Junior,Bernardo,,,440,39,75,68,,,,,17370b95,5245,364258
-209365,Matthijs,de Ligt,De Ligt,,,,,,,,,593,436,d6e53a3a,7902,326031
-209400,Daichi,Kamada,Kamada,,,,,,,,,205,271,15b287da,6145,356141
-209411,Joe,Tupper,Tupper,,,576,,,,,,,,7d675f6f,7348,424901
-209413,Jordi,Osei-Tutu,Osei-Tutu,,644,,,,,,,,,0a16eb36,6723,397099
-209418,Tobi,Omole,Omole,,,,,,598,,,,,296904e8,9950,503687
-209419,Max,Melbourne,Melbourne,,572,,,,,,,,,7ad65188,6423,460255
-209420,Joy,Mukena,Mukena,,625,,,,,,,,,8bfcc23b,6539,506213
-209925,Xande,Nascimento da Costa Silva,Xande Silva,,,560,387,,,390,,,,15d561fa,7312,258011
-210156,Taiwo,Awoniyi,Awoniyi,,,,,,,397,437,424,527,e5478b87,7814,295313
-210207,Fousseni,Diabaté,Diabaté,,601,232,,,,,,,,d07e3b41,5767,364861
-210237,Marko,Grujic,Grujic,475,231,,,,,,,,,8b8e759d,1669,222813
-210407,Matheus,Pereira,Pereira,,,,,481,,,,,,b04ee927,7153,225984
-210462,Ibrahim,Sangaré,Sangaré,,,,,,,,713,442,521,bced0375,5722,375885
-210494,Nayef,Aguerd,N.Aguerd,,,,,,,472,522,529,607,288e1e13,6935,361914
-211975,Manuel,Akanji,Akanji,,,,,,,610,341,340,404,89ac64a6,6490,284730
-212314,Saša,Lukić,Lukić,,,,,,,726,276,249,332,c6e8cf1f,1537,245056
-212319,Richarlison,de Andrade,Richarlison,,501,393,150,166,180,454,509,497,597,fa031b34,6026,378710
-212325,Pierre,Lees-Melou,Lees-Melou,,,,,,471,,,,,f5044e54,5619,377393
-212701,Denis,Zakaria,Zakaria,,,,,,,616,,,,384d58d9,6147,334526
-212721,Lyanco,Silveira Neves Vojnovic,Lyanco,,,,,,567,413,,,,b5bf1770,6252,379807
-212723,Milot,Rashica,Rashica,,,,,,449,,,,,6c6a3300,6523,291739
-213056,Tudor,Baluta,Baluta,,,,536,,,,,,,ed33f42d,8019,433976
-213198,Christopher,Nkunku,Nkunku,,,,,,,,212,181,240,7c56da38,3300,344381
-213280,Jake,Eastwood,Eastwood,,,,299,,,,,,,54d9b72d,8233,526873
-213345,Wesley,Moraes Ferreira da Silva,Wesley,,,,428,48,47,,61,,,bfae110f,7724,381362
-213384,Josh,Clackstone,Clackstone,515,,,,,,,,,,25dfa9be,1774,453306
-213405,Filip,Benkovic,Benkovic,,,501,597,237,,,,,,305a3820,8238,293168
-213482,Yan,Valery,Valery,,,556,306,378,546,414,,,,531a4aa8,7280,406008
-213687,Charlie,Goode,Goode,,,,,,87,96,102,,,7aee4dd3,9687,376856
-213999,Edson,Álvarez Velázquez,Álvarez,,,,,,,,642,511,616,8b3ab7ad,11926,401356
-214048,Maximilian,Kilman,Kilman,,,567,408,470,439,484,563,524,605,d0f72bf1,7332,525247
-214225,Joe,Rodon,Rodon,,561,,,584,374,442,510,,348,8d62d31a,6377,297212
-214285,Konstantinos,Tsimikas,Tsimikas,,,,,242,245,292,311,337,377,f315ca93,8852,338070
-214466,Will,Smallbone,Smallbone,,,,584,379,347,415,,471,,5e105217,8224,444211
-214470,Jake,Vokins,Vokins,,,,645,380,,,,,,d484c261,8493,421424
-214572,Brandon,Austin,Austin,,,,558,,659,451,491,479,566,5e253986,8093,428016
-214590,Aaron,Wan-Bissaka,Wan-Bissaka,612,579,145,122,313,288,341,401,388,610,9e525177,5584,477758
-214964,George,Edmundson,Edmundson,,,,,,,,,269,,46ff3923,12947,385848
-214987,Kamil,Miazek,Miazek,,,,,208,,,,,,ab20668a,,237632
-215059,Robert,Lynch Sánchez,Sánchez,,,,,597,69,113,145,185,220,6a713852,9098,403151
-215062,Max,Sanders,Sanders,,,572,,632,,,,,,4871d0e8,7341,411495
-215066,Alex,Cochrane,Cochrane,,,,666,,,,,,,8a08585e,8581,392773
-215136,Neco,Williams,N.Williams,,,,575,264,246,295,467,437,508,dd323728,8204,503680
-215379,Elliot,Anderson,Anderson,,,,,602,609,552,403,423,517,de31038e,9154,567576
-215407,Alfie,Lewis,Lewis,,,,651,,,,,,,548e5d9f,8521,423571
-215409,Cameron,John,John,,,596,,,,,,,,6c753e99,7389,425894
-215413,Kiernan,Dewsbury-Hall,Dewsbury-Hall,,,,,,505,266,,166,242,5c74c0f5,9739,475188
-215439,Tomáš,Souček,Souček,,,,616,449,422,468,542,530,613,6613c819,8288,283628
-215457,Kane,Wilson,Wilson,510,508,,,,,,,,,a3f1897f,1766,392774
-215460,Ian,Poveda-Ocampo,Poveda,,,,,209,195,,,,550,55b4f1d6,8723,392763
-215476,Joshua,Sargent,Sargent,,,,,,516,,,,,a8d4428b,7295,393325
-215531,Ionuț,Radu,Radu,,,,,,,,607,,,67f649be,1830,303657
-215610,Marcel,Lavinier,Lavinier,,,,,,724,,,,,6b3e4b53,10549,392772
-215711,Leon,Bailey,Bailey,,,,,,492,45,34,28,49,3a233281,5221,387626
-215885,Michael,Phillips,Phillips,606,,,,,,,,,,2a1c8e89,5583,378629
-216051,Diogo,Dalot Teixeira,Dalot,,,294,229,314,510,342,377,369,440,d9565625,7281,357147
-216054,Rúben,Nascimento Vinagre,Vinagre,,,431,406,471,,531,,,,b937e490,6856,357158
-216055,Florentino Ibrain,Morris Luís,Florentino,,,,,,,,,,722,881cd6be,8969,357162
-216058,Domingos,Quina,Quina,610,568,517,375,,397,,,,,41fb0f4e,5573,391719
-216094,Jeremie,Frimpong,Frimpong,,,,,,,,,,370,74f2e748,9328,484547
-216183,Brahim,Diaz,Diaz,,493,278,,,,,,,,407feb71,6421,314678
-216208,Matija,Šarkić,Šarkić,,,,,472,,492,571,,,a89e7b29,10754,293257
-216554,Sam,Hughes,Hughes,,645,,,,,,,,,286f5a8e,6729,395797
-216616,Dara,O'Shea,O'Shea,,,,,425,,,173,630,,1d042188,8756,401320
-216620,Marcus,Forss,Forss,,,,,,88,97,,,,82c215a0,9684,404584
-216646,Yoane,Wissa,Wissa,,,,,,524,89,119,110,135,2500cef9,5786,388165
-217331,Sam,Surridge,Surridge,679,,599,71,,,391,464,,,b017b770,5602,398402
-217401,Josh,Benson,Benson,,,583,653,535,116,,,,,bf3aeb61,7383,397102
-217487,Mbwana Ally,Samatta,Samatta,,,,613,49,48,,,,,dae8623e,8287,182201
-217593,Pablo,Fornals Malla,P.Fornals,,,,399,450,423,469,534,,,82927de4,2335,357885
-217989,Rafael,Camacho,Camacho,,641,557,201,,,,,,,91b43c98,6666,400831
-218023,Jimmy,Dunne,Dunne,,,,638,519,,,,,,1fdfd6da,8481,396174
-218031,Çaglar,Söyüncü,Söyüncü,,,515,164,238,217,267,,,,21166ff4,5264,320141
-218112,Jason,Lokilo,Lokilo,,491,,,,,,,,,fad4d5e8,6028,325200
-218218,Wout,Faes,Faes,,,,,,,612,,291,,9c221d14,8646,292808
-218328,Samuel,Chukwueze,Chukwueze,,,,,,,,,,727,b8a642fc,7208,401922
-218364,Borna,Sosa,Sosa,,,,,,,,,,259,af0d79a9,7075,293194
-218430,Gonzalo,Montiel,G.Montiel,,,,,,,,679,,,374d5158,9897,402733
-218997,Ellis,Simms,Simms,,,,667,596,602,686,264,,,26d3b5be,8582,511550
-219002,Dodi,Lukebakio,Lukebakio,,615,,,,,,,,,0c61c77c,5706,303259
-219168,Alexander,Isak,Isak,,,,,,,594,415,401,499,8e92be30,5232,349066
-219249,Matt,O'Riley,O'Riley,,,,,,,,,629,164,fb495bb8,13206,406634
-219265,Felix,Nmecha,Nmecha,,,,,609,,,,,,091c86e2,9202,406640
-219279,Sugawara,Yukinari,Sugawara,,,,,,,,,474,,580bcd18,12761,405385
-219291,Claudio,Gomes,Gomes,,,,,659,,599,,,,22f6ed2c,9314,395239
-219352,Ademola,Lookman,Lookman,627,157,170,155,557,587,,,,,7c104bb7,5556,406040
-219727,Joel,Asoro,Asoro,521,,,,,,,,,,13e827f8,1754,375391
-219847,Kai,Havertz,Havertz,,,,,500,141,145,6,4,30,fed7cb61,5220,309400
-219924,Issa,Diop,Diop,,,409,381,451,424,470,271,245,320,a712ca2b,3203,272622
-219929,Rafa,Mir,Mir,,,449,,,,,,,,bbf5c11b,2589,361254
-219937,Rhys,Williams,R.Williams,,,,,594,247,498,,334,379,012c975a,9086,503679
-219961,Raphael,Dias Belloli,Raphinha,,,,,570,196,232,,,,3423f250,8026,411295
-220037,Bailey,Peacock-Farrell,Peacock-Farrell,,,,495,99,117,,175,,,4879f8cb,8482,410436
-220087,Maximilian,Wöber,Wöber,,,,,,,691,,,,4b803b3c,7366,263361
-220166,Marc,Navarro,Navarro,,,385,360,,398,,,,,c2846353,5085,335245
-220237,Sven,Botman,Botman,,,,,,,377,405,393,475,ccce7025,8635,361093
-220307,Arnaut,Danjuma Groeneveld,Danjuma,,,,492,,,713,601,,,f08490a6,8066,355861
-220362,Axel,Disasi,Disasi,,,,,,,,611,167,815,ad82197c,6885,386047
-220394,Tommy,Doyle,Doyle,,,,644,285,566,,351,544,,5526deb1,8496,433183
-220566,Rodrigo 'Rodri',Hernandez Cascante,Rodrigo,,,,443,286,266,315,365,360,421,6434f10d,2496,357565
-220583,Luke,Woolfenden,Woolfenden,,,,,,,,,284,,e28e9bec,12746,527425
-220585,Flynn,Downes,Downes,,,,,,,509,531,518,,69fdb896,10845,506189
-220598,Michael,Obafemi,Obafemi,,603,550,314,381,348,,174,,219,caa1a7f0,6504,444208
-220627,James,Justin,Justin,,,,433,239,218,268,,295,706,fb614c44,7753,413220
-220650,Thibaud,Verlinden,Verlinden,599,,,,,,,,,,e5c026d6,5594,338673
-220682,Arthur,Okonkwo,Okonkwo,,,,,,572,,,,,75834acc,9909,503769
-220684,Aji,Alese,Alese,,,,,,644,,,,533,182a8b9d,10165,502065
-220686,Bali,Mumba,Mumba,,,,,,515,,,,,2d760d7b,9747,433186
-220688,Mason,Greenwood,Greenwood,,,608,234,315,289,,,,,58eee997,7490,532826
-220693,Rayhaan,Tulloch,Tulloch,,577,,,,,,,,,bddd8ba3,6432,433184
-220695,Paris,Maghoma,Maghoma,,,,,,614,,,674,132,8a3ddcd2,10053,470596
-220738,Jayson,Molumby,Molumby,,553,617,,550,,,,,,c908a1bc,6350,357656
-221239,Keinan,Davis,Davis,,,,34,50,49,52,39,,,9deaf2c8,1053,412660
-221245,Levi,Lumeka,Lumeka,,544,,,,,,,,,199ff86e,6283,537182
-221267,Josh,Tymon,Tymon,519,336,,,,,,,,,efe6f6ac,1745,419929
-221268,Ben,Hinchcliffe,Hinchcliffe,545,,,,,,,,,,6261bd48,1775,49597
-221271,Ben,Wynter,Wynter,585,,,,,,,,,,86334f1a,1756,464738
-221272,Sam,Woods,Woods,,,609,578,522,,,,,,a62da625,7534,611650
-221275,Luke,Dreher,Dreher,581,,618,140,,,,,,,d1c509d9,636,432293
-221286,Charlie,Rowan,Rowan,619,,,,,,,,,,d129989d,5585,479944
-221389,John Victor,Maciel Furtado,John,,,,,,,,,,715,33a235af,,432914
-221399,Jack,Harrison,Harrison,,,,,203,267,233,661,224,352,aa849a12,8720,417346
-221403,Richie,Laryea,Laryea,,,,,,,392,452,,,276fdbe4,,417348
-221466,Marcos,Senesi Barón,Senesi,,,,,,,576,83,79,72,35141f4c,10864,469781
-221568,Daniel,Kemp,Kemp,675,,,,,,,,,,82362769,5605,396857
-221610,Jamie,Shackleton,Shackleton,,,,,210,197,234,,,,8d03ca5a,8721,534700
-221632,Cristian,Romero,Romero,,,,,,494,443,511,498,569,a3d94a58,7218,355915
-221820,Lisandro,Martínez,Martinez,,,,,,,533,391,380,437,bac46a10,10802,480762
-222017,Conor,Coventry,Coventry,,,548,664,668,522,556,529,,,a5ca9127,7239,419025
-222018,Ben,Johnson,Johnson,,573,605,384,452,425,471,536,275,,9319781b,6424,468002
-222434,Jack,Simpson,Simpson,,570,32,66,,,,,,,76fa5f80,6410,419930
-222531,Morgan,Gibbs-White,Gibbs-White,,,448,416,473,440,493,447,433,515,32f60ed8,6857,429014
-222564,Francisco,Machado Mota de Castro Trincão,Trincão,,,,,,461,,,,,77e39b04,8934,412669
-222625,George,Hirst,Hirst,,,,661,,,,,272,,78e87179,8563,420808
-222627,João,Neves Virgínia,J.Virginia,,,,629,167,181,,266,227,,728e9b2e,8366,329813
-222677,Tahith,Chong,Chong,,,603,249,316,,,586,,,2696b6a9,7439,344830
-222683,Justin,Kluivert,Kluivert,,,,,,,,72,71,81,4c3a6744,6963,330659
-222690,Tyrell,Malacia,Malacia,,,,,,,504,389,379,448,6b6c793c,10803,339340
-222694,Pascal,Struijk,Struijk,,,,,211,198,235,,,343,f4d296e4,8717,410708
-222786,Panagiotis,Retsos,Retsos,,,,625,,,,,,,4bd00a50,6316,324351
-223081,Kristoffer,Klaesson,Klaesson,,,,,,490,236,,,,3f70db80,9700,418561
-223094,Erling,Haaland,Haaland,,,,,,,318,355,351,430,1f44ac21,8260,418560
-223175,Matthew,Longstaff,M.Longstaff,,,,540,487,312,,,,,c0027d2d,8016,484387
-223332,Faustino,Anjorin,Anjorin,,,,630,605,,,,,,b105919e,8383,433181
-223333,Louie,Watson,Watson,,,,,,,,339,,,d4f63087,,505548
-223335,Sylvester,Jasper,Jasper,,,,,707,,,,,,a9f04944,9553,502074
-223336,Dan,Neil,Neil,,,,,,,,,,549,a47ad0f5,13720,570336
-223337,Jamie,Bowden,Bowden,,,,,,717,,,,,9a5675c9,10537,504051
-223340,Bukayo,Saka,Saka,,,563,541,24,22,13,19,17,16,bc7dc64d,7322,433177
-223349,Indiana,Vassilev,Vassilev,,,,600,51,,,,,,04e195ee,8254,469860
-223434,Igor Julio,dos Santos de Paulo,Igor,,,,,,,,606,128,149,a4e85758,7943,380350
-223541,Federico,Chiesa,Chiesa,,,,,,,,,636,385,b0f7e36c,1433,341092
-223723,Tomiyasu,Takehiro,Tomiyasu,,,,,,590,14,25,22,,b3af9be1,7931,331560
-223824,Reece,Hannam,Hannam,,,,,675,540,,,,,974b8e7f,9394,503241
-223827,Daniel,Ballard,Ballard,,,,,,,,,,531,38f300f3,13715,503686
-223911,Chris,Mepham,Mepham,,,580,61,,,71,75,72,79,fed96827,7384,480987
-224024,Lucas,Tolentino Coelho de Lima,L.Paquetá,,,,,,,603,539,527,612,9b6f7fd5,7365,444523
-224068,Matt,Turner,Turner,,,,,,,24,28,445,504,4a51ba65,10700,425306
-224117,Viktor,Gyökeres,Gyökeres,,,551,,,,,,,666,4d5a9185,7254,325443
-224209,Rasmus,Kristensen,Kristensen,,,,,,,244,,,,39769cff,10750,369684
-224444,Ferran,Torres,Torres,,,,,287,268,,,,,9e1035f8,6441,398184
-224860,Carlos,Soler,C.Soler,,,,,,,,,654,,fed17f5a,2478,372246
-224946,Matthew,Worthington,Worthington,678,,,,,,,,,,8c8b941f,5601,493607
-224967,Vitalii,Mykolenko,Mykolenko,,,,,,675,194,260,231,292,30d4a2e5,10291,404842
-224995,Luis,Sinisterra Lucumí,Sinisterra,,,,,,,508,705,80,91,8e16dd48,10866,512385
-225000,Dion,Sanderson,Sanderson,,,,,,686,,,,,b3fa76c5,10294,495993
-225295,Mateus,Cardoso Lemos Martins,Tetê,,,,,,,715,,,,7120a04d,10536,371256
-225321,Aaron,Ramsdale,Ramsdale,677,549,,494,483,559,15,17,14,674,466fb2c5,5603,427568
-225368,Meritan,Shabani,Shabani,,,,,553,,,,,,012c38ec,6642,379980
-225702,Samuel,Kalu,Kalu,,,,,,698,,,,,b8d22478,6947,424051
-225796,Reece,James,James,,,,506,123,142,146,206,172,225,1265a93a,8067,472423
-225897,Fodé,Ballo-Touré,Ballo-Touré,,,,,,,,707,,,f449640d,,296422
-225902,Boubakary,Soumaré,B.Soumaré,,,,,,458,269,,285,,ae59b359,6310,344605
-226029,Lasse,Sorenson,Sorenson,,637,,,,,,,,,ce9c203e,6657,357967
-226182,Jayden,Bogle,Bogle,,,,,510,,,476,,342,ae5019e6,9205,465717
-226473,Scott,Twine,Twine,,,,,,,,180,,,5a425cab,,433818
-226597,Gabriel,dos Santos Magalhães,Gabriel,,,,,494,23,16,5,3,5,67ac5bb8,5613,435338
-226944,Boubacar,Kamara,Kamara,,,,,,,53,47,42,58,cc77354e,5789,394327
-226956,Mads,Roerslev Rasmussen,Roerslev,,,,,,89,90,114,105,112,57c94db2,9685,391005
-227127,Yves,Bissouma,Bissouma,,,466,53,76,70,444,493,482,587,6c203af0,5609,410425
-227444,Nikola,Milenković,Milenković,,,,,,,,,573,505,bee704fc,6174,413507
-227560,Oghenekaro Peter,Etebo,Etebo,,,,,,467,,,,,b579e83d,6538,409106
-228044,Mads,Bech Sørensen,Bech,,,,,,90,91,93,,,30db8574,9683,372240
-228286,Edouard,Mendy,Mendy,,,,,548,143,147,,,,33887998,6880,442531
-228798,Cengiz,Ünder,Ünder,,,,,541,,,,,,1880614f,6162,341647
-229164,Chiedozie,Ogbene,Ogbene,,,,,,,,328,632,,788c0277,11719,392591
-229384,Andy,Irving,Irving,,,,,,,,,576,621,b1be9fc0,12774,430310
-229415,Jon,McCracken,McCracken,,,,,,666,,,,,47188db7,10207,403564
-229600,Mark,Travers,Travers,,,616,74,,,72,88,84,288,fe558029,7582,357658
-230001,Noussair,Mazraoui,Mazraoui,,,,,,,,,594,438,b74277a0,10696,340456
-230046,Douglas Luiz,Soares de Paulo,Douglas Luiz,,,,470,52,50,46,43,,699,6f7d826d,6122,447661
-230127,Percy,Tau,Tau,,,,,627,,,,,,4d0eb7d2,9249,312239
-230251,Emmanuel,Dennis,Dennis,,,,,,450,585,443,430,,2c44a35d,9301,448854
-230348,Ross,Stewart,Stewart,,,,,,,,,473,,18986367,13060,447995
-230376,Jhon,Arias,J.Arias,,,,,,,,,,663,86d96066,13741,588989
-230428,Philippe,Sandler,Sandler,,,604,,,,,,,,60740e70,7440,340460
-231057,Jean-Ricner,Bellegarde,Bellegarde,,,,,,,,715,535,644,10f0fdd3,7762,450050
-231065,Ethan,Pinnock,Pinnock,,,,,,91,92,112,104,111,e541326e,9678,442248
-231172,Brandon,Mason,Mason,621,406,,,,,,,,,1415840f,5558,479942
-231372,Tanguy,Ndombélé Alvaro,Ndombele,,,,442,405,375,,505,,,5cdddffa,5962,450936
-231416,Ferdi,Kadıoğlu,F.Kadıoğlu,,,,,,,,,628,148,66c52a77,13066,369316
-231480,Santiago,Ignacio Bueno,S.Bueno,,,,,,,,697,564,636,edc98fac,10945,438001
-231747,Jean-Philippe,Mateta,Mateta,,,,,641,159,168,232,207,283,50e6dc35,5735,420002
-231899,Jack,Taylor,Taylor,,,,,,,,,281,,48eed8d5,12754,458178
-232112,Manuel,Ugarte Ribeiro,Ugarte,,,,,,,,,652,459,c9817014,11766,476701
-232185,Ismaïla,Sarr,Sarr,,,,525,,399,,,585,267,bfdb33aa,5675,410225
-232223,Folarin,Balogun,Balogun,,,,,,530,,1,,,31822f8c,9690,503770
-232228,Harry,Clarke,H.Clarke,,,,,,,,,266,,a64f2573,13133,528892
-232229,Vontae,Daley-Campbell,Daley-Campbell,,,,,660,639,,,,,192d4c3d,9312,530732
-232233,Tyreece,John-Jules,John-Jules,,,,585,,,,,,,247e5cfc,8225,503768
-232241,Matthew,Smith,Smith,,,,647,,,607,,,,54b6eed9,8494,528894
-232245,Zak,Swanson,Swanson,,,,,,711,,,,,5b7381b5,10436,540687
-232247,Dominic,Thompson,Thompson,,,,,,498,98,,,,235a62f8,9915,503688
-232351,Ryan,Giles,Giles,,,555,607,,687,,553,,,73b1d65b,7277,504581
-232356,Jenson,Jones,Jenson Jones,,,,,,,,,,774,4776da26,14276,990997
-232361,Taylor,Perry,Perry,,,,560,611,,,,,,01ba3996,8139,502073
-232391,Jeremy,Ngakia,Ngakia,,,,593,,400,,,,,3631ad41,8235,503795
-232398,Nathan,Trott,Trott,,574,,,674,,,,,,7494bea9,6425,431422
-232413,Eberechi,Eze,Eze,,,,,489,160,169,226,199,266,ae4fc6a4,8706,479999
-232423,Nathan,Ferguson,Ferguson,,578,,,145,161,174,,,,2f8d27bc,6451,507254
-232427,Rekeem,Harper,Harper,614,507,,,426,,,,,,3c066877,5562,456877
-232456,Dilan,Markanday,Markanday,,,,,,597,,,,,4f242e0e,9949,530807
-232477,Elliot,Thorpe,Thorpe,,,,,,,,337,,,9b1da146,,496661
-232571,Anthony,Patterson,Patterson,,,,,,,,,,528,b2470c6f,13721,475946
-232620,Lewis,Brunt,Brunt,,,,,,646,273,,,,a2081c6b,10168,533657
-232653,Jacob,Ramsey,J.Ramsey,,,,,554,51,47,55,53,52,1544f145,8941,503749
-232667,Akin,Famewo,Famewo,,,,552,,,,,,,9d9a71c1,8080,425713
-232787,Conor,Gallagher,Gallagher,,,,,544,144,148,202,169,796,c2731c10,9040,488362
-232792,Tariq,Lamptey,Lamptey,,,,586,77,71,114,139,131,150,f4e433d4,8226,504148
-232797,Kayne,Ramsay,Ramsay,,,565,311,598,,,,,,dc31b84c,7326,530879
-232820,Joe,Anderson,Anderson,,,,,,,,,,534,4fa3a3a4,,511551
-232826,Anthony,Gordon,Gordon,,,,561,168,503,195,412,398,485,2bd83368,8150,503733
-232829,Kyle,John,John,,,,,679,,637,,,,c9093a1a,9408,504507
-232859,Djed,Spence,Spence,,,,,,,522,517,504,573,9bc9a519,10764,483348
-232881,Thakgalo,Leshabela,Leshabela,,,,,661,,,,,,383e68b1,9311,461882
-232892,Calvin,Bassey,Bassey,,,,,,,,610,241,318,a36524bf,11728,461883
-232917,Arijanet,Muric,Muric,,,529,,,,,172,568,,99aa1a84,7027,371021
-232928,James,Garner,Garner,,,602,250,317,,570,250,223,303,4e015693,7438,505219
-232937,Brandon,Williams,B.Williams,,,,549,318,290,343,374,,,5e74d6c8,8075,507700
-232957,Thomas,Allan,Allan,,,,598,,,,,,,e95726c1,8237,484390
-232960,Lewis,Cass,Cass,,,623,,,,,,,,711a6e59,7601,474382
-232964,Lewis,Gibson,Gibson,,,,477,,,,,,,cdf0f2db,8262,419325
-232977,Kell,Watts,Watts,,,622,599,342,,,431,,,603e4f0b,7602,484389
-232979,Jack,Young,Young,,,,656,,,,,,,ad7cd1fa,8538,507235
-232980,Max,Aarons,Aarons,,,,274,,326,,643,59,,774cf58b,7688,471690
-233420,Renan Augusto,Lodi dos Santos,Renan Lodi,,,,,,,602,,,,ed9f7cfe,7891,476352
-233425,Aaron,Connolly,Connolly,,,,534,78,72,,127,,,27c01749,7991,434207
-233489,Leighton,Clarkson,Clarkson,,,,,601,,,,,,d5dafedb,9151,470606
-233497,Adama,Diakhaby,Diakhaby,,,471,,,,,,,,65585e3a,5740,453594
-233821,Anel,Ahmedhodžić,Ahmedhodžić,,,,,,,,471,,,eab957a3,10386,377468
-233849,Archie,Mair,Mair,,,,551,,,,,,,70e9afd8,8081,447063
-233963,Konstantinos,Mavropanos,Mavropanos,,595,10,8,,24,,676,528,606,00963611,6722,415912
-234370,Marc,Roca Junqué,Roca,,,,,,,245,,,,da27e268,5086,336869
-234483,Aiden,O'Neill,O'Neill,531,623,,,,,,,,,c7aee75b,1662,385918
-234720,Giovanni,McGregor,McGregor,,,,608,,,,,,,1b138e25,8261,611651
-234908,Juan,Foyth,Foyth,,534,549,335,406,,,,,,6c7762c3,6306,480763
-235382,Steven,Alzate,Alzate,,,,537,79,73,115,123,,,ad1f61f3,8020,476237
-235448,Ellery,Balcombe,Balcombe,,,,,,92,100,91,,102,e827567f,11985,456292
-235449,George,Wickens,Wickens,,,,,,,747,,,,eafaafa5,11459,502070
-235530,Lloyd,Kelly,Kelly,,,,64,,,73,70,404,,f31def1e,8090,480116
-235546,Jacob,Sørensen,Sørensen,,,,,,327,,,,,953c30b0,9748,390664
-235599,Nikola,Tavares,Tavares,,,619,635,,,,,,,0beeb166,7599,487428
-235640,Harry,Boyes,Boyes,,,,,704,,,,,,467bf546,9541,746778
-235674,Manor,Solomon,Solomon,,,,,,,562,583,502,589,886f9aac,10716,396638
-235826,Joël,Piroe,Piroe,,,,,,,,,,362,1f0072a6,13835,369962
-240143,Ibrahima,Diallo,Diallo,,,,,565,349,416,,,,11ff3d56,6736,413032
-240299,Joe,Hodge,Hodge,,,,,,,566,555,551,653,bd8a5d95,10755,503975
-240499,Daniel,Batty,Batty,676,,,,,,,,,,96c92a74,5604,509268
-240514,Kjell,Scherpen,Scherpen,,,,,,476,542,147,,142,f0e4c69e,9960,463527
-240796,Álvaro,Fernández,Fernández,,,,,,556,,,,,f127d782,5191,453704
-241157,Emerson,Leite de Souza Junior,E.Royal,,,,,,588,445,497,487,,df8b52a5,7430,476344
-241231,Jordan,Beyer,Jordan,,,,,,,,160,,194,9af1f9ff,6557,403898
-241289,Ben,Wilmot,Wilmot,,,544,,,401,,,,,2876eaa3,7216,467599
-241519,Weston,McKennie,McKennie,,,,,,,720,,,,01c3aff5,5360,332697
-241791,Ryan,Schofield,Schofield,,,533,,,,,,,,74947a21,7111,495441
-242058,Moise,Kean,Kean,,,,496,169,564,,,,,3d50bcdb,1304,364135
-242166,Mattéo,Guendouzi,Guendouzi,,,451,21,25,25,,,,,5ea8ef20,5759,465830
-242183,James,Morris,Morris,,,,,,633,,,,,59e3e314,990,610621
-242453,Jacob,Brown,Brown,,,,,,,,631,,,ca18c8f1,11720,469958
-242500,Joe,Taylor,Taylor,,,,,,,,336,,,bfd3801e,,944551
-242510,Louie,Moulden,Moulden,,,,,,611,,,,,7b7de75a,10030,444641
-242880,Benoît,Badiashile Mukinayi,B.Badiashile,,,,,,,689,191,153,229,06df8256,7240,463603
-242882,Bafodé,Diakité,Diakité,,,,,,,,,,685,1bfb6fef,7268,463605
-242885,Loïc,Mbe Soh,Mbe Soh,,,,,,,393,454,,,8f534f8e,7577,463610
-242898,Brennan,Johnson,Johnson,,,,,,,394,450,491,580,0cd31129,10760,470607
-243016,Alexis,Mac Allister,Mac Allister,,,,627,80,74,116,304,329,386,83d074ff,8379,534033
-243298,Cody,Gakpo,Gakpo,,,,,,,680,297,321,384,1971591f,11296,434675
-243343,Jake,Cain,Cain,,,,,607,,,,,,a33ce8e2,9192,565420
-243345,Lewis,O'Brien,O'Brien,,,,,,,524,458,439,520,089667a5,10759,560694
-243505,Jakub,Moder,Moder,,,,,628,75,117,144,137,,f230bc30,9284,384461
-243526,Gabriel,Gudmundsson,Gudmundsson,,,,,,,,,,347,d5d22a58,9944,362108
-243531,Andrew,Eleftheriou,Eleftheriou,605,,,,,,,,,,0878b548,5548,476532
-243532,Dion,Pereira,Pereira,659,,,,,,,332,,,8aab04dc,5559,499604
-243557,Moussa,Diaby,Diaby,,,,,,,,599,34,,aeed5c06,6556,395516
-243568,Billy,Gilmour,Gilmour,,,,533,124,145,149,133,124,,df10e27c,7988,423744
-243569,Adedapo,Awokoya-Mebude,Mebude,,,,,,469,,,,,b7996fe0,,424021
-243571,Nathan,Patterson,Patterson,,,,,,674,197,262,234,296,230f0471,10292,424015
-243710,Bernardo,Costa Da Rosa,Rosa,,,,595,,,,,,,cd3112d5,8236,476367
-244042,Rodrigo,Muniz Carvalho,Muniz,,,,,,,218,279,251,338,a755db8c,10717,735571
-244085,Siriki,Dembélé,Siriki,,,,,,,74,67,,,11f54bd5,10749,488656
-244262,Alfie,Doughty,Doughty,,,,,,,,321,,,bf33b257,11723,608175
-244560,Romain,Perraud,Perraud,,,,,,460,417,,,,6dfd8f05,6500,318523
-244619,Luke,Thomas,Thomas,,,,660,240,219,270,693,305,,fc027d02,8562,505194
-244704,Matías,Viña,Viña,,,,,,,718,,,,08eb3b58,9892,439072
-244716,Juan Camilo,Hernández Suárez,Cucho,,,,,,472,,,,,71b47ab9,6954,459463
-244723,Tyrick,Mitchell,Mitchell,,,,579,146,162,170,234,210,258,5cbd1eb0,8214,730893
-244731,Luis,Díaz Marulanda,Luis Díaz,,,,,,696,293,303,327,383,4a1a9578,10408,480692
-244845,Nathan,Wood-Gordon,Wood,,,,,,,,,477,,4ccf2d5b,12763,503990
-244848,Teddy,Jenks,Jenks,,,,,631,,,,,,a96ba40b,9253,530915
-244850,Morgan,Rogers,Rogers,,,,,,,,803,54,47,2e5915f1,12412,503743
-244851,Cole,Palmer,Palmer,,,,643,552,507,316,362,182,235,dc7f8a28,8497,568177
-244856,Teden,Mengi,Mengi,,,,,319,,,393,,,91748070,12073,548470
-244858,Fábio,Freitas Gouveia Carvalho,Carvalho,,,,,695,,296,,314,123,966e28d0,9501,559263
-244890,Joseph,Hungbo,Hungbo,,,,,,402,,,,,fdf9edec,,725703
-244930,Alex,Mighten,Mighten,,,,,,,395,456,435,,10ec4169,10761,503988
-244932,Ben,Knight,Knight,,,,,,,600,,,,190163f3,11032,568007
-244954,Pau,Torres,Pau,,,,,,,,584,52,41,532e1e4f,6221,399776
-245414,Nicolò,Zaniolo,Zaniolo,,,,,,,,672,,,9907b1c8,6686,392085
-245419,Patson,Daka,Daka,,,,,,455,271,,289,,ca45605e,9738,365172
-245719,Taylor,Harwood-Bellis,Harwood-Bellis,,,,642,623,,,,461,,47327321,8495,503977
-245824,Carlos Vinícius,Alves Morais,Vinicius,,,,,564,,618,287,258,,8b529245,7395,525287
-245830,Josh,Bowler,Bowler,,,,,,,,440,426,,ea39a081,,506470
-245923,Luke,Cundle,Cundle,,,,567,614,547,485,550,540,,cc3b8e78,8179,532541
-246265,Corrie,Ndaba,Ndaba,,,,,,,,,279,,4db55657,13876,433329
-246301,Jorge,Cuenca Barreno,J.Cuenca,,,,,,,,,586,321,0abc51f2,8489,494880
-246799,Jackson,Smith,Smith,,,,,,,557,,,,15fdac60,,511964
-246878,Abdelhamid,Sabiri,Sabiri,,522,205,,,,,,,,4830e0af,6296,340394
-247245,Hannes,Delcroix,Delcroix,,,,,,,,674,,188,b737f944,11998,338635
-247286,Kyle,Jameson,Jameson,,624,,,,,,,,,3e61e488,6527,494684
-247348,Daniel,Muñoz Mejía,Muñoz,,,,,,,,792,211,256,778ef829,12408,493003
-247412,Jørgen,Strand Larsen,Strand Larsen,,,,,,,,,566,654,f553b2b3,11070,429983
-247632,Pedro,Lomba Neto,Neto,,,,528,474,441,486,567,560,236,7ba2eaa9,6382,487465
-247664,Terry,Ablade,Ablade,,,,,,,591,,,,d524dcd7,11004,434015
-247670,Valentín,Castellanos,Taty,,,,,,,,,,791,da76bab4,10948,522784
-247693,Randal,Kolo Muani,Kolo Muani,,,,,,,,,,726,c0b3669f,5743,487969
-247955,Lutsharel,Geertruida,Geertruida,,,,,,,,,,724,242e1043,13064,420210
-248056,Tanaka,Ao,Tanaka,,,,,,,,,,358,1d36d6b6,13834,489359
-248164,Viljami,Sinisalo,Sinisalo,,,,,,596,707,57,55,,a48635b8,9967,484838
-248853,Dynel,Simeu,Simeu,,,,,,665,,,,,6df49f02,10204,503976
-248854,Josh,Brooking,Brooking,,,,,,,,723,,,330f638c,12130,566832
-248857,Noni,Madueke,Madueke,,,,,,,708,208,177,18,bf34eebd,11357,503987
-248859,Amadou,Diallo,Diallo,,,,,,,,738,,,e31708b2,12200,533086
-248865,Armstrong,Oko-Flex,Oko-Flex,,,,,,652,572,,,,ab77d10d,10179,531461
-248875,Jérémy,Doku,Doku,,,,,,,,678,346,418,fffea3e5,8981,486049
-248937,Sam,Greenwood,Greenwood,,,,,692,550,237,,,355,f3354c07,9493,532178
-249231,Keane,Lewis-Potter,Lewis-Potter,,,,,,,515,107,98,107,41f08ac8,10809,644401
-250199,Nicolás,Domínguez,Dominguez,,,,,,,,712,431,519,20b3a502,8252,497291
-250370,Nathan,Bishop,Bishop,,,,,686,,656,,,,bf713136,9433,495033
-250604,Owen,Otasowie,Otasowie,,,,566,581,442,,,,,6956ff08,8180,511815
-250735,Darko,Churlinov,Churlinov,,,,,,,,162,,204,c6608135,7790,386786
-420922,Jan,Zamburek,Zamburek,,,,,,93,,,,,395880a4,,487924
-421796,Sidnei,Tavares,Tavares,,,,,676,,,,,,3add8ed8,9395,511813
-422287,Kofi,Balmer,Balmer,,,,,,,642,,,,0284bd0d,11169,504518
-422303,John,McAtee,McAtee,,,,,,,,324,,,5c42b6b6,11726,504855
-422306,Will,Ferry,Ferry,,,,654,634,,,,,,f4765c97,8535,504856
-422612,Ryan,Astley,Astley,,,,,681,,,,,,0eb884e1,9407,511552
-423649,Enock,Mwepu,Mwepu,,,,,,462,118,,,,1d5cab82,9734,490307
-424001,Vini,de Souza Costa,Vini Souza,,,,,,,,638,,,6a8a7af8,10872,663581
-424044,Hamed,Traorè,H.Traorè,,,,,,,723,87,67,93,570bb4b9,6986,391065
-424876,Dominik,Szoboszlai,Szoboszlai,,,,,,,,309,336,387,934e1968,9788,451276
-427420,Giovanni,Reyna,Reyna,,,,,,,,801,,,7fa4e703,8191,504215
-427623,Chris,Richards,Richards,,,,,,,530,238,194,261,0a3d6d2b,8430,578539
-427637,Brenden,Aaronson,Aaronson,,,,,,,246,,,350,5bc43860,10751,393323
-428399,João,Félix Sequeira,João Félix,,,,,,,690,,621,,8aafd64f,7892,462250
-428580,Frank,Onyeka,Onyeka,,,,,,479,93,111,102,128,2944f86f,9681,421637
-428610,Bruno,Cavaco Jordão,Jordão,,,,609,475,661,,561,,,41ff002d,6336,415646
-428626,Przemyslaw,Placheta,Placheta,,,,,,328,,,,,3c33f9d9,10097,383109
-428971,Steven,Benda,Benda,,,,,,,,692,242,315,caaa7fab,12735,381469
-429414,Saša,Kalajdžić,Kalajdžić,,,,,,,608,562,555,656,15f24fe7,8812,369567
-430367,Joel,Mumbongo,Mumbongo,,,,665,613,,,,,,f8e588df,8566,381156
-430871,Matheus,Santos Carneiro da Cunha,Cunha,,,,,,,682,590,541,450,dc62b55d,7080,517894
-430992,Owen,Beck,Beck,,,,,,627,,782,,,a011a1e9,10119,551001
-431019,Karlo,Ziger,Ziger,,,,,593,,,,,,53b781b9,9083,526258
-431131,Moussa,Djenepo,Djenepo,,,,438,382,350,418,,,,254147d4,7701,485424
-431248,Ladislav,Krejcí,Krejčí,,,,,,,,,,709,5b5c2228,1447,345911
-431639,Zian,Flemming,Flemming,,,,,,,,,,215,b3f36e72,13729,411537
-431774,Kyle,Taylor,Taylor,,602,600,,,,,,,,0bb6d386,6493,562254
-431924,Daniel,Adshead,Adshead,,,,669,,,,,,,8f817fc7,8590,532464
-431960,Bendegúz,Bolla,Bolla,,,,,,,,547,,,b6ca3ab3,,439351
-432160,Shandon,Baptiste,Baptiste,,,,,,499,94,92,,,2886c9b5,9914,533916
-432422,Sandro,Tonali,Tonali,,,,,,,,429,417,491,0db169ae,7958,397033
-432656,Eric,Garcia,Garcia,,,,544,288,,,,,,2bed3eab,8045,466794
-432705,James,Daly,Daly,,638,,581,,,,,,,435c44b3,6668,577779
-432711,CJ,Egan-Riley,Egan-Riley,,,,,,651,,166,,,d313e8ff,10174,581669
-432712,Owen,Hesketh,Hesketh,,,,,,,,769,,,3f991cbb,12289,550995
-432714,James,McAtee,McAtee,,,,,,629,317,360,357,426,96593e89,10126,583199
-432720,James,Trafford,Trafford,,,,,595,,,596,,182,259fea27,9077,566799
-432735,Adam,Idah,Idah,,,,538,,329,,,,,291e3ec3,8021,434223
-432793,Abd-Al-Ali Morakinyo Olaposi,Koiki,Koiki,,,564,596,,,,,,,82726be5,7323,641441
-432830,Nathan,Collins,Collins,,,,,,451,516,96,88,106,a8c19eb8,9733,469050
-432927,Daniel,Langley,Langley,,,,,606,,,,,,096d1e60,9188,532824
-432931,Tyrese,Francois,Francois,,,,,708,,521,272,,,6722d4f0,9552,528888
-432987,Vítezslav,Jaros,Jaros,,,,,,,,,660,,12bb4d6a,13103,486604
-432990,Yasser,Larouci,Larouci,,,,,,,,592,,,0ed063d6,10041,554251
-433019,Liam,Hughes,Hughes,,,,,677,,,,,,54ae11f8,9404,494284
-433036,Tijjani,Reijnders,Reijnders,,,,,,,,,,427,afb61630,11965,460939
-433138,Marc,Leonard,Leonard,,,,,,654,,,,,bd8afa3d,10176,463751
-433154,Dwight,McNeil,McNeil,,646,534,97,100,118,534,259,230,300,fc15fb84,6756,584769
-433312,Marshall,Munetsi,Munetsi,,,,,,,,,770,648,2acf0cd7,7908,414908
-433589,Haydon,Roberts,Roberts,,,,,,560,122,,,,a731e8a0,9845,533523
-433590,Cody,Drameh,Drameh,,,,,694,562,547,,,,e0d1510a,9499,531957
-433952,Largie,Ramazani,Ramazani,,,,,,,,,,357,cc9256ef,10975,518644
-433979,Cameron,Archer,Archer,,,,,,568,54,33,27,,05e8ca6d,9912,533662
-434024,Patrik,Gunnarsson,Gunnarsson,,,,,,94,,,,,4d39152d,9688,429563
-434043,Alex,Robertson,Robertson,,,,,,,772,,,,3434ac72,11593,609887
-434044,Cieran,Slicker,Slicker,,,,,,615,,,280,,02aed921,10052,621997
-434138,Jordan,Stevens,Stevens,,,,,212,,,,,,7d3dc53e,,533913
-434399,Reinildo,Mandava,Reinildo,,,,,,,,,,541,c20bdcd7,7432,240692
-434662,Halil,Dervişoğlu,Dervişoğlu,,,,,,95,541,100,,,9d8cf204,9686,465606
-434752,Jaka,Bijol,Bijol,,,,,,,,,,344,6fdac234,6807,371851
-435973,Lyle,Foster,Foster,,,,,,,,168,,217,f84a807c,7498,467623
-435997,Noah,Okafor,Okafor,,,,,,,,,,698,ca607d59,11966,346890
-436234,Bryan,Gil Salvatierra,Bryan,,,,,,487,554,494,483,590,7b5ab7f2,7338,537382
-436416,Christos,Mandas,Mandas,,,,,,,,,,806,f794e9ab,12043,481675
-436680,Jakub,Stolarczyk,Stolarczyk,,,,,,,,,304,,a4a76b3d,13301,486144
-436893,Julián,Araujo Zúñiga,J.Araujo,,,,,,,,,592,78,8f4541c2,11745,513970
-437468,Sergio,Gómez,Sergio Gómez,,,,,,,587,366,,,01e5f06e,6656,366930
-437476,Braian,Ojeda Rodríguez,Ojeda,,,,,,,396,459,,,60953af0,,491596
-437495,Illan,Meslier,Meslier,,,,,213,199,238,,,339,6b625ac2,8715,542586
-437499,Maxence,Lacroix,Lacroix,,,,,,,,,650,257,277c49ed,8853,434224
-437505,Wilson,Isidor,Isidor,,,,,,,,,,560,a671316d,7148,494237
-437626,Nuno,Varela Tavares,Tavares,,,,,,466,17,23,,,a65c844b,9691,535955
-437688,Lewis,Richards,Richards,,,,,615,,,,,,ae0e6ba7,9082,571827
-437730,Antoine,Semenyo,Semenyo,,,,,,,714,82,78,82,efd2ec23,11363,583255
-437738,Sebastiaan,Bornauw,Bornauw,,,,,,,,,,345,01834aa0,7791,338629
-437742,Albert,Sambi Lokonga,Sambi,,,,,,478,18,21,,29,1b4f1169,9689,381967
-437748,Mike,Trésor Ndayishimiye,Trésor,,,,,,,,706,,214,b2a81fc6,12094,381963
-437753,Giulian,Biancone,Biancone,,,,,,,399,438,,,de40e38c,7282,536507
-437757,Han-Noah,Massengo,Massengo,,,,,,,,694,,,eba1e557,7264,536508
-437858,Vitor,Ferreira,Vitinha,,,,,515,,,,,,3b029691,8777,487469
-438098,Fábio,Ferreira Vieira,Fábio Vieira,,,,,,,25,4,1,23,6412cc03,11007,537598
-438234,Omar,Marmoush,Marmoush,,,,,,,,,755,413,0e0102eb,8393,445939
-438277,Ozan,Kabak,Kabak,,,,,652,580,,,,,2d61d13a,7376,361260
-438405,Billy,Crellin,Crellin,,,,,,,,863,,,1a85a237,12634,536794
-438464,Cheick,Doucouré,Doucouré,,,,,,,514,223,193,268,ce4f40c7,8666,543387
-439135,Eiran,Cashin,Cashin,,,,,,,,,763,154,f557c3b8,13459,581330
-439242,Taylor,Gardner-Hickman,Gardner-Hickman,,,,,701,,,,,,f05ee68d,9522,546944
-439482,Miguel,Azeez,Azeez,,,,,689,721,,,,,660e71be,9468,547533
-439483,Hubert,Graczyk,Graczyk,,,,,,,,,783,,aa41418a,13473,587018
-439485,Josh,Martin,Martin,,,,632,,330,,,,,3f072a68,8455,547534
-439509,Christos,Tzolis,Tzolis,,,,,,528,,,,,9f333379,9746,451677
-439510,Luke,Mbete-Tabu,Mbete,,,,,622,603,320,,,,387e1d35,9228,609883
-440089,Mikkel,Damsgaard,Damsgaard,,,,,,,580,98,89,121,215f3907,8859,540941
-440113,Aaron,Rowe,Rowe,,,607,,,,,,,,4b6bcb0d,7487,657994
-440120,Daniel,Chesters,Chesters,,,,,,710,,,,,240c8ab6,10424,561452
-440123,James,Furlong,Furlong,,,,,,,652,,,,ab18d1b0,11194,580030
-440148,Tyler,Morton,Morton,,,,,,620,,,331,395,2bc28bb9,10091,618494
-440241,Jensen,Weir,Weir,,,,,633,,,,,,2ae8e967,9252,520651
-440323,Armando,Broja,Broja,,,,631,,518,150,193,156,680,97220da2,8384,571743
-440854,Jakub,Kiwior,Kiwior,,,,,,,710,10,8,9,dc3e663e,10012,425918
-440955,Nazarii,Rusyn,Rusyn,,,,,,,,,,564,dab75831,,366729
-440993,Iliman,Ndiaye,Ndiaye,,,,,656,,,486,232,299,5ed97752,9307,623570
-441024,Harrison,Ashby,Ashby,,,,,,617,555,404,,482,b391383a,10061,559130
-441164,Pedro,Porro Sauceda,Pedro Porro,,,,,,,733,506,495,568,27d0a506,6912,553875
-441191,Tino,Livramento,Livramento,,,,,698,491,419,633,409,477,afed6722,9512,503981
-441192,Jeremy,Sarmiento Morante,Sarmiento,,,,,,612,119,146,141,171,ac0d576d,10036,568005
-441240,Romain,Faivre,Faivre,,,,,,,,799,66,92,745ca0a3,6420,555076
-441264,Brian,Brobbey,Brobbey,,,,,,,,,,730,4c184730,9789,473169
-441266,Ryan,Gravenberch,Gravenberch,,,,,,,,708,323,390,b8e740fb,10697,478573
-441271,Ki-Jana,Hoever,Hoever,,,,628,545,443,,556,552,638,9a71e978,8351,485583
-441302,Ian,Maatsen,Maatsen,,,,,,,,609,45,39,cab9634e,11807,485585
-441428,Jarell,Quansah,Quansah,,,,,,660,,626,333,,4125cb98,10187,632349
-441455,Victor,da Silva,Vitinho,,,,,,,,182,,,9295dc1c,11700,468249
-442229,Michał,Karbownik,Karbownik,,,,,663,536,,136,,,1b280c66,9320,401604
-442335,Edo,Kayembe,Kayembe,,,,,,679,,,,,f99b71de,10290,486477
-443211,Rhys,Norrington-Davies,Norrington-Davies,,,,,,,,487,,,ca76b087,12291,543164
-443261,Jack,Clarke,J.Clarke,,,,,,,,,631,,e16932d8,13019,559794
-443296,Theo,Corbeanu,Corbeanu,,,,,610,,,,,,25b82f9a,9209,568535
-443629,Marcelo,de Araújo Pitaluga Filho,Pitaluga,,,,,,656,,756,,,b3cafda8,10180,662334
-443661,Michael,Olise,Olise,,,,,,464,171,236,,,c4486bac,9948,566723
-443967,Junior,Firpo Adames,Firpo,,,,,,463,239,,,,24f59bb2,6485,374139
-444102,Francisco Evanilson,de Lima Barbosa,Evanilson,,,,,,,,,617,97,6f3cc2fe,12963,711337
-444145,Gabriel,Martinelli Silva,Martinelli,,,,504,26,26,19,12,9,19,48a5a5d6,7752,655488
-444172,Will,Dennis,Dennis,,,,,,,77,,599,68,d8edc4be,10748,582078
-444180,Jaidon,Anthony,Anthony,,,,,,,75,62,61,200,e4238fb1,10746,684210
-444181,Nnamdi,Ofoborh,Ofoborh,,,613,,,,,,,,76bca47e,7564,611906
-444183,Gavin,Kilkenny,Kilkenny,,,,565,,,,71,,,3eeda7dd,8172,469064
-444253,Jordan,Thomas,Thomas,,,,650,,,,,,,b547f08c,8518,563306
-444463,Wesley,Fofana,Fofana,,,,,561,220,272,201,189,230,132a82f1,7589,475411
-444575,Toby,King,King,,,,,706,,,,,,25671a6a,9542,614826
-444765,Sepp,van den Berg,Van den Berg,,,,,,,500,312,338,113,7bf9400b,10721,541231
-444880,Mika,Biereth,Biereth,,,,,,694,,,,,a1d95db3,10349,565821
-444884,Harvey,Elliott,Elliott,,,610,550,265,506,294,295,319,389,c8387671,7546,565822
-445044,Dejan,Kulusevski,Kulusevski,,,,,,701,446,501,492,583,df3cda47,6691,431755
-445122,Jurriën,Timber,J.Timber,,,,,,,,585,6,8,41034650,11707,420243
-445548,Odeluga,Offiah,Offiah,,,,,,712,736,845,139,,65c3efa2,10453,567597
-445550,Thomas,Dickson-Peters,Dickson-Peters,,,,,,649,,,,,f119a610,10171,566888
-445896,Kgaogelo,Chauke,Chauke,,,,,624,680,,,,,06791660,9232,703577
-446008,Bryan,Mbeumo,Mbeumo,,,,,,96,95,108,99,119,6afaebf2,6552,413039
-446189,Matej,Kovár,Kovár,,,,,,,615,,,,bc67a0e1,11069,550829
-446281,Tony,Springett,Springett,,,,,,716,,,,,35be8087,10525,570864
-447093,Allan,Tchaptchet,Tchaptchet,,,,,635,,,,,,ab7d7882,9257,465294
-447107,Ethan,Wady,Wady,,,,,,,771,,,,fe80cc4a,11584,573132
-447203,Darwin,Núñez Ribeiro,Darwin,,,,,,,297,293,316,397,4d77b365,10720,546543
-447235,Troy,Parrott,Parrott,,,,509,,,453,,,,4357f557,8145,552655
-447261,Mackenzie,Hunt,Hunt,,,,,,,,719,,,a7a688d7,12103,574420
-447325,Harry,Tyrer,Tyrer,,,,,682,616,,,,289,af49fb14,9411,574448
-447372,Ryan,Finnigan,Finnigan,,,,,655,,648,,,,9610c9c1,9309,807318
-447373,Shane,Flynn,Flynn,,,,,684,,,,,,862cc23f,9418,583258
-447715,Aaron,Ramsey,A.Ramsey,,,,,,496,,675,,211,e1618c22,9913,646658
-447720,Imari,Samuels,Samuels,,,,,,,765,,663,,8218e831,11571,565846
-447879,Joseph,Anang,Anang,,,,582,,,739,647,,,21a866b7,8223,576099
-447880,Josh,Wilson-Esbrand,Wilson-Esbrand,,,,,,604,322,,675,,c19a2df1,10005,576121
-447932,Jordan,Zemura,Zemura,,,,,,,76,,,,e8271ad9,10740,633530
-448047,Enzo,Fernández,Enzo,,,,,,,724,199,168,237,5ff4ab71,11356,648195
-448089,João Victor,Gomes da Silva,J.Gomes,,,,,,,721,559,553,646,8b57ad2c,11384,735570
-448104,Piero,Hincapié,Hincapie,,,,,,,,,,725,0c7a48f8,9911,659813
-448482,Robert,Street,Street,,,,,,542,,,,,b4390912,9736,703474
-448487,Andreas,Söndergaard,Söndergaard,,,,,617,444,,,,,43f9b4ba,9223,462820
-448496,Ed,Turns,Turns,,,,,,653,640,,,,9bbef03e,10178,580809
-448514,Rayan,Aït-Nouri,Aït-Nouri,,,,,563,470,487,545,533,402,9b398aea,6674,578391
-448791,Harvey,White,White,,,,634,,668,449,,,,4d90ce8c,8458,581598
-449027,Giorgi,Mamardashvili,Mamardashvili,,,,,,,,,,367,d4b73232,9693,502676
-449133,Harvey,Griffiths,Griffiths,,,,,,,658,787,,,6e4cb264,11209,670558
-449429,Jacob,Greaves,Greaves,,,,,,,,,270,,1f169636,12745,693095
-449434,Anthony,Elanga,Elanga,,,,,702,512,344,378,432,486,2fba6108,9524,583189
-449444,Mazeed,Ogungbo,Ogungbo,,,,,,719,,,,,bacf9d43,10541,581445
-449781,Alexandre,Jankewitz,Jankewitz,,,,649,643,,,,,,7c39363f,8511,507472
-449871,Amadou,Onana,Onana,,,,,,,577,261,233,59,828657ff,9667,485706
-449926,Adrián,Bernabé,Bernabé,,,,,537,,,,,,548672b4,8867,466802
-449974,Lukas,Jensen,Jensen,,,,641,,,,,,,47ed3795,8484,581890
-449988,Fábio,Soares Silva,Fábio Silva,,,,,504,445,488,552,545,655,e7aa9d7c,8778,505653
-450070,Crysencio,Summerville,Summerville,,,,,693,551,240,,587,615,df04eb4b,9492,474701
-450072,Shurandy,Sambo,Sambo,,,,,,,,,,196,4b1d5a70,,412937
-450197,George,Shelvey,G.Shelvey,,,,,,,749,636,,,5ab61aea,11462,565684
-450314,Matthew,Daly,Daly,,,606,,,,,,,,03e48abb,7458,566349
-450434,Deniz,Undav,Undav,,,,,,,123,149,143,,dd549382,10804,339314
-450527,Mohammed,Salisu,Salisu,,,,,479,351,420,,,,0b33f6ad,6923,563963
-450529,Lewis,Bate,Bate,,,,657,,624,241,,,,cd4256d3,8544,587003
-450535,Malcolm,Ebiowei,Ebiowei,,,,,,,173,224,197,277,fa9fa773,10698,512354
-450539,Myles,Peart-Harris,Peart-Harris,,,,,,662,,744,103,133,ea1a5662,10205,587002
-450541,Luke,Plange,Plange,,,,,,,496,237,,,2140e999,10699,586986
-450542,Jesurun,Rak-Sakyi,J.Rak-Sakyi,,,,,688,541,172,657,213,278,45685411,9461,586834
-450544,Charlie,Patino,Patino,,,,,,664,,,,,e71aac2c,10202,581674
-450550,Fin,Stevens,Stevens,,,,,,569,540,,,,7e003182,9916,587019
-450553,Alex,Kirk,Kirk,,,,,,730,,,,,ace36a62,10582,586980
-451302,Altay,Bayındır,Bayindir,,,,,,,,695,367,431,072e68ed,12054,336077
-451310,Jonathan,Tomkinson,Tomkinson,,,,,,643,,,,,4ba27cea,10162,696762
-451340,Mitoma,Kaoru,Mitoma,,,,,,,124,143,136,157,74618572,10806,504849
-451432,David,Mota Veiga Teixeira do Carmo,David Carmo,,,,,,,,,,509,3ce20eda,,498237
-453537,Carlos,Mendes Gomes,Mendes,,,,,,,,325,,,d90a63ec,,588412
-454667,Jens,Cajuste,Cajuste,,,,,,,,,619,,928a4a61,10301,468066
-455084,Leif,Davis,Davis,,,,,214,,,,267,,8574c61f,8919,596446
-456350,Gavin,Bazunu,Bazunu,,,,,,,422,,454,,c91441dc,10765,585550
-456512,Dan,Ndoye,Ndoye,,,,,,,,,,669,8e697a8f,8662,365108
-456966,Caleb,Watts,Watts,,,,,636,,,,,,c7170b46,9256,610665
-457569,Đorđe,Petrović,Petrović,,,,,,,,687,183,67,0cf321c8,12032,465555
-458249,Joshua,Zirkzee,Zirkzee,,,,,,,,,389,466,028e70b9,8044,435648
-458297,Pierre,Ekwah Elimby,Ekwah,,,,,,682,,,,556,830371be,10284,538994
-459373,Gonçalo Bento,Soares Cardoso,Cardoso,,,,594,,,,,,,47760615,8234,587106
-460028,Levi,Samuels Colwill,Colwill,,,,,,,559,197,162,227,700783e7,10805,614258
-460029,Nathan,Young-Coombes,Young-Coombes,,,,,,640,,,,,f9682888,10150,581679
-460842,Mohammed,Kudus,Kudus,,,,,,,,689,525,582,b62878a5,12027,543499
-461012,Cameron,Plain,Plain,,,,,,,649,,,,8c45f10e,11196,655136
-461013,Euan,Pollock,Pollock,,,,,,,706,,,,ea0271ee,11316,655142
-461017,Christian,Saydee,Saydee,,,,564,,,597,,,,af102dc3,8173,655835
-461023,Ryan,Alebiosu,Alebiosu,,,,,,695,,,,,ce048fb8,10350,610649
-461025,Nathan,Butler-Oyedeji,Butler-Oyedeji,,,,,,,685,,665,,3a686640,11272,638964
-461026,Chem,Campbell,Campbell,,,,,,548,568,,,,6f711f67,9741,614603
-461080,Joseph,McGlynn,McGlynn,,,,,,735,,,,,f6b1bcd6,10598,704801
-461096,Lewis,Richardson,Richardson,,,,,592,533,,,,,4fa62ae4,9082,657863
-461102,Bobby,Thomas,Thomas,,,,639,520,534,,179,,,6a471ee8,8483,788283
-461188,Bashir,Humphreys,Humphreys,,,,,,,673,671,,193,d2b32e91,11243,612517
-461195,Dennis,Cirkin,Cirkin,,,,655,,,,,,535,307ea3b6,8537,568006
-461199,Romaine,Mundle,Mundle,,,,,,,748,,,548,597610cd,11461,696181
-461201,Matthew,Craig,Craig,,,,,,729,764,,,,bc914523,10579,633659
-461212,Nile,John,John,,,,,710,,,,,,376d4a41,9555,581683
-461358,Julián,Álvarez,J.Alvarez,,,,,,,319,343,352,,15ab5a2b,10846,576024
-461382,John-Kymani,Gordon,Gordon,,,,668,,,634,658,,,d7e24aa1,8583,659331
-461416,Tom,Cannon,Cannon,,,,,,,662,649,286,,4506aec5,11232,669366
-461421,Lewis,Dobbin,Dobbin,,,,,,607,,624,37,57,e814e1cf,10027,627248
-461446,Tyler,Onyango,Onyango,,,,,644,630,,650,,704,d86a1f3e,9287,663225
-461450,Max,Thompson,Thompson,,,,640,591,,,,,,fa38722f,8480,598958
-461453,Lewis,Warrington,Warrington,,,,,,,561,841,,,8e633970,10775,652979
-461484,Joe,White,White,,,,,,599,,794,419,498,d60c03a9,9959,614811
-461508,Lucas,De Bolle,De Bolle,,,,,,707,,,,,430e09c0,10416,626291
-461529,Charlie,Savage,Savage,,,,,,737,,,,,e07398f8,10617,686837
-461533,Ademipo,Odubeko,Odubeko,,,,,638,,,,,,dcba03f6,9255,655880
-461537,Dermot,Mee,Mee,,,,,,,,835,788,435,caa32820,12531,620362
-461548,Zidane,Iqbal,Iqbal,,,,,,,551,,,,6fa3c28e,11173,686845
-461558,Maxwell,Haygarth,Haygarth,,,,,,628,,,,,2294d430,10114,596216
-461566,William,Fish,Fish,,,,,713,,,,,,b2ee9d2c,9557,640245
-461567,Owen,Dodgson,Dodgson,,,,,,565,,622,,189,2e590065,9827,686839
-461584,Wanya,Marçal-Madivádua,Marcal,,,,,,,735,,297,,6faae64f,11368,670988
-461585,Tawanda,Maswanhise,Maswanhise,,,,,703,,,,,,4f622ca3,9525,670987
-461587,Kasey,McAteer,McAteer,,,,,,647,687,,299,,b2c66859,10166,621193
-461682,Brandon,Aguilera Zamora,B.Aguilera,,,,,,,,434,,,938fa024,12034,631996
-462116,Jean-Clair,Todibo,Todibo,,,,,,,,,591,609,88f130ed,6816,605184
-462381,Filip,Marschall,Marschall,,,,,,650,670,670,46,35,a79abd8b,10173,610863
-462384,Jamal,Baptiste,Baptiste,,,,,669,554,,,,,41d3704d,9347,610706
-462387,Ali,Al-Hamadi,Al-Hamadi,,,,,,,,,260,,8450467d,12751,610581
-462424,William,Saliba,Saliba,,,,,27,27,26,20,18,6,972aeb2a,6888,495666
-462438,Micah,Hamilton,Hamilton,,,,,,,,771,,,0b059e15,12292,652797
-462491,Luke,Chambers,Chambers,,,,,,,563,726,,,7d6af698,10722,670861
-462492,Joe,Gauci,Gauci,,,,,,,,818,39,34,5600c774,12445,591844
-462635,Joe,Gelhardt,Gelhardt,,,,,667,577,242,,,360,01962d0d,9339,503980
-462831,Scott,Banks,Banks,,,,,,543,,,,,d01f8942,9737,596821
-463034,Liam,Delap,Delap,,,,,539,704,323,,268,250,dd897ee7,8868,610849
-463067,Georginio,Rutter,Georginio,,,,,,,700,,618,158,c64c01fc,6937,538977
-463210,Shea,Charles,Charles,,,,,,,773,348,458,,5cc3ce65,11594,747951
-463212,Carlos Roberto,Forbs Borges,Forbs,,,,,,,,,655,,8a310070,13092,742451
-463748,Karl,Hein,Hein,,,,,,532,655,646,5,3,aa81d8f8,9692,493513
-463903,Jesper,Lindstrøm,Lindstrøm,,,,,,,,,577,,37dc1a48,9752,513245
-463912,Elia,Caprile,Caprile,,,,,532,,,,,,97d7afbd,7087,421873
-463936,Jamie,Bynoe-Gittens,Gittens,,,,,,,,,,239,10745192,10542,670882
-463981,James,Hill,Hill,,,,,,,539,69,68,77,69942fb3,10747,611793
-464353,Harvey,Davies,Davies,,,,,,,592,,669,,fd08a24b,11028,706815
-464618,Liam,McCarron,McCarron,,,,,,576,,,,,076bb352,9933,614082
-465247,Senne,Lammens,Lammens,,,,,,,,,,733,8e6d2fcd,14056,503883
-465299,Anthony,Mancini,Mancini,,,,,612,736,,,,,bda82fc2,7168,677311
-465351,Matheus,Nunes,Matheus N.,,,,,,,589,566,356,407,e6af02e0,11000,601883
-465390,Kaine,Kesler-Hayden,Kesler-Hayden,,,,,671,684,,793,43,,9b066938,9409,626888
-465527,Hannibal,Mejbri,Hannibal,,,,,712,706,,383,373,207,ca22ccb0,9558,607224
-465551,Nigel,Lonwijk,Lonwijk,,,,,629,,,,,,17be8dc3,9248,566043
-465572,Reda,Khadra,Khadra,,,,,630,,,,,,88acf83f,9250,405686
-465607,Anssumane,Fati Vieira,Ansu Fati,,,,,,,,700,,,0ba976e4,7967,466810
-465642,Malick,Thiaw,Thiaw,,,,,,,,,,684,ff5ea0bf,8378,521964
-465680,Arnaud,Kalimuendo,Kalimuendo,,,,,,,,,,696,bf4c41f9,8056,585959
-465694,Nico,González Iglesias,N.Gonzalez,,,,,,,,,765,423,2c56a792,9802,466805
-465702,Timothée,Pembélé,Pembele,,,,,,,,,,540,f8ce97ca,8701,538998
-465730,Maxim,De Cuyper,De Cuyper,,,,,,,,,,145,d494882e,13711,429915
-465920,Mykhailo,Mudryk,Mudryk,,,,,,,699,210,179,245,049a888d,11305,537860
-466052,Rayan,Cherki,Cherki,,,,,,,,,,417,b34c63a5,8094,607223
-466075,Riccardo,Calafiori,Calafiori,,,,,,,,,578,7,aded8e6f,8129,502821
-466117,Naouirou,Ahamada,Ahamada,,,,,,,725,219,190,275,a6c58494,9274,538971
-466404,Andrew,Omobamidele,Omobamidele,,,,,,331,,711,440,,c393a6c4,9833,621993
-466525,Anton,Stach,Stach,,,,,,,,,,660,0f59a7bf,9910,344069
-466955,Brandon,Pierrick,Pierrick,,,,580,147,,,,,,9a526299,8216,703470
-467114,Oliver,Casey,Casey,,,,,215,,,,,,2d82641c,8724,559800
-467169,Antony,dos Santos,Antony,,,,,,,609,372,365,454,99127249,11094,602105
-467189,Mads,Hermansen,Hermansen,,,,,,,,,293,679,c924b17d,12910,400536
-467311,Matthew,Pollock,Pollock,,,,,,454,,,,,6681bcc8,,624948
-467779,Mats,Wieffer,Wieffer,,,,,,,,,149,173,4876c9ab,12758,415381
-468243,Kamil,Conteh,Conteh,,,,,,669,,,,,1d5c9842,10208,733494
-469130,Lorenzo,Lucca,Lucca,,,,,,,,,,805,83c06f3a,11936,572265
-469142,Jan Paul,van Hecke,Van Hecke,,,,,,,544,150,144,151,4fd08daa,10807,576314
-469247,Samuel,Iling-Junior,Iling Jr,,,,,,,,,41,51,ba492306,10616,581672
-469249,Nohan,Kenneh,Kenneh,,,,,,600,,,,,bc91e227,10000,581677
-469272,Loum,Tchaouna,Tchaouna,,,,,,,,,,210,a3c8b4d3,9977,607226
-470255,Caleb,Taylor,Taylor,,,,,700,,,,,,4ed3f5c4,9521,671074
-470294,Darko,Gyabi,Gyabi,,,,,,,247,,,361,56d838f7,10752,663264
-470296,Jeremiah,Chilokoa-Mullen,Chilokoa-Mullen,,,,,,,742,,,,3b57a494,11391,719681
-470313,Nick,Woltemade,Woltemade,,,,,,,,,,714,7ca196eb,8117,455661
-470315,Luca,Netz,Netz,,,,,,,,,,814,e79269bd,8401,524285
-471471,Imrân,Louza,Louza,,,,,,403,,,,,e1df6989,7278,635336
-471798,Gabriel,Słonina,Slonina,,,,,,,,215,,223,c55a846e,13854,656316
-471848,Femi,Seriki,Seriki,,,,,705,,,653,,,e4e0deaa,9540,638649
-472464,Shola,Shoretire,Shoretire,,,,,673,727,660,399,,,00f0482f,9359,640026
-472713,Aaron,Hickey,Hickey,,,,,,,510,104,93,116,1780bb4a,8942,591949
-472739,Carl,Rushworth,Rushworth,,,,,,,,,615,141,810912d5,12760,646353
-472769,Nico,O'Reilly,O'Reilly,,,,,,,774,,607,411,91ca4a16,11592,743413
-473341,Caleb,Okoli,Okoli,,,,,,,,,301,,8ec109e6,7333,461833
-473342,Stuart,McKinstry,McKinstry,,,,,,601,,,,,1000a059,10001,592474
-474003,Leonardo,Campana,Campana,,,,652,476,,,,,,bf9c0749,8529,606872
-474120,Julio,Enciso Espínola,Enciso,,,,,,,125,130,121,161,9cfbad36,11058,660867
-474772,Ben,Greenwood,Greenwood,,,,,,,737,619,,,7eda24fe,11364,646333
-474803,Eddie,Beach,Beach,,,,,,,,680,,,7cbd6d68,11979,732120
-474907,Reece,Welch,Welch,,,,,690,623,605,,803,298,a182122b,9469,655986
-474908,Jadan,Raymond,Raymond,,,,,,,,724,,,9ad8d732,12138,655815
-475123,Carlos Miguel,dos Santos Pereira,C.Miguel,,,,,,,,,427,503,84454067,12764,641458
-475168,João Pedro,Junqueira de Jesus,João Pedro,,,,592,,404,,135,129,249,e8832875,8272,626724
-475480,Benicio,Baker-Boaitey,Baker-Boaitey,,,,,,,,742,114,,4c5835e6,12204,657817
-475492,Oliver,Hammond,Hammond,,,,,,,553,,,,3766178e,10763,646214
-476161,Lewis,Payne,Payne,,,,,,,647,,,,32e9d210,11190,744131
-476344,Jhon,Durán,Duran,,,,,,,711,44,38,,414184f7,11366,649317
-476369,Issa,Kaboré,Kaboré,,,,,,,,602,626,,c066d1a5,9619,649452
-476502,Boubacar,Traoré,B.Traore,,,,,,,629,574,534,649,999ceb5f,8119,649020
-476887,Dilane,Bakwa,Bakwa,,,,,,,,,,734,2b5a35e5,8920,540664
-476888,Sékou,Mara,Mara,,,,,,,528,,468,,3544641e,8970,557612
-476938,Ismaila,Coulibaly,Coulibaly,,,,,,,,478,,,d33e3242,11999,490224
-477064,Rico,Lewis,Lewis,,,,,,,573,358,355,410,b57e066e,10847,701057
-477386,Armel,Bella-Kotchap,Bella-Kotchap,,,,,,,423,,456,,a39d11bc,9710,467563
-477424,Joško,Gvardiol,Gvardiol,,,,,,,,616,350,403,5ad50391,9790,475959
-477547,Leo Fuhr,Hjelde,Hjelde,,,,,,608,243,,,536,d102b8a2,10028,661208
-477555,Oscar,Bobb,Bobb,,,,,,,,345,343,424,eed2427e,11903,661207
-477580,Illia,Zabarnyi,Zabarnyi,,,,,,,722,89,85,71,88968486,11486,659089
-477717,Maxime,Estève,Estève,,,,,,,,806,,191,1a066e69,9487,842341
-477733,Radek,Vítek,Vítek,,,,,,,,669,,,d617bff6,11874,622236
-477851,Abdoullah,Ba,Ba,,,,,,,,,,554,3f651f34,,654412
-478028,Kayky da Silva,Chagas,Kayky,,,,,,663,,,,,17734ea0,10203,668265
-478227,Stefan,Parkes,Parkes,,,,,,,636,,,,66b290f7,11145,657724
-478449,Kyron,Gordon,Gordon,,,,,646,,,,,,f4aba1af,9289,746734
-478912,Carney,Chukwuemeka,Chukwuemeka,,,,,672,526,48,196,161,,b2f9c73e,9356,659459
-478969,Hjalmar,Ekdal,Ekdal,,,,,,,,167,,190,f503ea63,11704,392179
-479641,Sebastian,Revan,Revan,,,,,,,754,,,,8525ec2a,11497,667925
-479683,Marcus,Oliveira Alencar,Marquinhos,,,,,,,27,11,,,59878425,11035,668268
-480216,Mateusz,Bogusz,Bogusz,,,,,533,,,,,,a2c1d8c2,8817,431475
-480455,Jarrad,Branthwaite,Branthwaite,,,,637,170,544,196,245,219,290,c1949191,8476,661053
-480818,Billy,Koumetio,Koumetio,,,,,697,,,,,,866c67e9,9513,696324
-481283,James,Wright,Wright,,,,,,,753,778,,688,9417a430,11488,712181
-481371,Zak,Brunt,Brunt,,,,,657,,,,,,a31f0ebf,9308,746777
-481405,Mads,Bidstrup,Bidstrup,,,,,,97,99,94,,,407db0d5,9682,462832
-481510,Victor,Kristiansen,Kristiansen,,,,,,,709,,296,,505486d6,11367,564529
-481624,Jaden,Philogene,Jaden,,,,,683,497,55,54,569,,19f4d211,9415,665390
-481626,Christian,Marques,Marques,,,,,616,549,,,,,a7cf1541,9215,539807
-481655,Martín,Zubimendi Ibáñez,Zubimendi,,,,,,,,,,26,3ee0dd59,7526,423440
-482158,Lucas,Bergström,Bergström,,,,,,,,659,154,,b59c2a92,11809,490606
-482442,Pape Matar,Sarr,P.M.Sarr,,,,,,,450,513,499,593,feb5d972,9021,568693
-482609,Malo,Gusto,Gusto,,,,,,,,203,171,228,d56b9520,9017,620322
-482769,Máximo,Perrone,Perrone,,,,,,,712,363,,,53552942,11378,668547
-482973,Igor Jesus,Maciel da Cruz,Igor Jesus,,,,,,,,,,526,dbe24cce,13778,432164
-483081,Rodrigo,Martins Gomes,R.Gomes,,,,,,,,,563,635,8dcf77c0,12756,667121
-483364,Krisztián,Hegyi,Hegyi,,,,,,,740,,,602,2411c7f7,11369,543726
-483365,Jonathan,Rowe,Rowe,,,,,,648,,,,,8c12f884,10172,672381
-483391,Luke,McNally,McNally,,,,,,,,171,,,22a93e73,,535927
-483398,Matthew,Whittingham,Whittingham,,,,,,,,749,,,cd84f0e3,12235,908798
-484420,Enzo,Le Fée,E.Le Fée,,,,,,,,,,547,c79f7793,8651,633992
-484658,Kacper,Kozłowski,Kozlowski,,,,,,,126,137,130,,3ece036c,,554284
-485047,Felipe,Rodrigues da Silva,Morato,,,,,,,,,653,511,0f41e2ee,13068,673492
-485055,Antonín,Kinský,Kinsky,,,,,,,,,716,567,b38ac6a4,13348,725912
-485337,Evann,Guessand,Guessand,,,,,,,,,,677,b73f17f8,8006,500689
-485711,Benjamin,Sesko,Šeško,,,,,,,,,,681,3260690c,11974,627442
-486385,Norberto Bercique,Gomes Betuncal,Beto,,,,,,,,691,218,311,ed5c0319,9983,595809
-486520,Ilia,Gruev,Gruev,,,,,,,,,,356,1fc4f3d1,8000,381753
-486623,Sean,McAllister,McAllister,,,,,,,768,,,,66c0246b,11575,720720
-486672,Moisés,Caicedo Corozo,Caicedo,,,,,664,538,120,126,157,241,16264a81,9453,687626
-486870,Frederik,Alves,Alves,,,,,637,521,,,,,95827107,9254,542690
-487053,Destiny,Udogie,Udogie,,,,,,,,519,505,574,7cd520e8,8831,556385
-487117,Evan,Ferguson,Ferguson,,,,,,655,596,132,123,179,4596da74,10177,648046
-487676,Trai,Hume,Hume,,,,,,,,,,532,4fa3a3a4,13713,515544
-487693,Devan,Tanton,Tanton,,,,,,,,732,,,3c256bb1,12176,745452
-487702,Luca,Koleosho,Koleosho,,,,,,,,605,,208,fc076f78,10620,745461
-487818,Joe,Whitworth,Whitworth,,,,,,,590,243,,,3f847d95,11005,670840
-487828,Omari,Forson,Forson,,,,,,,,632,,,1b9728b0,12340,670845
-487835,Benjamin,Chrisene,Chrisene,,,,,,703,,,,,b17008fc,10406,670846
-487836,Antwoine,Hackford,Hackford,,,,,618,,,656,,,a7588cdc,9222,670859
-487837,Divin,Mubama,Mubama,,,,,,,669,538,698,,92868cb5,11242,670848
-487838,Lewis,Hall,Hall,,,,,,671,661,204,399,473,da011f18,10216,670858
-487968,Ameen,Al-Dakhil,Al-Dakhil,,,,,,,,157,,,93e08bce,11699,620598
-488024,Yéremy,Pino Santos,Yeremy,,,,,,,,,,712,540ec57b,9024,568157
-488213,Tolu,Arokodare,Tolu,,,,,,,,,,720,a42760bc,8875,683571
-488404,Facundo,Pellistri Rebollo,Pellistri,,,,,575,,347,394,384,,ac7e7b1c,9324,676318
-488439,Woyo,Coulibaly,Coulibaly,,,,,,,,,726,,beb6e3a6,12782,592975
-488464,Caleb,Wiley,Wiley,,,,,,,,,575,,64796fe0,12837,746833
-489571,Etienne,Green,Green,,,,,,,,,,184,667b65da,9294,696849
-489580,Calvin,Ramsay,Ramsay,,,,,,,298,,,380,919acea0,11214,633652
-489639,Bart,Verbruggen,Verbruggen,,,,,,,,152,146,139,cf134113,11711,565093
-489706,Justin,Devenny,Devenny,,,,,,,,,645,276,6c2b66fc,13038,747009
-489888,Amine,Adli,Adli,,,,,,,,,,697,dcfb17f4,8211,532776
-490000,Blondy,Nna Noukeu,Nna Noukeu,,,,,,,,,,530,9b526c28,,696892
-490094,Tim,Iroegbunam,Iroegbunam,,,,,709,638,49,46,226,304,84c5ceea,9554,696589
-490095,Ty,Barnett,Barnett,,,,,,,,770,,,c68c6838,12290,751666
-490098,Kaine,Hayden,Hayden,,,,659,,,,,,,9b066938,9409,626888
-490138,Jakub,Ojrzynski,Ojrzynski,,,,,678,,,,,,94e5390a,9405,540630
-490142,Freddie,Potts,Potts,,,,,,,,,,623,86bf27f0,13724,698164
-490145,Dane,Scarlett,Scarlett,,,,,666,520,447,640,500,599,21945a9e,9332,670883
-490146,Jay,Stansfield,Stansfield,,,,,,,219,651,256,,b2626673,10718,696346
-490150,Michael,Ndiweni,Ndiweni,,,,,,,,745,,,8aff2b51,12215,698151
-490161,Abu,Kamara,Kamara,,,,,,715,,,,,a6fbfa77,10526,696764
-490180,Aribim,Pepple,Pepple,,,,,,,,331,,,94c53a55,,696502
-490503,Samuel,Edozie,Edozie,,,,,,508,624,,459,,007414dd,10072,680806
-490721,Hugo,Bueno López,H.Bueno,,,,,649,635,558,548,549,633,bfc3b3a0,10140,698678
-490881,Toby,Collyer,Collyer,,,,,,,,826,613,460,4f9091bc,12461,654253
-490885,George,Earthy,Earthy,,,,,,,,829,519,620,123d2733,12474,697280
-490887,Zach,Awe,Awe,,,,,,705,,,,,7a0ae4f0,10407,697282
-491007,Dário,Luís Essugo,D.Essugo,,,,,,,,,,247,1e4319ac,13094,670717
-491008,Diogo,Pinheiro Monteiro,Monteiro,,,,,,,743,,,,17850779,11390,670713
-491011,Diego Manuel Jadon,da Silva Moreira,Diego Moreira,,,,,,,,681,,,12de1b0d,11978,655006
-491012,Youssef,Ramalho Chermiti,Y.Chermiti,,,,,,,,645,237,312,890f108d,11984,670688
-491279,Micky,van de Ven,Van de Ven,,,,,,,,639,506,575,8fe2a392,10050,557459
-491287,Enzo,Barrenechea,Barrenechea,,,,,,,,,30,56,6caffe81,11140,671915
-491501,James,McConnell,McConnell,,,,,,,,629,330,394,bf973eeb,11811,845289
-491551,Thierry,Small,Small,,,,,,667,,,,,6f487e5d,10206,746554
-491556,Charlie,Whitaker,Whitaker,,,,,,613,,,,,08288a57,10033,726992
-491557,Jenson,Metcalfe,Metcalfe,,,,,,,,760,614,309,5c2595e2,12269,855890
-491559,Isaac,Price,Price,,,,,691,718,678,,,,b9403c99,9470,612749
-491598,Cameron,Peupion,Peupion,,,,,,,762,786,140,,0bdeb013,11544,703626
-491745,Elijah,Campbell,Campbell,,,,,,,,761,,705,48ba3f58,12270,747598
-491785,Harvey,Vale,Vale,,,,,,672,606,,,,a70182a5,10215,581675
-491970,Bobby,Clark,Clark,,,,,,,584,627,315,,73341ace,10997,712117
-492066,Niall,Huggins,Huggins,,,,,619,,,,,537,6d646ff7,9219,559801
-492368,Isaac,Schmidt,Schmidt,,,,,,,,,,349,f8b9b94d,13974,449597
-492373,Charlie,Cresswell,Cresswell,,,,,620,563,,,,,4654e5f5,9220,597659
-492374,Jack,Jenkins,Jenkins,,,,,599,631,,,,,3d46127c,9102,734375
-492776,Dexter,Lembikisa,Lembikisa,,,,,,,664,,,,0bdda685,11233,712099
-492777,Conor,Bradley,Bradley,,,,,,626,,757,313,375,bbd67769,10120,624258
-492779,Yago,de Santiago Alonso,Yago Santiago,,,,,,,777,754,,,88b3215c,11617,706947
-492831,Zeki,Amdouni,Amdouni,,,,,,,,594,,216,2ee5b0c9,11701,548729
-492859,Wilfried,Gnonto,Gnonto,,,,,,,619,,,351,75fdd638,11155,627626
-493105,Alejandro,Garnacho Ferreyra,Garnacho,,,,,,723,569,382,372,453,7aa8adfe,10552,811779
-493121,Roshaun,Mathurin,Mathurin,,,,,,,,842,,,c036048e,12548,706822
-493125,Radu,Drăgușin,Dragusin,,,,,,,,777,486,572,620922ed,9105,568559
-493250,Amad,Diallo,Amad,,,,,640,636,550,371,364,452,9dc96f10,8127,536835
-493347,Denis,Franchi,Franchi,,,,,,,,169,,,aab362e6,9475,606576
-493362,Xavi,Simons,Xavi,,,,,,,,,,717,da4d670f,8700,566931
-493736,Jimmy,Morgan,Morgan,,,,,,,671,,,,f9d409a1,11239,936867
-493837,Jay,Matete,Matete,,,,,,,,,,558,7748a7c5,,535479
-493928,Marcelo,Flores,Flores,,,,,,720,,,,,937b36b1,10540,668495
-493934,Kwadwo,Baah,Baah,,,,,,405,,,,,f240e4f2,9846,711247
-494041,Ethan,Brierley,Brierley,,,,,,,,684,87,,c2c5ecda,11986,718250
-494307,Max,Alleyne,Alleyne,,,,,,,,,703,794,5383979b,13298,843595
-494521,Adrien,Truffert,Truffert,,,,,,,,,,74,5d0e0a1f,8640,654539
-494541,Kamari,Doyle,Doyle,,,,,,,769,,,,65983e4d,11582,864480
-494543,Dominic,Ballard,Ballard,,,,,,,770,,,,ed8d597c,11583,864496
-494551,Jayden,Moore,Moore,,,,,,,,,804,,ed23d14e,13648,1122027
-494556,Ollie,Shield,Shield,,,,,,,,,,819,16173169,14483,1211262
-494595,Florian,Wirtz,Wirtz,,,,,,,,,,382,e7fcf289,8397,598577
-494779,Albert,Grønbæk,Grønbæk,,,,,,,,,734,,0da5076f,12880,503866
-494960,Quilindschy,Hartman,Hartman,,,,,,,,,,192,39e1138f,13727,514285
-495024,Jay,Robinson,Jay Robinson,,,,,,,,,798,,2a616c85,13582,1045124
-495145,Alex,Paulsen,Paulsen,,,,,,,,,75,70,2da46a72,,617009
-495161,Marko,Stamenić,Stamenic,,,,,,,,,,524,690d1049,,617018
-495542,Niels,Nkounkou,Nkounkou,,,,,559,570,198,,,,f5b281e7,8109,591193
-496178,Roman,Dixon,Dixon,,,,,,,,,627,297,82e2cc75,12946,856479
-496179,Alfie,Devine,Devine,,,,,650,714,452,,485,,ba08056d,9306,728734
-496185,Kaide,Gordon,Gordon,,,,,,625,,783,,,19a9cb70,10118,732119
-496208,Ben,Gannon-Doak,Gannon-Doak,,,,,,,665,628,318,391,733f1a7d,11231,719673
-496221,Adam,Wharton,Wharton,,,,,,,,807,216,273,4b542852,12409,744149
-496222,Zak,Sturge,Sturge,,,,,,,,859,,,1095aec1,12602,801472
-496228,Sonny,Perkins,Perkins,,,,,,634,663,,,,87f12e30,10141,670877
-496279,Isaac,Heath,Heath,,,,,,,,,773,308,b54c480e,13457,847579
-496283,Mahamadou,Susoho,Susoho,,,,,,,,762,,,6cdd9d3d,12268,895074
-496661,Tyler,Dibling,Dibling,,,,,,731,,,608,707,bdcc89ae,10586,866655
-496683,Max,Kinsey,Kinsey,,,,,,,738,802,680,,ed46ab76,11365,939615
-497605,Liam,Gibbs,Gibbs,,,,,,683,,,,,e4b6d914,10285,724785
-497606,Tawanda,Chirewa,Chirewa,,,,,,,,750,538,650,34721c11,12234,724783
-497894,Rasmus,Højlund,Højlund,,,,,,,,617,375,465,491a433d,11055,610442
-497949,David,Møller Wolfe,Møller Wolfe,,,,,,,,,,682,9affc5f2,13740,661427
-498016,Robin,Roefs,Roefs,,,,,,,,,,670,349fa918,13712,646991
-498046,Salah-Eddine,Oulad M'hand,Oulad M'hand,,,,,,693,,,638,,b85c3273,10351,559330
-499167,Josh,Nichols,Nichols,,,,,,,,,662,15,676cf55d,13115,964554
-499169,Myles,Lewis-Skelly,Lewis-Skelly,,,,,,,,764,597,10,5dff6c28,12272,890721
-499175,Ethan,Nwaneri,Nwaneri,,,,,,,630,772,12,25,7f94982c,11132,890719
-499300,Adam,Aznou,Aznou,,,,,,,,,,667,e678d983,12371,938146
-499309,Marc,Guiu Paz,Marc Guiu,,,,,,,,,178,252,d3d774cc,11633,938158
-499604,Rayan Vitor,Simplício Rocha,Rayan,,,,,,,,,,807,288647fc,14395,1012564
-499716,James,Rowswell,Rowswell,,,,,,,,,,750,419147f7,14176,999743
-499717,Jayden,Meghoma,Meghoma,,,,,,,,,649,118,07382f6c,13067,954104
-499721,Mikey,Moore,Moore,,,,,,,,860,610,592,00953a9d,12603,1011147
-499724,Samuel,Amo-Ameyaw,Amo-Ameyaw,,,,,,,778,,451,,9eedf0e0,11618,933900
-499726,Callum,Olusesi,Olusesi,,,,,,,,,683,595,d6455444,13224,985546
-499857,Teddy,Sharman-Lowe,Sharman-Lowe,,,,,,,,847,,803,7cd31238,12561,731466
-500016,Welington Damascena,Santos,Welington,,,,,,,,,718,,a7f95b1f,13403,729264
-500040,Cristhian,Mosquera,Mosquera,,,,,,,,,,662,dc1ce4f5,10024,646750
-500052,Luca,Barrington,Barrington,,,,,,,,755,,,85d7679f,12246,745689
-500058,Jayden,Danns,Danns,,,,,,,,824,709,398,003cf4d1,12455,939290
-500151,Nicolò,Savona,Savona,,,,,,,,,,716,e041497d,12905,708072
-500267,Loïc,Badé,Badé,,,,,,,621,,,,114bbdee,8665,730581
-500696,Nectarios,Triantis,Triantis,,,,,,,,,,559,73d58203,,957224
-500926,Ronnie,Edwards,Edwards,,,,,,,,,460,,be90c4b0,13239,732165
-501284,Michael,Olakigbe,Olakigbe,,,,,,,752,620,,,cdd70dc0,11487,734425
-501468,Tayo,Adaramola,Adaramola,,,,,,709,766,763,,,c150b220,10429,724529
-501620,Dante,Cassanova,Cassanova,,,,,,,,,760,,0b8373bb,13409,738269
-501770,Ben,Nelson,Nelson,,,,,,645,,,616,,7be10897,10167,714458
-501837,Yerson,Mosquera Valdelamar,Mosquera,,,,,,446,494,788,558,634,1e159d70,9958,716276
-502222,Ramón,Sosa,Sosa,,,,,,,,,620,,2d3417a1,13021,745191
-502500,Igor Thiago,Nascimento Rodrigues,Thiago,,,,,,,,,107,136,dc45ac24,13222,739443
-502697,Carlos,Alcaraz Durán,Alcaraz,,,,,,,693,,450,301,4abac767,11297,748319
-502988,Danny,Imray,Imray,,,,,,,,,,798,c1395580,14355,862109
-503139,Alex,Scott,Scott,,,,,,,,644,77,90,104d0bb8,12149,855256
-503300,Matthew,Cox,Cox,,,,,,619,633,97,,103,fea06849,10093,741236
-503301,Omari,Hutchinson,Hutchinson,,,,,,692,653,,274,693,bd9553e6,10348,741238
-503308,James,Sweet,Sweet,,,,,,,,817,,,d4632cfa,12444,583952
-503714,Lesley,Ugochukwu,Ugochukwu,,,,,,,,613,188,676,1df4a109,9451,711999
-503724,Lorenz,Assignon,Assignon,,,,,,,,805,,,b026bbf6,8973,711969
-504198,Anis,Slimane,Slimane,,,,,,,,587,,,9ade9ce1,11730,546712
-504296,Coby,Ebere,Ebere,,,,,,,,,775,307,61a42f10,13462,1018714
-504598,Daniel,Gore,Gore,,,,,,,,685,,,861e9b3b,11987,747153
-504750,Justin,Hubner,Hubner,,,,,,,,751,,,f233ed69,12236,678641
-504751,Mauro,Bandeira,Bandeira,,,,,,,767,815,,,9b67eca8,11578,745846
-504783,Kamaldeen,Sulemana,Kamaldeen,,,,,,,731,,462,,a62f8bf1,9630,746695
-505079,Alfie,McNally,McNally,,,,,,,,,,786,419fba9c,14308,747950
-505187,Cesare,Casadei,Casadei,,,,,,,,791,158,,fb920f3a,10433,622380
-505265,Cheikh,Diaby,Diaby,,,,,621,,,,,,45787ffa,9224,592988
-507433,Hákon Rafn,Valdimarsson,Valdimarsson,,,,,,,,789,109,105,57a34cf4,12595,488935
-508395,Yehor,Yarmoliuk,Yarmoliuk,,,,,,,,120,111,129,907a5d7c,11772,717411
-508479,Filip,Jörgensen,Jörgensen,,,,,,,,,581,221,0107757e,9272,585323
-509291,André,Trindade da Costa Neto,André,,,,,,,,,642,643,ec604e2c,13022,800176
-509416,Yasin,Ayari,Ayari,,,,,,,719,124,600,166,f173303a,11385,667287
-510281,Sávio,Moreira de Oliveira,Savinho,,,,,,,,,571,415,fe6e7156,11735,743591
-510328,Stanley,Mills,Mills,,,,,,,560,,,,c0a454d5,10776,801005
-510362,Toti,Gomes,Toti,,,,,,685,489,573,567,637,f0caab96,10293,606718
-510363,Francisco Jorge,Tomás Oliveira,Chiquinho,,,,,,689,490,549,537,,dc6c2f02,10327,695454
-510500,João Pedro,Ferreira da Silva,Jota,,,,,,,,,596,518,4d77e622,12766,663244
-510663,Hugo,Ekitiké,Ekitiké,,,,,,,,,,661,5b92d896,8995,709726
-511499,Mathys,Tel,Tel,,,,,,,,,768,584,829aa60c,9780,801734
-511504,Kristian,Sekularac,Sekularac,,,,,,,667,796,,,e20a28ce,11237,539810
-511783,Anass,Zaroury,Zaroury,,,,,,,,184,,,07d65234,11703,491296
-512462,Jake,O'Brien,O'Brien,,,,,,,,235,582,293,25f2ef01,12014,711544
-513046,Danilo,dos Santos de Oliveira,Danilo,,,,,,,703,442,429,,a816dbfb,11317,808509
-513418,Kevin,Schade,Schade,,,,,,,688,115,106,120,52afb588,9156,473050
-513433,Brajan,Gruda,Gruda,,,,,,,,,595,162,ae9b998d,11310,700106
-513466,Merlin,Röhl,Röhl,,,,,,,,,,728,1f2c7b55,11331,608832
-513527,Bilal,El Khannouss,El Khannouss,,,,,,,,,635,,f7042636,13020,654982
-513588,Jamie,Donley,Donley,,,,,,,,722,,,5e4d9b48,12118,796305
-513789,Thanawat,Suengchitthawon,Suengchitthawon,,,,,687,,,,,,7a6bb9ed,9446,427691
-513834,Andrew,Moran,Moran,,,,,,,651,,601,177,c4720845,11193,724537
-513836,Leigh,Kavanagh,Kavanagh,,,,,,,,753,,,e16986b1,12242,724530
-513840,Samy,Chouchane,Chouchane,,,,,,,,843,,,6c1ebbc8,12554,756591
-513852,Kris,Moore,Moore,,,,,,657,,,,,b660a486,10185,746067
-514154,Ben,Jackson,Jackson,,,,,,,,746,,,0cd9c796,12216,801474
-514229,Sam,Waller,Waller,,,,,,708,,,,,8ee48565,10428,733430
-514254,Diego,Gómez Amarilla,Gomez,,,,,,,,,714,169,916728da,13364,996897
-514277,Jimi,Tauriainen,Tauriainen,,,,,,,,830,,,cac9e583,12497,681615
-514280,Alfie,Gilchrist,Gilchrist,,,,,,,775,716,170,,d91f104d,11595,790992
-514284,Joe,Wormleighton,Wormleighton,,,,,,,645,,,,59d2e6bb,11181,814524
-514287,Sil,Swinkels,Swinkels,,,,,,,744,,640,,a42f6058,11393,646710
-514307,Jack,Henry-Francis,Jack Henry-Francis,,,,,,,,,793,,e93d8ed1,13587,796024
-514315,Lino,da Cruz Sousa,Sousa,,,,,,,631,,56,45,e09d77a2,11133,743414
-514356,Roméo,Lavia,Lavia,,,,,,605,321,667,174,244,ecad9aa5,10004,628451
-514362,Temple,Ojinnaka,Ojinnaka,,,,,,,,853,,777,4e93ceb2,12575,813142
-514514,Lewis,Koumas,Koumas,,,,,,,,812,,,d77edba6,12434,922462
-514613,Zak,Johnson,Johnson,,,,,,,,,,538,67cd6d8d,,827440
-515023,Matthew,Dibley-Dias,Dibley-Dias,,,,,,,763,652,,,979cb300,11553,817611
-515024,Luke,Harris,Harris,,,,,,,546,683,246,334,42dd1b56,10719,817612
-515046,Melker,Ellborg,Ellborg,,,,,,,,,,812,013d348e,,605426
-515496,Owen,Goodman,Goodman,,,,,,,644,,,,8074e66f,11180,814848
-515500,Rhys,Bennett,Bennett,,,,,,,674,768,,,50c7de8f,11244,794816
-515501,Álvaro,Fernández Carreras,Fernandez,,,,,,728,,380,,,f127d782,5191,453704
-515503,Jack,Wells-Morrison,Wells-Morrison,,,,,,,654,,,,a71ebcc8,11192,814811
-515504,Joe,Hugill,Hugill,,,,,,,,748,,,49134eb2,12224,726859
-515571,Juan,Larios López,Larios,,,,,,,622,,464,,cf7fb13a,11078,646738
-515597,Lamare,Bogarde,Bogarde,,,,,,610,638,,598,44,bca5c4a7,10025,645686
-515599,Tommi,O'Reilly,O'Reilly,,,,,,713,761,767,,,345fc437,10454,818237
-515621,Chadi,Riad Dnanou,Chadi Riad,,,,,,,,,195,262,b3b9b8b8,11167,689637
-516159,Oliwier,Zych,Zych,,,,,,,745,686,641,,be18d79f,11394,555074
-516211,Abdallah,Sima,Sima,,,,,,,,,,165,fdbde523,11046,776798
-516234,Charlie,Gray,Gray,,,,,,,,,,763,59429fa1,14255,1033103
-516250,Jacob,Wright,Wright,,,,,,,,814,671,,b6db05c3,12427,983702
-516432,Valintino,Adedokun,Adedokun,,,,,,,,733,,,1b5344ef,12179,747996
-516874,Charles,Sagoe,Sagoe,,,,,,,,735,,,187ab096,12195,796037
-516875,Ronnie,Hollingshead,Hollingshead,,,,,,,,,,757,74ab11a7,14218,667490
-516895,Kobbie,Mainoo,Mainoo,,,,,,,643,388,378,458,c6220452,11174,820374
-516939,Emmanuel,Agbadou,Agbadou,,,,,,,,,720,631,75f1ed80,10856,683895
-517052,Nicolas,Jackson,N.Jackson,,,,,,,,211,180,251,9c36ed83,10048,776890
-517178,Elkan,Baggott,Baggott,,,,,,,,,261,,a0e00e23,,758030
-517179,Alfie,Pond,Pond,,,,,,,,,664,641,039c3d96,13117,821522
-517995,Leo,Castledine,Castledine,,,,,,,,758,,,1c86192d,12247,796303
-517996,Ronnie,Stutter,Stutter,,,,,,,,717,,,e3f9e68a,12085,825024
-518030,Max,Weiß,Weiss,,,,,,,,,,183,882228c2,13731,829299
-518199,Fabian,Mrozek,Mrozek,,,,,,,,813,,,927eecf9,12433,678402
-518335,Max,Merrick,Merrick,,,,,,,,,,789,420d18fe,14317,827435
-518438,Kaelan,Casey,Casey,,,,,,,746,774,643,611,cd4b2c5f,11409,845321
-518442,Lewis,Orford,Orford,,,,,,,,773,701,622,40aaa04c,12296,845809
-518466,Willy,Kambwala,Kambwala,,,,,,,,766,,,6a7353d7,12275,780630
-518467,Marc,Jurado Gomez,Jurado,,,,,,,759,,,,c1d75f69,11518,709960
-518504,James,Storer,Storer,,,,,,621,,,,,257b20e1,10103,838367
-518620,Ângelo Gabriel,Borges Damaceno,Ângelo,,,,,,,,589,151,,737945d9,11818,743598
-518892,Ted,Curd,Curd,,,,,,,,858,,,d9bd6f58,12596,857792
-518906,Owen,Bevan,Bevan,,,,,,,598,,,76,87966294,11034,583990
-519198,Alex,Matos,Matos,,,,,,,,718,,,ed383e43,12086,670850
-519223,Sammy,Braybrooke,Braybrooke,,,,,,,639,,802,,9f684e25,11160,840640
-519321,Alfie,Dorrington,Dorrington,,,,,,,,740,699,,ac1ef440,12193,796300
-519324,Amario,Cozier-Duberry,Cozier-Duberry,,,,,,,668,,118,,04eb7d82,11241,878150
-519325,Habeeb,Ogunneye,Ogunneye,,,,,,,,833,,,d0cdc0a3,12520,864788
-519327,George,Abbott,Abbott,,,,,,,758,,,,56628958,11509,907215
-519328,Callum,Scanlon,Scanlon,,,,,,,,728,,,37739c71,12147,796298
-519440,Wellity,Lucky,Lucky,,,,,,,,,,760,5fbafc66,14236,922461
-519634,Jenson,Seelt,Seelt,,,,,,,,,,542,ec75ee25,13714,617755
-519895,Oliver,Sonne,Sonne,,,,,,,,,,197,b66b8d5e,13726,541628
-519913,Tyler,Fletcher,Fletcher,,,,,,,,,,771,81a92add,14272,1049911
-520295,David Datro,Fofana,D.D.Fofana,,,,,,,684,200,164,,e82900ef,11295,787232
-521966,Finley,Munroe,Munroe,,,,,,,,854,,,36625c27,12581,845723
-523700,Daniel,Jebbison,Jebbison,,,,,699,,,483,69,,03edb878,9509,746740
-523705,Jackson,Tchatchoua,Tchatchoua,,,,,,,,,,695,aeca7743,12113,848509
-523957,Bénie,Traoré,T.Bénie,,,,,,,,593,,,77816c91,11729,852024
-524069,Dale,Taylor,Dale Taylor,,,,,,,666,,,,d5094280,11230,624267
-524070,Jamie,McDonnell,McDonnell,,,,,,,,779,,,b0df78a0,12349,694901
-524180,Cameron,Humphreys,Humphreys,,,,,,,,,273,,6068431b,1061,871335
-524196,Shaqai,Forde,Forde,,,,,,725,,,,,ebeac9e5,10553,852517
-530117,Louis,Jackson,Jackson,,,,,,,,856,,,06a441c4,12590,858191
-530121,Zain,Silcott-Duberry,Silcott-Duberry,,,,,,,,,728,95,2f5fa231,13351,777308
-530318,Kaden,Rodney,Rodney,,,,,,,601,825,647,281,49375cdd,11033,860078
-530335,Pablo Felipe,Pereira de Jesus,Pablo,,,,,,,,,,785,866ba412,14290,817665
-530873,Dara,Costelloe,Costelloe,,,,,,726,,164,,,6281b7ed,10568,614700
-531076,Frankie,Maguire,Maguire,,,,,670,,,,,,3e5bd5e0,9348,746753
-531170,Nasser,Djiga,Djiga,,,,,,,,,769,,1a7a4d84,13463,862297
-531363,Nathan,Fraser,Fraser,,,,,,,657,704,546,658,00b77ecf,11210,863741
-531442,Abdul,Fatawu,A.Fatawu,,,,,,,,,570,,bceda5ff,12911,864121
-531989,David,Ozoh,Ozoh,,,,,,,676,721,212,280,d00d45ab,11268,865993
-531993,Ademola,Ola-Adebomi,Ola-Adebomi,,,,,,,,720,,,efacf4fd,12116,814820
-531997,Henry,Cartwright,Cartwright,,,,,,,,,694,,0b6dfc4f,13273,866651
-532135,Killian,Phillips,Phillips,,,,,,,604,,,,cfa9f361,11059,801420
-532372,Oliver,Arblaster,Arblaster,,,,,,,,823,,,afe1a491,12449,874066
-532377,Louie,Marsh,Marsh,,,,,,,,654,,,7923301c,11734,874043
-532528,Joshua,Duffus,Duffus,,,,,,,,747,,,6224214f,12217,867700
-532529,Jack,Hinshelwood,Hinshelwood,,,,,,,677,621,126,163,e98211e7,11269,867688
-532534,Will,Alves,Alves,,,,,,,,,606,,39ef5a7b,13302,867711
-532535,Thomas,Wilson-Brown,Wilson-Brown,,,,,,,,,708,,b495353c,13304,867710
-532605,Andrey,Nascimento dos Santos,Andrey Santos,,,,,,,702,186,150,246,dd745366,11808,743600
-533463,Dango,Ouattara,O.Dango,,,,,,,705,78,74,83,2f9e4435,9662,823231
-533710,Iwan,Morgan,Morgan,,,,,,,,,780,137,ad31049a,13472,966671
-533719,Adrian,Blake,Blake,,,,,,733,,,,,d9a21f02,10592,875581
-534392,Mason,Burstow,Burstow,,,,,,,,623,,,dab84ad2,11810,874080
-534836,Travis,Patterson,Patterson,,,,,,,755,,,710,e0b5d31b,11507,874902
-535017,Julian,Eyestone,Eyestone,,,,,,,,,759,104,e839dde1,13408,1008553
-535262,Reuell,Walters,Walters,,,,,,,751,736,,,501ac0cc,11475,878160
-535264,Bradley,Ibrahim,Ibrahim,,,,,,,,737,,,aaab4602,12194,871837
-535301,Carlos,Baleba,Baleba,,,,,,,,690,115,167,a1390d2f,10527,973085
-535339,Tiago,Çukur,Çukur,,,,,,732,,,,,ca990d30,10591,594276
-535818,Simon,Adingra,Adingra,,,,,,,,122,113,543,4dcec659,11710,658536
-535928,Stefan,Bajčetić Maquieira,Bajcetic,,,,,,,564,292,312,393,32e8417f,10723,864799
-536109,Ollie,Scarles,Scarles,,,,,,,,784,677,608,242e5e6d,12358,922563
-536110,Josh,Feeney,Feeney,,,,,,670,,,,,185321d3,10211,875929
-536119,Charlie,Crew,Crew,,,,,,,,,,359,e8392083,,883539
-536134,Rio,Kyerematen,Kyerematen,,,,,,,,,,811,04a1c050,14409,882172
-536238,Ishé,Samuels-Smith,Samuels-Smith,,,,,,,757,819,782,,da95fde0,11508,922698
-536241,Martin,Sherif,Sherif,,,,,,,,,724,313,74c0903d,13345,922695
-536661,Nilson,Angulo,Angulo,,,,,,,,,,813,a9b9d89c,,903611
-536677,Detlef Esapa,Osong,Osong,,,,,,,,780,,,a42bbccc,12351,921532
-536681,Joe,Gardner,Gardner,,,,,,,,781,,,f4c17979,12350,921513
-536694,Matheus,França de Oliveira,M.França,,,,,,,,615,208,279,077faf72,12152,743597
-536908,Alejo,Véliz,Veliz,,,,,,,,641,507,,3f7bafbe,12105,888493
-536916,Facundo,Buonanotte,Buonanotte,,,,,,,679,125,117,168,468a7a91,11362,983989
-537043,Kaine,Kesler Hayden,Kesler Hayden,,,,,,,537,,,,9b066938,9409,626888
-537403,Kadan,Young,Young,,,,,,,672,865,656,63,91c75917,11240,887433
-538182,Jimi,Gower,Gower,,,,,,,,,790,,4571f93e,13569,890718
-538206,Jordan,Amissah,Amissah,,,,,,,,472,,,50fc4c0a,12156,385412
-538207,William,Osula,Osula,,,,,711,,,490,590,500,7b355808,9556,609556
-538210,Andre,Brooks,Brooks,,,,,,,,655,,,5f346071,11731,746739
-539721,Ruairi,McConville,McConville,,,,,,,,,681,,1a28b886,13219,701021
-541462,Matai,Akinmboni,Akinmboni,,,,,,,,,712,75,cfed08d5,13344,994604
-543158,Valentín,Barco,Barco,,,,,,,,816,116,,b9f282ec,12498,849410
-543295,Antoni,Milambo,Milambo,,,,,,,,,,122,b05f4787,13780,683620
-544877,Milos,Kerkez,Kerkez,,,,,,,,595,70,371,0ad53bdc,11709,730861
-545477,Alex,Murphy,A.Murphy,,,,,,,,634,390,481,f1c42eb3,12199,900601
-545508,Joseph,O'Brien-Whitmarsh,O'Brien-Whitmarsh,,,,,,,,,693,,fd1c27b8,13258,741228
-547027,Habib,Diarra,Diarra,,,,,,,,,,544,6d0fe035,9767,876631
-547037,Jack,Fletcher,J.Fletcher,,,,,,,,,667,462,38a6c944,13150,1011140
-547410,Harrison,Jones,H.Jones,,,,,,,,,,557,2a78981b,13722,937840
-547659,Josh,Powell,Powell,,,,,,,,637,,,8129b437,,855279
-547668,Axel,Piesold,Piesold,,,,,,,,831,,,68201bf9,12510,907219
-547673,Charlie,Robinson,C.Robinson,,,,,,,750,,,,693a5e1a,11467,921992
-547676,Tyler,Fredricson,Fredricson,,,,,,,,,777,446,58630379,13467,911424
-547686,Luc,De Fougerolles,De Fougerolles,,,,,,,,625,,,45c427ff,12172,921995
-547692,Samuel,Rak-Sakyi,Rak-Sakyi,,,,,,,,,695,,301ba71e,13286,906214
-547693,Somto,Boniface,Boniface,,,,,,,,,799,,6115a18a,13595,922472
-547701,Archie,Gray,Gray,,,,,,658,565,,489,591,f58515f5,10184,922693
-547716,Ben,Parkinson,Parkinson,,,,,,,,739,,,32163807,12198,922764
-547719,Lewis,Miley,L.Miley,,,,,,,741,635,411,497,2c6835e5,11386,922769
-547720,Charlie,Tasker,Tasker,,,,,,,,,791,156,c155dd7d,13570,921662
-547801,Callum,Bates,Bates,,,,,,,,,678,306,b2010f35,13204,1018716
-548308,Ashley,Phillips,Phillips,,,,,,,,702,478,576,4f21d3af,12031,859951
-549014,Noël,Atom,Atom,,,,,,,,861,,,966f64a3,12625,913214
-549067,Zach,Abbott,Abbott,,,,,,,,,706,513,c103921a,13306,933017
-549068,Omari,Kellyman,Kellyman,,,,,,,,618,173,,aa888da7,11739,926135
-549074,Tom,Watson,Watson,,,,,,,,,,172,9886c32e,14029,933018
-549329,Lucas,Pires Silva,Lucas Pires,,,,,,,,,,195,5d68f5b2,11824,927768
-549344,Sam,Curtis,Curtis,,,,,,,,828,,,7d42865e,12465,741267
-549640,Michael,Golding,Golding,,,,,,,,,292,,67c5e0e8,13606,936842
-549912,Chemsdine,Talbi,Talbi,,,,,,,,,,553,645481cc,13717,743384
-549939,Mike,Penders,Penders,,,,,,,,,,222,074e1710,13816,834397
-550090,Diego,Coppola,Coppola,,,,,,,,,,144,22ae86f9,10169,660860
-550141,Adrian,Mazilu,Mazilu,,,,,,,,,133,176,6029f951,,723835
-550596,Dominic,Sadi,Sadi,,,,,,,697,811,723,94,54778940,11300,936901
-550615,Tyrique,George,George,,,,,,,,851,696,243,e6f7797e,12573,936874
-550833,Noha,Lemina,N.Lemina,,,,,,,,800,,,28401b55,12499,816124
-550839,Wilson,Odobert,Odobert,,,,,,,,660,612,588,35516eac,10822,743498
-550864,Leny,Yoro,Yoro,,,,,,,,,572,444,6763f716,10564,923831
-551153,Luís Hemir,Silva Semedo,Luís Hemir,,,,,,,,,,563,95a98690,,840687
-551206,Jaydon,Banel,Banel,,,,,,,,,,213,98e0d76c,,706889
-551210,Jorrel,Hato,Hato,,,,,,,,,,672,bde35051,13776,904802
-551221,Tommy,Setford,Setford,,,,,,,,,639,4,d1a2e006,13011,848753
-551226,Mateus Gonçalo,Espanha Fernandes,M.Fernandes,,,,,,,,,623,708,ef491564,12948,880245
-551230,Renato,Palma Veiga,Renato Veiga,,,,,,,,,184,,fc8fcbd1,11383,805714
-551232,Rodrigo,Duarte Ribeiro,Ribeiro,,,,,,,,809,,,484a3eae,12418,726701
-551483,Álex,Jiménez Sánchez,A.Jimenez,,,,,,,,,,713,faa13947,12168,741257
-551995,Taylan,Harris,Harris,,,,,,,,848,,,96630213,12565,985717
-552030,Aidan,Francis-Clarke,Francis-Clarke,,,,,,,,648,,,38c29201,11725,802230
-552425,Sydie,Peck,Peck,,,,,,,,759,,,767d9605,12251,745851
-552427,Will,Lankshear,Lankshear,,,,,,,,,609,598,92df535b,13127,879768
-553299,Takai,Kōta,Takai,,,,,,,,,,577,9f59ff55,,671108
-553742,Finlay,Herrick,Herrick,,,,,,,,,,825,8a764f73,,848439
-553746,Leo,Shahar,Shahar,,,,,,,,,,765,5536f008,13572,940858
-554194,Jahmai,Simpson-Pusey,Simpson-Pusey,,,,,,,,,672,,383b10fd,13185,942497
-554197,Chris,Rigg,Rigg,,,,,,,,,,551,35741fe2,13719,947411
-554605,Dean,Huijsen,Huijsen,,,,,,,,,580,,87278bce,11943,890290
-556637,Nehemiah,Oriola,Oriola,,,,,,,,,,744,febb2831,14127,914269
-556639,Jayce,Fitzgerald,Fitzgerald,,,,,,,,,673,461,462c5660,13196,964690
-559610,Luka,Bentt,Bentt,,,,,,,,,,810,331545b0,14405,1407213
-559684,Jack,Moorhouse,Moorhouse,,,,,,,,,778,464,973d6049,13468,953933
-559962,Jamaldeen,Jimoh-Aloba,Jimoh-Aloba,,,,,,,,,710,62,1e711234,13310,954105
-559963,Kiano,Dyer,Dyer,,,,,,,,852,,,b43204f6,12574,954125
-560248,Bastien,Meupiyou Menadjou,Meupiyou,,,,,,,,,637,639,dcd94cdb,11775,955253
-560262,Junior,Kroupi,Kroupi.Jr,,,,,,,,,,100,b2fe86e5,11504,955357
-560441,Luis Eduardo,Soares da Silva,Cuiabano,,,,,,,,,,729,7e49bdbd,,891353
-560552,Kevin,Santos Lopes de Macedo,Kevin,,,,,,,,,,731,93508980,14030,900195
-563324,Brayden,Clarke,Clarke,,,,,,,,,801,13,f9657b1b,13607,1005844
-563883,Vincent,Angelini,Angelini,,,,,,642,,752,,,536e58cc,10158,736251
-563934,Tyrese,Hall,Hall,,,,,,,,862,,,f2e48542,12623,965971
-564406,Eliezer,Mayenda Dossou,Mayenda,,,,,,,,,,561,6a021e43,13718,967346
-564505,Sam,Proctor,Proctor,,,,,,,,765,,703,b96cec48,12273,1004709
-564510,Garang,Kuol,Kuol,,,,,,,683,418,406,496,a8a80be7,,967948
-564940,Soungoutou,Magassa,S.Magassa,,,,,,,,,,718,dfc5d4fa,10770,745181
-565297,Mateo,Joseph Fernández-Regatillo,Mateo Joseph,,,,,,,659,,,364,6ad43f9a,11208,834742
-565431,Callum,Marshall,Marshall,,,,,,,,785,,626,3a27f1bf,12359,953135
-565858,Killian,Cahill,Cahill,,,,,,,,,668,,4352b7be,13170,745716
-565863,Sam,Chambers,Chambers,,,,,,,,,,787,30b33655,14306,980343
-566164,Sverre,Nypan,Nypan,,,,,,,,,,428,3dde85f2,,911736
-566213,Stephen,Mfuni,Mfuni,,,,,,,,,,740,c6685def,14054,1049020
-567119,Shumaira,Mheuka,Mheuka,,,,,,,,,781,,43d0b694,13476,982097
-567121,Joe,Knight,Knight,,,,,,,,,758,175,16168a0f,13399,978668
-568791,Callan,McKenna,McKenna,,,,,,,,855,727,69,9d316492,12582,983248
-569014,Eric,da Silva Moreira,Da Silva Moreira,,,,,,,,,428,523,0a4f579a,12765,897481
-569577,Triston,Rowe,Rowe,,,,,,,,,,701,3fcc22d5,13869,984593
-570241,Kim,Ji-soo,Ji-soo,,,,,,,,725,96,117,f4065d9e,12136,709767
-570526,Lucas,Bergvall,Bergvall,,,,,,,,,481,586,a109e5c8,12912,866246
-570929,Jack,Whittaker,Whittaker,,,,,,,,,,821,33ea39be,,1018830
-571087,Jaydon,Jones,Jones,,,,,,,,,,822,3ad7599b,,1018837
-572702,Keiber,Lamadrid,Lamadrid,,,,,,,,,,802,5903eca2,,1004203
-573062,Martial,Godo,Godo,,,,,,,641,,605,333,e0eea46f,11164,992686
-573808,Jack,Grieves,Grieves,,,,,,734,,,,,2cf03378,10593,974327
-574398,Franco,Umeh-Chibueze,Umeh,,,,,,,,821,644,282,8e526344,12454,943560
-574402,Mark,O’Mahony,O’Mahony,,,,,,,,741,138,,a3afdd69,12205,943549
-574458,Mamadou,Sarr,M.Sarr,,,,,,,,,,231,61f80c89,11253,910905
-574799,Damola,Ajayi,Ajayi,,,,,,,,,729,,d3a6f5a3,13363,999745
-575034,Ethan,Wheatley,Wheatley,,,,,,,,850,648,468,5c368c88,12568,888639
-575204,Claudio,Echeverri,Echeverri,,,,,,,,,785,425,49a605df,13649,994536
-575458,Jair,Paula da Cunha Filho,Jair Cunha,,,,,,,,,,510,ac31d35e,13779,984096
-575476,Murillo,Costa dos Santos,Murillo,,,,,,,,696,436,506,1704b0b8,12123,1005649
-575901,Julio,Soler Barreto,Soler,,,,,,,,,713,80,98c8559a,13474,1009658
-576323,Oluwaseun,Adewumi,Adewumi,,,,,,,,,,212,4a9dfc4c,,982081
-576620,Bendito,Mantato,Bendito Mantato,,,,,,,,,,769,e8a55b80,14266,1085591
-576628,Shea,Lacey,Lacey,,,,,,,,,,755,3160e952,14198,926309
-576637,Godwill,Kukonki,Kukonki,,,,,,,,,691,788,30416cc3,13259,1184841
-576756,Zépiqueno,Redmond,Redmond,,,,,,,,,,65,c8365ab8,,765972
-576980,Zach,Marsh,Marsh,,,,,,,,,676,286,6baa90d0,13203,1004679
-577016,Josh,Acheampong,Acheampong,,,,,,,,838,697,233,b7e62e1d,12535,1004708
-577114,Luis Guilherme,Lira dos Santos,L.Guilherme,,,,,,,,,526,619,b7672d43,13026,991800
-577285,George,Hemmings,George Hemmings,,,,,,,,,,754,28795530,14193,1023191
-577669,Noah,Sadiki,Sadiki,,,,,,,,,,552,645481cc,13716,727089
-577725,Josh,King,King,,,,,,,,810,604,335,86109b3b,12410,1011131
-577731,Ben,Broggio,Broggio,,,,,,,,,679,60,cdf9e86a,13221,985544
-577974,Harry,Amass,Amass,,,,,,,,846,670,445,7b47100c,12559,1011738
-578153,Abdukodir,Khusanov,Khusanov,,,,,,,,,732,406,d17ce930,11763,763079
-578512,Miodrag,Pivaš,Pivas,,,,,,,,,574,483,d50ec076,,908890
-578545,Kosta,Nedeljković,Nedeljkovic,,,,,,,,,50,,c70be9cf,12775,848682
-578614,Enock,Agyei,Boateng,,,,,,,,156,,203,a1dd3b81,5563,724041
-579075,Asher,Agbinone,Agbinone,,,,,,,,,646,274,6a10efb3,13039,1047256
-580921,Reigan,Heskey,Heskey,,,,,,,,,,764,d4ee4622,14254,1056437
-585472,Ryan,Oné,Oné,,,,,,,,730,,,d4aa4582,12158,1031293
-586268,Ármin,Pécsi,Pécsi,,,,,,,,,,368,46206cf7,,933215
-586309,Thierno,Barry,Barry,,,,,,,,,,310,52c3244b,12916,937941
-587178,Yasin,Özcan,Yasin,,,,,,,,,,46,3c841afd,,1043003
-587433,Conor,McManus,McManus,,,,,,,,,,824,d80e9e0e,,1008162
-588555,Elyh,Harrison,Harrison,,,,,,,,,761,433,6175ebf8,13410,1013690
-588793,Maldini,Kacurri,Kacurri,,,,,,,,,657,14,7be4311f,13081,903189
-588796,Ismeal,Kabia,Kabia,,,,,,,,,659,28,6b15cf32,13082,964561
-589100,Jacob,Slater,Slater,,,,,,,,,685,155,a4a51de9,13238,854930
-589114,Zack,Nelson,Nelson,,,,,,,,734,,,de0abf23,12188,965940
-589121,Ethan,Sutherland,Sutherland,,,,,,,,,,778,a7abd792,14284,1044516
-589507,Leon,Chiwome,Chiwome,,,,,,,,836,539,657,a2852b4f,12532,1043634
-590012,Caleb,Kporha,Kporha,,,,,,,,,666,265,c80f8c9d,13130,1047261
-590014,Rio,Cardines,Cardines,,,,,,,,,,690,702812fe,13777,1047257
-590035,Yusuf,Akhamrich,Akhamrich,,,,,,,,,,751,e19dc888,14175,1047345
-590039,Divine,Mukasa,Mukasa,,,,,,,,,,739,ce7ae86a,14055,1047280
-590760,Daniel,Adu-Adjei,Adu-Adjei,,,,,,,695,,722,99,2093823e,11301,963878
-591357,Ryan,Trevitt,Trevitt,,,,,,,632,118,602,134,732327ae,11146,874538
-591382,Genesis,Antwi,Genesis Antwi,,,,,,,,,787,,aaa96db5,13527,1045121
-591384,George,King,King,,,,,,,,,,793,72103498,14328,1045118
-591385,Samuel,Amissah,Amissah,,,,,,,,,690,323,2835bfe1,13250,1026524
-591386,Trey,Nyoni,Nyoni,,,,,,,,743,688,396,1d3b3d77,12203,1045123
-591538,Owen,Hampson,Hampson,,,,,,,,857,,,081b8cac,12591,967340
-591539,Billy,Blacker,Blacker,,,,,,,,822,,,2b08b6e5,12450,967318
-592031,Yankuba,Minteh,Minteh,,,,,,,,,135,160,c3cf087d,12759,1012534
-592436,Travis,Hernes,Hernes,,,,,,,,795,,,849e071e,12396,1053908
-592661,Tristan,Crama,Crama,,,,,,,646,,,,130e085a,11189,732529
-592662,Tony,Yogane,Yogane,,,,,,,,,661,,4cccbed1,13104,979064
-592712,Tom,Taylor,Tom Taylor,,,,,,,,,800,,648a86b4,13603,1099929
-592736,Maeson,King,King,,,,,,,,,700,,b00671f2,13287,1047342
-593001,Enso,González Medina,Gonzalez,,,,,,,,698,547,652,7e5bebeb,12047,1060740
-593174,Kaye,Furo,Furo,,,,,,,,,,797,9fea2579,14356,1011936
-596042,Kieran,Morrison,Morrison,,,,,,,,,,746,25683300,14144,1055345
-596047,Chido,Obi,Obi,,,,,,,,,776,467,0c9bfc3b,13466,1042886
-596054,Tom,Edozie,Edozie,,,,,,,,,682,651,3354ea94,13220,1065227
-596572,Michael,Dacosta Gonzalez,Dacosta Gonzalez,,,,,,,696,849,,,c1426015,11302,854722
-596777,Patrick,Dorgu,Dorgu,,,,,,,,,766,441,e6536124,11944,926952
-597320,Harry,Howell,Howell,,,,,,,,,795,795,d8a7e52c,13584,1067168
-597983,Ollie,Harrison,Harrison,,,,,,,,820,,,6ce635b6,12447,1071819
-599303,Sean,Neave,Neave,,,,,,,,,789,501,ff392864,13532,1071818
-600882,Harry,Gray,Gray,,,,,,,,,,741,99965ed0,14073,1108476
-601496,Jili,Buyabu,Buyabu,,,,,,,,731,,,15ee4bc1,12157,1072898
-601956,Saheed,Olagunju,Olagunju,,,,,,,,,,766,a3aa41c2,14257,1081155
-601975,Yegor,Yarmolyuk,Yarmolyuk,,,,,,,650,,,,907a5d7c,11195,717411
-602903,Ezra,Mayers,Mayers,,,,,,,,,686,747,9a85a651,13247,1107726
-602934,Fletcher,Holman,Holman,,,,,,,,840,,,de40b95a,12551,1080392
-604211,Tymur,Tutierov,Tutierov,,,,,,,,,,775,7ba5d93b,14277,1079078
-604988,Freddie,Simmonds,Simmonds,,,,,,,,,794,761,c1a271b9,13583,1120418
-605319,Luke,Rawlings,Rawlings,,,,,,,,,,767,ba8a2a36,14256,1083691
-606689,Romelle,Donovan,Donovan,,,,,,,,,,130,519db366,,1091562
-606745,Ayden,Heaven,Heaven,,,,,,,,,658,447,64e17fab,13080,1078163
-606774,Remy,Rees-Dottin,Rees-Dottin,,,,,,,,,707,687,1db75ccb,13307,1089802
-606775,Ben,Winterburn,Winterburn,,,,,,,,,687,96,ba31eee2,13242,854721
-606798,Andrés,García,A.García,,,,,,,,,731,42,40498af1,13392,1063329
-606921,Romain,Esse,Esse,,,,,,,,,730,269,87189f25,13387,967319
-607464,Michael,Kayode,Kayode,,,,,,,,,757,110,e19660a8,11281,823486
-608060,Jayden,Luker,Luker,,,,,,,,729,,,61aed9fe,12150,1088817
-608181,Stefanos,Tzimas,Tzimas,,,,,,,,,,180,a497130f,14028,950091
-609640,Mathis,Amougou,Amougou,,,,,,,,,771,,f93cca97,12808,1010854
-609873,Harrison,Armstrong,Armstrong,,,,,,,,,603,305,de59e609,12757,1107733
-610799,Luka,Vušković,Vuskovic,,,,,,,,,,578,fd6bdbce,13725,892160
-611011,Joseph,Johnson,Johnson,,,,,,,,682,,,d9e7c4da,11980,1088818
-611134,Kendry,Páez Andrade,Paez,,,,,,,,,,248,f3bb9f59,13818,1052439
-611695,Malick,Yalcouyé,Yalcouye,,,,,,,,,,174,e295402e,,1178758
-611912,Landon,Emenalo,Emenalo,,,,,,,,,,743,e1cc82b1,14112,1108471
-611917,Lucá,Williams-Barnett,Williams-Barnett,,,,,,,,,689,790,d2fe0b0b,13249,1108475
-611920,Malachi,Hardy,Hardy,,,,,,,,,684,,3478fa17,13225,1108465
-611922,Rio,Ngumoha,Ngumoha,,,,,,,,,,686,022eca88,13692,1108466
-611926,Amara,Nallo,Nallo,,,,,,,,837,692,378,398a24f6,12534,1108049
-611975,Ahmed,Abdullahi,Abdullahi,,,,,,,,,,562,8073edf4,,1015619
-612534,Benjamin,Fredrick,Fredrick,,,,,,,,797,786,115,fde367e5,12397,1071138
-612855,Ibrahim,Osman,I.Osman,,,,,,,,,127,,acdfe835,13792,1110406
-613120,Spike,Brits,Brits,,,,,,,,,704,,d5837248,13299,1080903
-613232,James,Wilson,Wilson,,,,,,,,,,818,e9cd8e92,14462,1041600
-613467,Wes,Okoduwa,Okoduwa,,,,,,,,832,711,,58469e7c,12500,1115502
-613804,El Hadji Malick,Diouf,Diouf,,,,,,,,,,603,bd5eb2e5,13723,1111589
-614574,Alex,Tóth,Tóth.A,,,,,,,,,,801,5e18c6f4,14374,998101
-616059,Jack,Porter,Porter,,,,,,,,,756,,0b4ecd65,13378,1131973
-616065,Marli,Salmon,Salmon,,,,,,,,,,759,3dabb62e,14220,1294399
-616077,Max,Dowman,Dowman,,,,,,,,,,700,9008bb70,13872,1187629
-616094,Dovydas,Sasnauskas,Sasnauskas,,,,,,,,827,,,9463c7eb,12466,1108667
-616221,João Victor,de Souza Menezes,Souza,,,,,,,,,,804,10b0c6f4,14410,1086258
-616222,Vitor,de Oliveira Nunes dos Reis,Vitor Reis,,,,,,,,,733,412,c4ce0ab5,13380,1005575
-616288,Ryan,McAidoo,McAidoo,,,,,,,,,,742,8dd0d7c5,14097,1187640
-617054,Deivid Washington,de Souza Eugênio,Deivid,,,,,,,,677,165,,95bd120d,12033,1082850
-618027,TJ,Carroll,Carroll,,,,,,,,,,781,88bf137b,14288,1131945
-618873,Sékou,Koné,Kone,,,,,,,,,779,463,dedb9d04,13469,1133978
-619146,Olabade,Aluko,Olabade Aluko,,,,,,,,,796,,12bb637a,13586,1135364
-619536,Seth,Ridgeon,Ridgeon,,,,,,,,,,770,b12ba5d9,14270,1078158
-620408,Joachim,Kayi-Sanda,Kayi Sanda,,,,,,,,,719,,e2b2a181,13636,986298
-620487,Veljko,Milosavljevic,Milosavljević,,,,,,,,,,721,c478319d,14027,989112
-622536,Benjamin,Arthur,Arthur,,,,,,,,834,705,114,093f0923,12533,1144158
-622758,Aarón,Anselmino,Anselmino,,,,,,,,,774,234,1d87670e,13460,1145504
-623095,Yang,Min-hyeok,Min-hyeok,,,,,,,,,717,594,fe3db176,13362,1004327
-623110,Seung-Soo,Park,Seung soo,,,,,,,,,,689,b6aabcf8,13710,1134717
-624773,Estêvão,Almeida de Oliveira Gonçalves,Estêvão,,,,,,,,,,238,2eda11b1,13775,1056993
-626464,Gustavo,Nunes Fernandes Gomes,Nunes,,,,,,,,,634,127,e504780f,13588,1086375
-626844,Milan,Aleksić,Aleksić,,,,,,,,,,546,c79f7793,,942738
-628204,Yunus Emre,Konak,Konak,,,,,,,,864,97,131,e02b5b36,12633,1141628
-629068,Braiden,Graham,Graham,,,,,,,,,,779,bd1d3020,14283,1122712
-630664,Jake,Evans,Jake Evans,,,,,,,,,797,,cb7bcef0,13585,1171764
-630699,Mohamadou,Kanté,Mohamadou Kanté,,,,,,,,,,758,0041f3e6,14219,1081995
-631106,Ben,Casey,Casey,,,,,,,,,,780,39f7c6fe,14285,1172646
-631786,Jonah,Kusi-Asare,Kusi-Asare,,,,,,,,,,737,c7c26e61,13262,1069512
-632822,Archie,Harris,Harris,,,,,,,,,702,,8eab81d9,13300,963879
-634640,Christian,Chigozie,Chigozie,,,,,,,,844,,,2dbd5678,12557,1225825
-640108,Antoñito,Cordero Campillo,Antoñito C.,,,,,,,,,,492,d9b0e57e,,1178393
-640419,Jun'ai,Byfield,Byfield,,,,,,,,,,745,0312881b,14134,1196272
-641221,Pedro,Cardoso de Lima,Pedro Lima,,,,,,,,,561,640,b2f4cad5,13156,1193867
-643135,Fer,López González,Fer López,,,,,,,,,,645,675cacff,13200,1064471
-643426,Dean,Benamar,Benamar,,,,,,,,,,773,b047bb3b,14278,1285021
-643473,Airidas,Golambeckis,Golambeckis,,,,,,,,,,752,59149473,14179,1108668
-644593,Kian,McMahon-Brown,McMahon-Brown,,,,,,,,,,820,643dadae,,1165131
-645618,Bradley,Burrowes,Burrowes,,,,,,,,,,702,802ee5ca,13870,1202361
-646243,Andre,Harriman-Annous,Harriman-Annous,,,,,,,,,,711,2d14071d,14000,1237740
-646754,Lander,Emery,Emery,,,,,,,,866,,,b5f7fd45,12632,1237073
-647597,Dominic,Dos Santos Martins,Martins,,,,,,,,839,,,00464670,12536,1203143
-647671,Mateus,Mané,Mané,,,,,,,,,784,749,c15cb409,13484,1230661
-647681,Giovanni,Leoni,Leoni,,,,,,,,,,692,570888ce,13031,1086619
-647850,Charalampos,Kostoulas,Kostoulas,,,,,,,,,,181,816010c4,14118,1060087
-647960,Oliver,Pimlott,Pimlott,,,,,,,,,,776,b928f19e,14282,1214634
-649208,Jeremy,Monga,Monga,,,,,,,,,792,,4c168d3a,13579,1245948
-649240,Joshua,Stephenson,Stephenson,,,,,,,,,,823,c9c4c85d,,967342
-651426,Jaydee,Canvot,Canvot,,,,,,,,,,723,3684108d,13091,1006411
-653481,Alysson Edward Franco,da Rocha dos Santos,Alysson,,,,,,,,,,792,99b63a82,,1005583
-658013,Charlie,Stevens,Stevens,,,,,,,,,,799,6c2a4c10,14367,1122668
-660392,Christantus,Uche,Uche,,,,,,,,,,732,87941696,12726,1124005
-661712,Diego,León Blanco,D.Leon,,,,,,,,,,439,69ea448b,14057,1283997
-664015,Leon,Routh,Leon Routh,,,,,,,,,,768,e2177db5,14265,1300041
-666607,Sam,Alabi,Alabi,,,,,,,,,,772,d5f1b74a,14273,1146664
-672492,Joél,Drakes-Thomas,Drakes-Thomas,,,,,,,,,,762,1bd530e8,14263,1348941
-678552,Malcom,DaCosta,DaCosta,,,,,,,,,,756,c96b1407,14215,1323654
-685628,Jerome,Abbey,Abbey,,,,,,,,,,809,4f504fcc,14394,1370903
-699989,Djiamgone Jocelin Ta,Bi,Jocelin.T,,,,,,,,,,800,1f019509,14460,1322090
-704232,George,Brierley,Brierley,,,,,,,,,,784,a57a4ea8,14292,1352710
+code,first_name,second_name,web_name,16-17,17-18,18-19,19-20,20-21,21-22,22-23,23-24,24-25,25-26,fbref,understat,transfermarkt,whoscored
+1243,Robert,Green,Green,,547,,,,,,,,,a350680b,4390,11680,7890
+1616,Alexander,Manninger,Manninger,524,,,,,,,,,,eb55b1bc,277,5278,2856
+1632,Gareth,Barry,Barry,137,151,,,,,,,,,7dbbe367,590,3291,188
+1718,John,Terry,Terry,75,,,,,,,,,,68517cfd,917,3160,70
+1801,Paul,Robinson,Robinson,472,75,,,,,,,,,3515ba56,1667,3630,3874
+1822,Shay,Given,Given,315,,,,,,,,,,0db918ff,889,3146,1034
+2404,Michael,Carrick,Carrick,259,276,,,,,,,,,ab7263c1,654,3878,2115
+2513,Jamie,Murphy,Murphy,,69,,,,,,,,,6c96b263,6052,51730,25829
+3201,Stuart,Taylor,Taylor,597,506,,,,,,,,,30871c08,5580,3190,2809
+3736,John,O'Shea,O'Shea,342,,,,,,,,,,7c1f4685,729,3540,3841
+3773,Peter,Crouch,Crouch,336,347,590,,,,,,,,73d9bdc7,872,4072,3807
+5288,Gerhard,Tremmel,Tremmel,682,,,,,,,,,,4370cecc,1062,488,5487
+5589,Dean,Whitehead,Whitehead,,178,,,,,,,,,a32204c9,6328,13683,8176
+6744,Lee,Grant,Grant,574,329,520,237,604,,,,,,9dab6e3b,1742,13460,8195
+7525,Steven,Pienaar,Pienaar,533,,,,,,,,,,8056f6e6,924,4321,3553
+7551,Joleon,Lescott,Lescott,635,,,,,,,,,,62393d3b,664,4241,8137
+7638,Mark,Hudson,Hudson,,170,,,,,,,,,e4e3de44,,3640,
+7645,Phil,Jagielka,Jagielka,127,140,158,444,529,,,,,,3233eefd,587,13520,6105
+7906,Damien,Delaney,Delaney,107,121,,,,,,,,,210d9ecb,511,36861,8466
+7958,Jermain,Defoe,Defoe,355,52,46,,,,,,,,f1e8372d,735,3875,2837
+8380,James,Collins,Collins,452,441,,,,,,,,,c61f1719,655,12691,8148
+8432,José,Reina,Reina,,,,603,,,,,,,e358587b,1374,7825,2987
+9047,Glen,Johnson,Johnson,325,335,,,,,,,,,8cceca90,944,3881,4574
+9089,Ben,Foster,Foster,430,421,445,366,,376,,,,,d0b3ceb9,803,13572,11530
+9110,Shaun,Maloney,Maloney,162,,,,,,,,,,0558e236,1692,9508,4616
+9808,Zlatan,Ibrahimovic,Ibrahimovic,272,523,,,,,,,,,4cde5509,1741,3455,3281
+10318,Maarten,Stekelenburg,Stekelenburg,124,137,155,149,,,,,,,fefce889,846,4311,4065
+10460,Grant,Leadbitter,Leadbitter,284,,,,,,,,,,516f7fc1,5542,13796,12417
+10589,Brian,Murphy,Brian Murphy,,,537,,,,,,,,47e0ce24,4459,4190,9191
+11037,Rickie,Lambert,Lambert,447,,,,,,,,,,495de82c,816,49655,8409
+11334,Petr,Cech,Cech,2,2,1,,,,,,,,71672fa0,491,5658,6775
+11352,Bruno,Saltor Grau,Bruno,,58,50,,,,,,,,78803d03,6046,51528,23957
+11467,Billy,Jones,Jones,343,,,,,,,,,,aa3cb1ad,742,36866,8236
+11554,Julian,Speroni,Speroni,99,116,136,,,,,,,,8e65a5e5,523,12814,7895
+11735,Steve,Sidwell,Sidwell,,65,,,,,,,,,ed083afd,1007,13427,5554
+11829,Wayne,Routledge,Routledge,369,360,,,,,,,,,1d387eee,719,14066,4759
+11854,Daryl,Murphy,Murphy,,304,,,,,,,,,ac99973f,,31312,
+11948,Andy,Lonergan,Lonergan,,,,530,639,571,760,579,,,165cf989,7821,14044,8105
+11974,Eldin,Jakupovic,Jakupović,147,473,214,169,,573,627,,,,1148323a,1697,2857,18310
+12002,Stewart,Downing,Downing,282,,,,,,,,,,b13c4620,1712,4063,5641
+12086,Boaz,Myhill,Myhill,429,420,,,,,,,,,7ca2d989,820,3838,8462
+12150,Glenn,Whelan,Whelan,329,339,,,,,,,,,d5bd56a5,862,12124,8505
+12390,Allan,McGregor,McGregor,146,,,,,,,,,,f3a97d02,4409,9422,
+12413,Robert,Huth,Huth,173,194,,,,,,,,,0bd1ea64,747,2998,4145
+12496,Víctor,Valdés,Valdés,274,,,,,,,,,,e029e404,1705,7589,9484
+12679,Michael,Dawson,Dawson,150,,,,,,,,,,4771114f,1744,9988,4905
+12744,David,Nugent,Nugent,291,,,,,,,,,,f9b5e5bd,1753,33963,7616
+12745,Leighton,Baines,Baines,125,138,156,145,,,,,,,b18095b6,588,13507,8222
+12813,Jonathan,Walters,Walters,330,89,81,,,,,,,,0356cf4f,863,3306,3860
+13017,Wayne,Rooney,Rooney,269,161,,,,,,,,,f07be45a,629,3332,3859
+13152,Andy,King,King,178,201,,480,,,,,,,d790907f,784,56872,32018
+14075,Patrice,Evra,Evra,,626,,,,,,,,,51a3caf1,1298,5285,6410
+14295,Darren,Fletcher,Fletcher,439,346,,,,,,,,,184e4970,809,3547,5835
+14664,Gnegneri Yaya,Touré,Yaya Touré,231,249,,,,,,,,,c204f844,878,13091,14053
+14927,Greg,Halford,Halford,,,97,,,,,,,,06d45e81,,42062,
+14937,Cristiano Ronaldo,dos Santos Aveiro,Ronaldo,,,,,,579,326,,,,dea698d9,2371,8198,5583
+15033,Wes,Morgan,Morgan,167,191,215,165,216,,,,,,80c31c97,748,10003,8157
+15109,Tom,Huddlestone,Huddlestone,160,,,,,,,,,,464cbbc9,1695,13465,8194
+15114,Leon,Britton,Britton,370,361,,,,,,,,,b92dd711,830,40043,8730
+15137,Liam,Rosenior,Rosenior,,60,,,,,,,,,8b0d6fe9,4462,15166,11869
+15144,David,Marshall,Marshall,554,,,,,,,,,,4d93d433,1684,9500,9002
+15149,Simon,Francis,Francis,31,32,26,62,,,,,,,1e0b6a73,456,13573,9298
+15157,James,Milner,Milner,208,222,254,200,241,221,274,142,134,170,2f90f6b8,489,3333,4511
+15208,Bastian,Schweinsteiger,Schweinsteiger,265,,,,,,,,,,ccc22fea,907,2514,4567
+15237,Andrew,Surman,Surman,39,41,35,80,,,,,,,7d41b619,460,29975,13447
+15276,Joey,Barton,Barton,626,,,,,,,,,,93bfa675,4430,3292,4835
+15633,Alex,Baptiste,Baptiste,522,,,,,,,,,,7b72f0b6,1783,16660,8806
+15749,Joe,Hart,Hart,218,479,490,95,482,352,,,,,cb4f24c6,609,40204,8786
+15885,Adam,Federici,Federici,30,31,,,,,,,,,e5ea8be7,469,4233,13797
+15944,Michael,Kightly,Kightly,66,,,,,,,,,,26e5c484,1668,25366,9794
+15982,Dean,Marney,Marney,64,83,,,,,,,,,b3379356,1658,4055,5566
+16045,Ben,Watson,Watson,418,486,,,,,,,,,df540668,571,14081,10254
+17127,Per,Mertesacker,Mertesacker,4,5,,,,,,,,,5be28712,507,6710,6292
+17336,Gaël,Clichy,Clichy,223,,,,,,,,,,450ad405,613,7449,6042
+17339,Steven,Davis,Davis,305,316,337,,,,,,,,cf15bbb1,883,28973,9734
+17349,Aaron,Lennon,Lennon,142,153,83,430,,575,,,,,2ff964a0,593,14221,5625
+17476,Vincent,Kompany,Kompany,222,244,263,,,,,,,,d2bff301,612,9594,10136
+17601,Scott,Carson,Carson,,,,562,608,593,502,347,344,,3e1550ee,8158,14555,8155
+17740,Jesús,Navas,Navas,232,,,,,,,,,,3f10bd22,616,15956,9446
+17745,Kasper,Schmeichel,Schmeichel,165,189,213,168,217,200,248,,,,53af52f3,745,16911,19545
+17761,James,Tarkowski,Tarkowski,59,79,72,84,81,98,199,265,236,291,15ea812b,1665,173504,131464
+17878,Cesc,Fàbregas,Fàbregas,83,105,123,,,,,,,,33508c78,686,8806,8040
+17997,Phil,Bardsley,Bardsley,323,334,75,86,82,99,,,,,1ae30132,857,15773,18181
+18006,Martin,Cranie,Cranie,,168,,,,,,,,,9e53837d,6344,27659,19114
+18008,James,Morrison,Morrison,441,428,,,,,,,,,21a66e33,990,27614,10498
+18073,Mark,Noble,Noble,458,450,411,396,427,406,,,,,ff527768,533,31835,8247
+18155,Mathieu,Flamini,Flamini,576,,,,,,,,,,148d4105,895,17396,6321
+18440,Leon,Clarke,Clarke,,,,547,,,,,,,91c975a0,8061,36859,7807
+18499,Michael,McGovern,McGovern,,,,281,,313,,,,,51a19d04,8022,29391,20113
+18507,Diego,Da Silva Costa,Diego Costa,97,114,,,,,625,,,,a190d597,802,44779,14013
+18656,Heurelho da Silva,Gomes,Gomes,407,397,373,513,,,,,,,d596e193,564,105112,10133
+18665,Alexander,Tettey,Tettey,,,,289,,,,,,,75566759,791,12384,9342
+18726,Artur,Boruc,Boruc,29,30,25,73,,,,,,,34ccf6fa,455,15220,14111
+18759,Álvaro,Arbeloa,Arbeloa,568,,,,,,,,,,6dc73abd,1704,28260,11104
+18805,Joe,Ledley,Ledley,113,,,,,,,,,,c221f149,517,34409,11020
+18832,Richard,Stearman,Stearman,,,,296,,,,,,,9a3a436e,7989,34349,11502
+18867,Billy,Sharp,Sharp,,,,298,343,,,,,,e8c9f4e9,7712,49542,13399
+18892,Ashley,Young,Young,260,277,293,224,,52,538,588,238,,be927d03,631,14086,8166
+18987,Robert,Snodgrass,Snodgrass,155,448,489,393,428,,,,,,9f4647e9,1691,22614,9767
+19057,Sebastian,Larsson,Larsson,349,,,,,,,,,,b26efc36,740,31720,11235
+19071,Uwe,Hünemeier,Hünemeier,,57,,,,,,,,,f42456eb,4258,10503,14179
+19101,Dimitrios,Konstantopoulos,Konstantopoulos,273,,,,,,,,,,05778dfe,1767,50552,8572
+19115,Curtis,Davies,Davies,149,,,,,,,,,,607fb965,1686,18227,8484
+19151,Chris,Brunt,Brunt,438,434,,,,,,,,,ec7e6ad1,904,36814,8507
+19159,Ashley,Williams,Williams,359,143,159,,,,,,,,a498e276,709,67355,8408
+19188,Scott,Dann,Dann,104,118,139,127,486,,,,,,52105203,512,62688,12124
+19194,David,Martin,Martin,,,,553,429,,,,,,07666c20,8082,15930,131509
+19197,Jason,Puncheon,Puncheon,110,125,146,,,,,,,,fd3f57ce,514,47995,9156
+19236,John,Ruddy,Ruddy,,,421,412,453,452,,,414,753,da8b19e2,785,29712,8643
+19272,Gareth,McAuley,McAuley,436,425,,,,,,,,,ac7d7378,806,40567,8773
+19342,Ikechi,Anya,Anya,419,,,,,,,,,,c55e973d,577,107427,9795
+19419,Gary,Cahill,Cahill,78,98,114,503,125,,,,,,7914b9fe,699,27511,11981
+19520,Ryan,Babel,Babel,,,575,,,,,,,,6438d426,5176,16135,12158
+19523,Sol,Bamba,Bamba,,,91,,,,,,,,5534217d,4027,28984,21370
+19524,Santiago,Cazorla,Cazorla,15,17,,,,,,,,,e2e9c250,965,15799,4522
+19556,David,Jones,Jones,61,,,,,,,,,,2f0edbe7,1787,24634,12713
+19568,Ibrahim,Afellay,Afellay,332,341,,,,,,,,,9a8c6673,864,15760,12480
+19624,João Filipe Iria,Santos Moutinho,Moutinho,,,475,415,454,426,503,,,,f5a00fa4,3422,29364,16161
+19687,Alex,Bruce,Bruce,154,,,,,,,,,,102ed2b2,4411,37957,
+19760,Fernando,Llorente,Llorente,500,371,371,,,,,,,,82dbf623,1728,35564,13361
+19812,Dusan,Kuciak,Kuciak,517,,,,,,,,,,c78c8c27,1772,31886,31101
+19838,Robert,Elliot,Elliot,,286,307,573,,574,,,,,b1b25949,763,39037,13450
+20037,Marc,Pugh,Pugh,38,40,34,,,,,,,,9aacb284,466,36939,14000
+20046,Stefano,Okaka,Okaka,552,418,397,,,,,,,,601ef102,1763,35249,14255
+20047,Jordan,Rhodes,Rhodes,292,,,,,,,,,,3b8b641c,1714,48950,33704
+20066,Wayne,Hennessey,Hennessey,100,115,135,132,126,480,518,448,721,,76eca7e2,509,45494,21571
+20145,Adrian,Mariappa,Mariappa,556,405,382,356,,,,,,,8aa5f52c,524,38145,13805
+20208,Charlie,Adam,Adam,328,338,,,,,,,,,aff418dc,873,28990,8327
+20310,Willy,Caballero,Caballero,219,96,112,112,101,641,424,,,,a179d516,624,19948,34749
+20399,Antonio,Barragán,Barragán,477,,,,,,,,,,487d9b09,1706,32522,14085
+20452,Shane,Long,Long,313,325,347,315,361,519,,,,,9f472354,839,37304,13798
+20467,Theo,Walcott,Walcott,13,15,164,153,148,332,400,,,,1ecb65be,503,33713,13796
+20480,Tim,Krul,Krul,,540,,280,,314,,665,,,f23f9d20,982,33027,22319
+20481,Stephen,Ireland,Ireland,327,590,,,,,,,,,bcf30f17,867,34838,14169
+20487,Vito,Mannone,Mannone,339,,,,,,,,,,c4173f1a,726,33781,21682
+20529,Glenn,Murray,Murray,,71,62,44,53,,,,,,f2f29dda,882,45693,21427
+20658,Pablo,Zabaleta,Zabaleta,221,447,405,379,,,,,,,6813ac34,610,20007,14244
+20664,David,Silva,David Silva,230,248,271,219,,,,,,,e2716bd0,617,35518,14102
+20669,Shaun,MacDonald,MacDonald,41,,,,,,,,,,fdcff59c,471,10375,
+20695,Antonio,Valencia,Valencia,250,267,288,,,,,,,,08aa17d0,627,33544,18296
+21083,Nathan,Dyer,Dyer,376,366,,,,,,,,,6dfd5af0,783,37011,13814
+21123,Valon,Behrami,Behrami,420,410,,,,,,,,,d3d758d8,570,21905,12462
+21205,Tom,Heaton,Heaton,54,74,67,94,28,509,348,384,374,434,a6de6361,1651,34130,17708
+21246,Lewis,Grabban,Grabban,51,,,,,,,,,,1a857282,467,35413,19736
+26719,Rene,Gilmartin,Gilmartin,683,,,,,,,,,,f1b7c957,969,66518,17876
+26901,Kevin,Mirallas,Mirallas,133,148,469,,,,,,,,aa51343f,595,33639,15834
+26921,Arouna,Koné,Koné,144,,,,,,,,,,f9a72ca4,601,8552,8943
+27334,Mathieu,Debuchy,Debuchy,8,564,,,,,,,,,92232aad,967,27306,11367
+27335,Stephan,Lichtsteiner,Lichtsteiner,,,11,,,,,,,,99b1d0e6,1303,2865,15302
+27341,Yohan,Cabaye,Cabaye,118,129,,,,,,,,,ad7b19ef,516,29434,12376
+27436,David,McGoldrick,McGoldrick,,,,303,344,,,,,,dbe56a33,7711,35416,18501
+27462,Jesús,Gámez Duarte,Gámez,,293,,,,,,,,,bd1d1cbb,2329,29055,18538
+27698,Matthew,Connolly,Connolly,,,93,,,,,,,,2797fc1d,7237,34559,13939
+27707,Darron,Gibson,Gibson,138,,,,,,,,,,f0e72e1c,921,42413,30395
+27770,Birkir,Bjarnason,Bjarnason,,,,33,,,,,,,da13074e,8269,34453,
+27789,Fernando,Luiz Rosa,Fernandinho,233,250,272,221,266,453,,,,,101da2b5,614,26267,19119
+28082,Ralf,Fahrmann,Fahrmann,,,,449,,,,,,,1e43fad8,330,39015,23592
+28147,Mohamed,Diamé,Diamé,159,298,319,,,,,,,,b7d082af,4471,70950,27188
+28160,Mario,Suárez,Suárez,423,,,,,,,,,,7106f0a0,576,37337,
+28244,George,Boyd,Boyd,62,,,,,,,,,,0a9048ce,1656,45623,13056
+28411,Keylor,Navas,Navas,,,,,,,729,,,,ecada4fc,2243,79422,65901
+28448,Lee,Cattermole,Cattermole,348,,,,,,,,,,538e77d5,738,37363,14268
+28462,Sam,Baldock,Baldock,,73,64,,,,,,,,9d597f08,6430,67211,19494
+28468,Craig,Gardner,Gardner,440,,,,,,,,,,1117b9ff,812,37171,14038
+28495,John Obi,Mikel,Mikel,89,,,,,,,,,,424d5f72,685,30739,
+28541,Fraizer,Campbell,Campbell,121,,,,,,,,,,81d63375,634,42411,29299
+28554,Samir,Nasri,Nasri,229,,569,,,,,,,,165bed61,877,18935,13298
+28593,Victor,Anichebe,Anichebe,575,,,,,,,,,,4aed5c19,818,39532,14114
+28609,Adam,Legzdins,Legzdins,,545,,,,,,,,,f5b114ca,6302,43858,21814
+28654,Martin,Olsson,Olsson,633,358,,,,,,,,,2f72f79e,798,38073,33748
+28690,Pablo,Hernández Domínguez,Hernández,,,,,193,182,,,,,c0398aca,2164,46220,29571
+32259,Darren,Randolph,Randolph,451,439,,606,430,407,571,80,,,6385ebfb,540,51321,19782
+32318,Marc,Wilson,Marc Wilson,319,,,,,,,,,,c325c010,945,30456,23446
+33148,Claudio,Bravo,Bravo,541,241,261,213,267,,,,,,10072610,1731,40423,14199
+33871,Ragnar,Klavan,Klavan,474,220,244,,,,,,,,008a6e6d,265,26669,10839
+34654,Lukas,Jutkiewicz,Jutkiewicz,69,,,,,,,,,,3943a06f,1664,33507,
+36903,Gareth,Bale,Bale,,,,,543,,,,,,a58bb1e1,2251,39381,13812
+37002,Rouwen,Hennings,Hennings,71,,,,,,,,,,17611373,7060,16311,
+37096,Lukasz,Fabianski,Fabianski,356,350,400,388,431,408,455,533,521,738,9328b835,706,29692,20973
+37265,Alexis,Sánchez,Sánchez,12,14,295,240,,,,,,,2c0f8e9e,498,40433,25244
+37339,Ahmed,El Mohamady,El Mohamady,158,,,22,29,,,,,,615ef733,1685,66333,34876
+37388,Marcin,Wasilewski,Wasilewski,170,,,,,,,,,,24249219,760,16947,14621
+37402,Christian,Fuchs,Fuchs,168,192,216,163,218,,,,,,a67a09fb,749,6636,12431
+37572,Sergio,Agüero,Agüero,239,257,280,210,268,,,,,,4d034881,619,26399,14260
+37605,Mesut,Özil,Özil,14,16,13,15,1,,,,,,16380240,499,35664,13756
+37614,Mario,Vrancic,Vrancic,,,,282,,,,,,,16fa6881,12,39372,21562
+37642,Jonny,Evans,Evans,431,423,222,162,219,201,249,703,371,,f8fcd2a5,807,42412,22079
+37742,Younes,Kaboul,Kaboul,341,398,375,,,,,,,,3680d723,736,27114,14805
+37748,Bacary,Sagna,Sagna,224,,,,,,,,,,6ef56efd,625,26764,19471
+37869,Ryan,Shawcross,Shawcross,318,330,,,,,,,,,285a3d44,886,45861,29798
+37901,Dimitri,Payet,Payet,461,,,,,,,,,,58ae47b2,536,37647,14058
+37915,Hugo,Lloris,Lloris,380,375,351,340,383,353,425,502,,,8f62b6ee,637,17965,25604
+37998,Bafétimbi,Gomis,Gomis,377,,,,,,,,,,3d6686f9,717,22388,
+38038,Ben,Hamer,Hamer,583,190,190,,,,,,,,d822a850,1759,67283,29832
+38290,Danny,Rose,Rose,383,378,354,332,384,377,,,,,89d10e53,641,50174,24711
+38411,Nacho,Monreal,Monreal,10,10,5,6,,,,,,,d4cb83cc,495,43003,23072
+38419,Loïc,Remy,Remy,98,,,,,,,,,,5c2da10f,690,45121,23054
+38439,Etienne,Capoue,Capoue,416,409,389,373,,,,,,,5acc4a10,572,63494,33590
+38454,Dejan,Lovren,Lovren,191,215,239,186,,,,,,,1a2935f6,602,37838,29106
+38490,Beram,Kayal,Kayal,,64,57,56,,,,,,,26679cdf,6409,44741,33318
+38499,Tomer,Hemed,Hemed,,72,63,,,,,,,,27d7453c,4046,112668,28981
+38533,Rui Pedro,dos Santos Patrício,Patrício,,,454,411,455,427,,,,,79b0d6a0,6849,45026,23089
+38580,Jose,Fonte,Fonte,297,440,,,,,,,,,90f87966,834,33829,19859
+38588,Gaetano,Berardi,Berardi,,,,,685,,,,,,5348aada,9423,43084,52407
+38716,Lee,Peltier,Peltier,,,95,,600,,,,,,af341b88,6822,38094,22654
+39104,Mousa,Dembélé,Dembélé,391,385,362,,,,,,,,f7ee69fb,642,19368,12187
+39155,Adam,Lallana,Lallana,205,228,250,195,54,53,101,138,463,,99813635,486,43530,21683
+39158,Scott,Arfield,Arfield,63,82,,,,,,,,,b1313ec4,1659,55291,21686
+39167,Andrea,Ranocchia,Ranocchia,638,,,,,,,,,,539230cf,1522,44327,27421
+39187,Jeremain,Lens,Lens,351,,,,,,,,,,6f1721f0,781,38497,27512
+39194,Jan,Vertonghen,Vertonghen,385,380,355,330,,,,,,,ba23a904,640,43250,21778
+39215,Michel,Vorm,Vorm,381,376,352,555,,,,,,,1bebde9d,651,26276,19270
+39253,Jonas,Olsson,Olsson,432,,,,,,,,,,48844a9b,805,25248,6695
+39270,Marvin,Emnes,Emnes,378,,,,,,,,,,a5900d91,829,37787,
+39472,Dieumerci,Mbokani,Mbokani,569,,,,,,,,,,d9847696,795,44624,22820
+39476,Sokratis,Papastathopoulos,Sokratis,,,12,5,2,,,,,,b682dcf6,371,34322,22210
+39487,Erik,Pieters,Pieters,321,332,,447,83,100,,,,,1ef37668,887,43763,24148
+39725,Anders,Lindegaard,Lindegaard,,554,485,,,,,,,,636f1a28,950,22491,10620
+39790,Francisco,Casilla Cortés,Casilla,,,,,194,183,,,,,58bc7d18,2259,27486,23154
+39847,Steven,Defour,Defour,525,85,77,99,,,,,,,73489527,1657,33866,19155
+40002,Matteo,Darmian,Darmian,251,268,289,230,,,,,,,96e0490d,557,54906,23220
+40142,Andy,Carroll,Carroll,468,457,418,520,320,,,,,,b581987a,537,48066,23383
+40145,Jack,Cork,Cork,367,90,82,102,84,101,,163,,,74e12f1e,712,40613,22847
+40146,Ryan,Bertrand,Bertrand,296,307,330,305,362,473,250,,,,01226327,835,40611,22846
+40202,George,Friend,Friend,276,,,,,,,,,,4f97147d,1708,77544,34822
+40232,Gonzalo,Higuaín,Higuaín,,,579,,,,,,,,8a08491a,1293,39153,19729
+40276,Bojan,Krkic Perez,Bojan,335,344,,,,,,,,,9fa0a0b8,871,44675,31402
+40346,Erwin,Mulder,Mulder,,576,,,,,,,,,b3576b7c,6431,56631,34171
+40349,Asmir,Begovic,Begovic,74,29,24,72,,481,176,,624,,7b4de647,694,33873,23122
+40383,Fraser,Forster,Forster,294,306,329,317,523,333,426,498,488,782,c3e39f12,831,52570,29796
+40386,Chris,Basham,Basham,,,,423,345,,,474,,,1aa84968,7704,52495,35607
+40387,Dan,Gosling,Gosling,43,43,37,81,,378,,,,,7fec31a0,462,44983,13846
+40399,Sam,Vokes,Vokes,67,91,84,,,,,,,,1d6ac165,1661,48078,13938
+40451,Anthony,Pilkington,Pilkington,,,103,,,,,,,,b31af577,,67322,
+40555,Joe,Allen,Allen,202,337,,,,,,,,,9feb8f24,480,51452,23444
+40559,Fabricio,Agosto Ramírez,Fabri,,,474,,171,,,,,,af245161,2587,45882,23474
+40564,Henri,Lansbury,Lansbury,,,,35,30,,,,,,fe8e6fa1,7727,44794,32858
+40616,Stephen,Ward,Ward,57,78,71,,,,,,,,3831b9fe,1655,34691,15764
+40669,Angelo,Ogbonna,Ogbonna,456,444,403,377,432,409,456,577,,,74b2cd7e,528,48002,23547
+40694,Roberto,Jimenez Gago,Roberto,,,,450,433,,,,,,ba3ca78f,5087,37403,19442
+40720,Edinson,Cavani,Cavani,,,,,569,269,,,,,527f063d,3294,48280,24328
+40725,Danny,Simpson,Simpson,172,193,217,,,,,,,,3201b03d,746,37442,23683
+40755,Daniel,Sturridge,Sturridge,214,236,472,,,,,,,,1b7ec703,483,47082,23736
+40772,Gökhan,Inler,Inler,180,,,,,,,,,,3200c583,761,19041,
+40784,Mamadou,Sakho,Sakho,190,221,143,125,127,,,,,,87935cf3,485,47713,29575
+40833,Jérémy,Pied,Pied,492,312,,,,,,,,,a634b9d2,1784,60583,42248
+40836,Vicente,Guaita,Guaita,,,137,131,128,146,152,227,,,ab13a5aa,2190,64399,33866
+40845,Dale,Stephens,Stephens,,63,56,57,55,102,,,,,653ee42d,6051,49755,24238
+40868,José,Holebas,Holebas,411,401,378,353,,,,,,,12aa7661,568,41112,21499
+41135,Branislav,Ivanovic,Ivanovic,76,,,,530,,,,,,85f8571a,682,36827,15338
+41184,Marouane,Fellaini,Fellaini,257,275,298,,,,,,,,87575fd9,630,39679,22738
+41251,Eduardo,dos Reis Carvalho,Eduardo,663,95,,,,,,,,,81b906e7,5561,34159,34098
+41270,David,Luiz Moreira Marinho,David Luiz,570,101,116,106,3,,,,,,c0e27d1a,1676,46741,27586
+41320,Charlie,Daniels,Daniels,33,34,28,60,,,,,,,9d107085,459,61819,24827
+41321,Yohan,Benalouane,Benalouane,174,195,218,,,,,,,,8309b068,974,50477,29574
+41328,César,Azpilicueta,Azpilicueta,77,97,113,105,102,119,127,189,,,53cad200,681,57500,25931
+41338,Craig,Cathcart,Cathcart,408,399,376,358,,379,,,,,89e4b358,581,59606,25241
+41464,Marko,Arnautovic,Arnautovic,331,340,417,385,,,,,,,00459419,865,41384,34693
+41674,Kevin,Long,Long,594,80,73,88,85,103,,,,,5a4280b1,1747,111114,74606
+41705,Bradley,Guzan,Guzan,490,,,,,,,,,,d899e3bf,662,39471,28746
+41725,Troy,Deeney,Deeney,425,417,396,362,,380,,,,,82e34b69,574,65477,25832
+41727,Ryan,Bennett,Bennett,,,427,404,456,,,,,,0bad4516,787,67252,25834
+41733,Georginio,Wijnaldum,Wijnaldum,485,232,252,199,243,,,,,,eb58eef0,771,49499,33568
+41792,Aaron,Ramsey,Ramsey,16,18,14,,,,,,,,ef619b0b,504,50057,26820
+41823,Fabian,Delph,Delph,227,246,269,205,149,163,,,,,111c3236,876,50362,27213
+41926,Almen,Abdi,Abdi,417,,,,,,,,,,8d425d84,569,9966,
+41945,Sebastian,Prödl,Prödl,409,400,377,361,,,,,,,f5e6d08d,566,37981,27349
+42427,Kieran,Gibbs,Gibbs,7,8,,,407,,,,,,46ee5234,545,44792,27550
+42493,Mario,Balotelli,Balotelli,215,,,,,,,,,,8ff07990,1817,45146,
+42525,Stephen,Henderson,Henderson,,,,556,578,,,,,,f234c188,8095,52191,29800
+42564,Eric Maxim,Choupo-Moting,Choupo-Moting,,497,,,,,,,,,0e6bc38c,339,45660,29809
+42583,Sébastien,Pocognoli,Pocognoli,434,,,,,,,,,,cc41eec1,893,17804,
+42593,Aleksandar,Kolarov,Kolarov,220,243,,,,,,,,,eda40760,621,46156,12267
+42727,Yoan,Gouffran,Gouffran,,297,,,,,,,,,a28d181a,916,23825,
+42738,Juan,Zuñiga,Zuñiga,479,,,,,,,,,,06b34f37,1722,37941,26682
+42748,Gaëtan,Bong,Bong,,59,51,41,,,,,,,cfd5e123,6105,36291,32720
+42774,Morgan,Schneiderlin,Schneiderlin,264,154,167,158,,,,,,,51b41c5c,551,56818,29544
+42786,Eden,Hazard,Hazard,82,104,122,,,,,,,,a39bb753,701,50202,33404
+42824,Carlos,Sánchez,Carlos Sánchez,,,518,397,,,,,,,50b51fac,667,51226,26720
+42892,Álvaro,Negredo,Negredo,478,,,,,,,,,,63b0ca6b,1715,18644,23757
+42899,Sergio,Romero,Romero,243,261,283,236,289,,,,,,1e26e376,560,30690,33831
+42996,Angel,Rangel,Rangel,361,353,,,,,,,,,93ee387c,707,66550,29820
+43020,Javier,Hernández Balcázar,Chicharito,,487,419,386,,,,,,,189cee7b,191,50935,35003
+43191,Leiva,Lucas,Lucas,200,224,,,,,,,,,4c78b5ed,475,41414,31451
+43250,Tom,Cleverley,Cleverley,135,408,388,371,,381,,,,,6cdd8245,596,73484,69956
+43252,James,Chester,Chester,437,,,23,,,,,,,a772eba6,819,73482,70285
+43521,Henri,Saivet,Saivet,,516,,,,,,,,,f3709655,778,51540,34949
+43626,Håvard,Nordtveit,Nordtveit,465,,593,,,,,,,,6cafd68d,202,42234,21742
+43670,Juan,Mata,Mata,256,274,297,242,290,459,,,,,29733c72,554,44068,25363
+43693,Martín,Cáceres,Cáceres,652,,,,,,,,,,e94d79e3,1942,54935,30635
+43808,Markus,Suttner,Suttner,,461,52,,,,,,,,7391c2d9,379,31514,33477
+44302,Adlène,Guédioura,Guédioura,415,,,,,,,,,,f75825e3,583,74768,64343
+44336,Sofiane,Feghouli,Feghouli,466,455,,,,,,,,,691f64f5,1674,57162,34239
+44343,Bakary,Sako,Sako,119,130,148,,,,,,,,381d7d54,520,46791,34974
+44346,Olivier,Giroud,Giroud,25,25,133,110,103,120,,,,,16ceb862,502,82442,24444
+44413,Steve,Mandanda,Mandanda,102,,,,,,,,,,1d2d5cc8,1670,23951,29545
+44604,Nordin,Amrabat,Amrabat,422,412,,,,,,,,,7c2a398c,575,55619,22932
+44683,Jay,Rodriguez,Rodriguez,311,437,,451,86,104,,177,,,4ab53cdb,844,53360,33891
+44699,Ashley,Barnes,Barnes,70,93,85,90,87,105,,,,218,2691c772,4422,63200,33386
+45034,Ivan,Perišić,Perišić,,,,,,,448,507,,,6fe90922,448,42460,70524
+45076,Lamine,Koné,Koné,346,,,,,,,,,,a46472d0,728,57420,34214
+45124,André,Ayew,A.Ayew,374,449,,,,,734,,,,5dbefa9d,713,45403,30060
+45196,Gary,Madine,Madine,,,109,,,,,,,,e3e6502a,6829,66994,37050
+45220,Alex,Smithies,Smithies,,,89,,,,581,,,,bb91617c,6832,33754,132887
+45268,Moussa,Sissoko,Sissoko,572,393,369,349,385,354,,,,,2acd49b9,772,46001,29595
+46483,Adrien,Silva,Silva,,589,231,,220,,,,,,d6f88a1d,6464,56810,32598
+46695,Ritchie,de Laet,de Laet,171,,,,,,,,,,dc234f98,955,55687,
+47247,John,Fleck,Fleck,,,,301,346,,,481,,,b63e789d,7709,54383,30448
+47390,Neil,Taylor,Taylor,360,,,24,31,,,,,,c2f9d19f,710,67416,31558
+47431,Willian,Borges da Silva,Willian,86,106,124,113,478,3,614,591,772,,8b9ebd03,700,52769,29463
+48332,Orestis,Karnezis,Karnezis,,536,,,,,,,,,85b011bb,1138,16408,11624
+48615,Harry,Arter,Arter,37,39,33,,,,378,435,,,2f4c5a52,881,55742,67807
+48717,Winston,Reid,Reid,453,442,401,383,,410,,,,,562eed5c,529,37526,19277
+48760,Mathias,Jorgensen,Zanka,,171,195,,,594,595,121,112,,0db5d2c8,6030,52059,29026
+48771,Emilio,Nsue Lopez,Nsue,279,,,,,,,,,,1c9bc4fa,1757,59558,32224
+48773,Siem,de Jong,de Jong,,466,,,,,,,,,cf2a6ace,774,45509,
+48844,David,Ospina,Ospina,1,1,,,,,,,,,82b1198a,505,73396,36745
+48860,Niki,Mäenpää,Mäenpää,,53,,,,,,,,,14a96e1c,6053,12359,35565
+49013,Victor,Moses,Moses,92,102,117,,,,,,,,e726e11e,541,59866,33064
+49083,Luke,Freeman,Freeman,,,,441,477,,,322,,,636b64cd,7713,66923,33290
+49195,Jefferson,Montero,Montero,373,364,,,,,,,,,fa6561bf,715,77932,28416
+49202,Sean,Scannell,Scannell,,180,,,,,,,,,7ab42a5e,,61549,
+49207,Rudy,Gestede,Gestede,629,,,,,,,,,,822b3ef9,671,39908,33403
+49262,Jason,Steele,Steele,,,439,,528,54,102,148,142,138,28300a16,7235,73564,33532
+49277,Leroy,Fer,Fer,375,365,,,,,,,,,3cefa66a,711,63342,35174
+49382,Bruno,Ecuele Manga,Ecuele Manga,,,92,,,,,,,,72a0fb65,4883,60990,42573
+49384,Jack,Rodwell,Rodwell,350,,,591,,,,,,,a07579ee,733,57079,33833
+49413,James,Tomkins,Tomkins,103,117,138,124,129,147,153,241,,,e7ca0439,530,61592,33930
+49438,Jordon,Mutch,Mutch,115,552,,,,,,,,,37c408cc,632,57207,43742
+49440,Hal,Robson-Kanu,Robson-Kanu,571,436,,,408,,,,,,fb2dec57,1738,65976,35371
+49464,Cristhian,Stuani,Stuani,293,,,,,,,,,,220c11f1,1709,59323,24400
+49539,Kyle,Naughton,Naughton,358,352,,,,,,,,,e860c42f,718,66219,34131
+49579,Pedro,Rodríguez Ledesma,Pedro,90,109,125,114,,,,,,,3ca7254a,687,65278,44055
+49688,Alfred,N'Diaye,N'Diaye,644,,,,,,,,,,7789bf63,2144,77737,34123
+49696,Mauro,Zárate,Zárate,636,419,,,,,,,,,cc18ff4c,939,26456,14524
+49773,Albert,Adomah,Adomah,281,,,,,,,,,,c7174e81,1782,83430,35328
+49806,David Junior,Hoilett,Hoilett,,,99,,,,,,,,33af5b9e,4395,58993,35460
+49845,Aron,Gunnarsson,Gunnarsson,,,102,,,,,,,,e2533c20,7199,63821,35734
+49944,Jake,Livermore,Livermore,157,426,,,409,,,,,,b98570d1,1689,61832,36849
+49957,Kamil,Grosicki,Grosicki,647,,,,410,,,,,,81d8091f,3231,37920,30524
+49982,Sean,Morrison,Morrison,,,90,,,,,,,,09fec029,6823,79723,37505
+50089,Geoff,Cameron,Cameron,320,331,,,,,,,,,1a160ea3,859,31642,38772
+50093,David,Button,Button,,,179,48,56,,,,,,e608ed4c,6843,61814,34388
+50175,Danny,Welbeck,Welbeck,26,26,21,512,588,447,103,154,148,178,ce5143da,501,67063,39308
+50229,Matt,Phillips,Phillips,446,432,,,411,,,,,,7bb5f40e,1737,77274,40036
+50232,Jonjo,Shelvey,J.Shelvey,,296,318,269,321,291,349,463,,,3727dd3c,769,71292,40027
+50471,James,McArthur,McArthur,114,127,147,138,130,148,154,,,,cee31595,633,41416,20339
+50472,James,McCarthy,McCarthy,136,150,166,157,131,,,,,,64b08de7,589,45333,31281
+51090,Thiago,Emiliano da Silva,T.Silva,,,,,490,121,128,217,,,86e7deaf,3288,29241,28550
+51344,Rajiv,van La Parra,van La Parra,,173,200,,,,,,,,1931bde9,6036,77001,42947
+51507,Laurent,Koscielny,Koscielny,3,4,3,7,,,,,,,f5efb153,494,76277,30051
+51917,Diego,Cavalieri,Cavalieri,,633,,,,,,,,,84e6ea11,6620,53231,40767
+51927,Ben,Mee,Mee,56,77,70,83,88,106,526,109,100,,8df7a2fb,1654,74810,94935
+51934,Ron-Robert,Zieler,Zieler,166,,,,,,,,,,a0606ae8,91,21327,67300
+51938,Marc,Albrighton,Albrighton,177,200,224,174,221,202,251,,,,b827d5b3,753,61560,42147
+51940,David,De Gea Quintana,De Gea,242,260,282,235,291,270,327,,,,7ba6d84e,546,59377,79554
+51943,Václav,Hladký,Hladký,,,,,,,,,,185,6658971d,,95795,
+52153,Miguel,Britos,Britos,413,402,379,,,,,,,,356a9a62,567,76799,36096
+52287,Evandro,Goebel,Evandro,630,,,,,,,,,,67dbadfc,5550,53359,121488
+52484,Leon,Balogun,Balogun,,,54,40,,,,,,,78e68b4d,394,56100,43362
+52538,Fernando Francisco,Reges,Fernando,234,251,,,,,,,,,41f32541,615,51174,31958
+52775,Nicolas,Nkoulou,Nkoulou,,,,,,618,,,,,93cf32a8,,60577,43834
+52940,Daryl,Janmaat,Janmaat,540,404,381,359,,,,,,,45da6694,764,60744,32323
+53371,David,Meyler,Meyler,161,,,,,,,,,,8ea6417a,1693,68183,41589
+54102,Jack,Wilshere,Wilshere,17,24,447,394,434,,,,,,9c318325,1036,74223,42686
+54284,Chris,Löwe,Löwe,,165,193,,,,,,,,c6896eab,6032,55125,101664
+54316,Leonardo,Ulloa,Ulloa,185,210,,,,,,,,,eed56f6c,756,54890,19847
+54421,Floyd,Ayité,Ayité,,,186,,,,,,,,fd5888a0,3328,77974,42572
+54469,Adam,Smith,Smith,34,35,29,63,,,57,84,81,73,20b104bc,825,61841,69877
+54484,Francisco,Femenía Far,Femenía,,407,383,357,,382,,,,,e5d01ecf,5043,76467,75919
+54513,Vicente,Iborra,Iborra,,208,228,,,,,,,,ad1ffcfd,2065,65467,34052
+54527,Loïc,Damour,Damour,,,104,,,,,,,,074d8166,7215,81190,294510
+54694,Pierre-Emerick,Aubameyang,Aubameyang,,616,23,11,4,4,617,188,,,d5dd5f1f,318,58864,44120
+54738,Thomas,Kaminski,Kaminski,,,,,,,,614,,,1caa93a5,11712,77757,64342
+54756,Victor,Wanyama,Wanyama,400,389,366,348,,,,,,,e0900238,836,77760,71714
+54764,Jonathan,Kodjia,Kodjia,,,,26,,,,,,,ecf44e09,7725,88971,68862
+54771,Fabio Pereira,da Silva,Fabio,527,,,,,,,,,,bc7b4580,1752,61891,44031
+54861,Christian,Benteke,Benteke,213,134,152,129,132,149,155,,,,ab070c55,606,50201,68312
+54908,Nacer,Chadli,Chadli,392,427,,,,,,,,,5b54bf3b,648,59631,34302
+55037,Cheikhou,Kouyaté,Kouyaté,459,451,412,139,133,150,583,451,,,8d3c902d,532,66934,66741
+55038,Kevin,McDonald,McDonald,,,183,,172,,,,,,71a08f97,6836,36529,20100
+55313,Franck,Tabanou,Tabanou,364,,,,,,,,,,15e1afd5,980,66413,
+55317,Bernardo,Espinosa Zúñiga,Bernardo,280,,,,,,,,,,4242011c,1716,64598,67327
+55422,Gylfi,Sigurdsson,Sigurdsson,368,359,172,151,150,164,,,,,76dd1480,714,90466,69346
+55452,Yannick,Bolasie,Bolasie,109,147,165,,,,,,,,715fc0fe,518,75471,69844
+55459,Aaron,Cresswell,Cresswell,454,443,402,376,435,411,457,530,517,,4f974391,534,92571,68049
+55494,Joel,Ward,Ward,105,119,441,126,134,474,156,242,215,,8a7ff278,510,92572,43105
+55605,Toby,Alderweireld,Alderweireld,382,377,353,331,386,355,,,,,f7d50789,639,42710,69933
+55829,Claudio,Yacob,Yacob,442,429,,,,,,,,,bda6ffd4,808,45330,35691
+55909,Chris,Smalling,Smalling,244,263,284,223,292,,,,,,b6964eb6,628,103427,71345
+55914,Liam,Cooper,Cooper,,,,,195,184,221,,,,dc64b8b3,8816,75067,44148
+56192,Rhu-endly,Martina,Cuco Martina,302,464,163,577,,,,,,,22551915,832,91251,43712
+56377,Andriy,Yarmolenko,Yarmolenko,,,453,392,436,412,,,,,849c826a,6274,69015,41672
+56827,Costel,Pantilimon,Pantilimon,406,396,,,,,,,,,d24e154c,580,47659,43948
+56864,Francis,Coquelin,Coquelin,20,20,,,,,,,,,a6951bf8,497,74869,69738
+56872,Junior,Stanislas,Stanislas,42,42,36,77,,,58,,,,6992791d,463,87672,69912
+56917,Steve,Cook,Cook,32,33,27,58,,,379,441,,,3e5e4e63,458,90836,68662
+56979,Jordan,Henderson,Henderson,201,225,249,198,244,222,275,299,,124,935e6b8f,605,61651,68659
+56981,Joe,Bennett,Bennett,,,94,,,,,,,,dc936144,959,90964,68658
+56983,Matt,Ritchie,Ritchie,,295,317,251,322,292,350,425,,,71ef519e,461,92469,68648
+57001,Wilfried,Bony,Bony,240,542,,,,,,,,,61abe9b6,622,81808,42705
+57112,Eliaquim,Mangala,Mangala,225,502,,,,,,,,,f520049f,626,90681,68852
+57127,Teemu,Pukki,Pukki,,,,278,,315,,,,,0745b37d,7696,46972,25028
+57134,Salomón,Rondón,Rondón,449,435,493,,,591,177,,,,b318a643,813,80197,25964
+57145,Federico,Fernández,Fernández,363,354,516,254,323,465,351,,,,f25b010f,708,85475,44847
+57187,Giedrius,Arlauskis,Arlauskis,639,,,,,,,,,,1858bbf7,949,69001,66957
+57249,Henrikh,Mkhitaryan,Mkhitaryan,268,281,18,16,,,,,,,dd0daf32,317,55735,28421
+57328,Nathaniel,Clyne,Clyne,193,217,241,,577,493,157,222,196,263,0442183b,603,85177,69375
+57410,Nicolás,Otamendi,Otamendi,226,245,264,208,269,,,,,,0d267745,611,54781,75691
+57513,Jonas,Lössl,Lössl,,163,191,479,151,673,,,,,939bc634,3468,48870,131171
+57531,Michail,Antonio,Antonio,464,454,415,389,437,413,458,523,512,,ac05f970,531,104124,69517
+57586,Luciano,Narsingh,Narsingh,632,369,,,,,,,,,977ffc24,5554,72462,69525
+57647,Lyle,Taylor,Lyle Taylor,,,,,,,380,,,,3e80e04e,10762,104495,134189
+57736,Jan,Kirchhoff,Kirchhoff,347,,,,,,,,,,a14d04e3,232,49734,69609
+57913,Barry,Douglas,Douglas,,,424,,196,,,,,,c859705e,,91854,
+58376,Alex,McCarthy,McCarthy,101,305,328,318,363,334,401,,469,,36c2ca73,635,95976,38577
+58476,Rui Pedro,da Rocha Fonte,Fonte,,,188,,,,,,,,6ff8ef56,7145,9335,
+58498,Odion,Ighalo,Ighalo,426,,,624,293,,,,,,03622183,573,62121,31376
+58621,Kyle,Walker,Walker,384,379,265,203,270,249,299,369,363,187,86dd77d1,638,95424,69778
+58771,Jack,Colback,Colback,,299,,482,,,381,,,,963a9201,767,61644,69867
+58786,Martin,Kelly,Kelly,106,120,140,128,135,151,,,,,d7492450,525,78959,44687
+58791,Ryan,Mason,Mason,396,,,,,,,,,,c8fac933,649,61834,69878
+58822,Cédric,Alves Soares,Cédric,301,310,332,486,5,5,1,2,,,839c14e1,847,112988,69945
+58845,Ciaran,Clark,Clark,,289,311,259,324,293,352,,,,2b91cf8e,875,98240,70099
+58877,Daley,Blind,Blind,254,270,290,,,,,,,,691bef82,548,12282,70033
+58893,Marcos,Rojo,Rojo,248,266,287,227,294,,,,,,e0991c04,550,93176,70050
+59044,Adam,Clayton,Clayton,283,,,,,,,,,,45b59689,1717,73067,70140
+59115,Mile,Jedinak,Jedinak,112,,,,,,,,,,22fd2214,515,28336,13727
+59125,Connor,Wickham,Wickham,122,133,444,130,136,,,,,,41cc19c2,519,95435,73382
+59614,Mark,Duffy,Duffy,,,,300,,,,,,,d86ccbc9,,105565,
+59735,Karl,Darlow,Darlow,,287,308,263,325,294,353,408,,341,cde3309f,780,99397,70483
+59741,Max,Gradel,Gradel,44,44,,,,,,,,,c5a500ca,464,28140,29814
+59779,Pedro,Obiang,Obiang,460,452,413,400,,,,,,,ba1e04b3,542,101213,70676
+59796,Gökhan,Töre,Töre,467,,,,,,,,,,51960957,1703,82130,71015
+59846,Ander,Herrera,Herrera,262,278,299,,,,,,,,436a9dd0,552,99343,71174
+59856,Abel,Hernández,Hernández,163,,,,,,,,,,a36da810,1698,76608,32741
+59859,İlkay,Gündoğan,Gündoğan,236,253,274,222,271,250,300,,625,420,819b3158,314,53622,77464
+59940,Kyle,Bartley,Bartley,,485,,,412,,,,,,18e96f64,964,67421,71327
+59949,Séamus,Coleman,Coleman,126,139,157,144,152,165,178,247,221,294,0420d84f,585,68390,31826
+59966,Alexandre,Lacazette,Lacazette,,28,22,12,6,6,,,,,9dbb75ca,3277,93720,73078
+60025,James,Rodríguez,James,,,,,508,166,,,,,715bf047,2249,88103,71182
+60165,Wahbi,Khazri,Khazri,352,,,,,,,,,,2677a1de,734,103565,71381
+60232,Craig,Dawson,Dawson,433,424,,439,576,414,459,551,542,,3e9e06cb,804,121477,73063
+60252,Andros,Townsend,Townsend,120,131,149,135,137,482,179,727,,,b28bbd58,775,61842,71522
+60270,Simone,Zaza,Zaza,550,,,,,,,,,,9592289a,1642,96828,71647
+60307,Pascal,Groß,Groß,,70,59,49,57,55,104,134,125,783,8aec0537,239,82873,71824
+60551,Ashley,Westwood,Westwood,641,88,80,101,89,107,,,,,495945ef,669,91317,79050
+60586,Jóhann Berg,Gudmundsson,Gudmundsson,473,84,76,96,90,108,,170,,,f72293fc,1663,89231,41868
+60598,Aleksandar,Dragovic,Dragovic,,541,,,,,,,,,6fd8a334,5219,59032,40560
+60689,Chris,Wood,Wood,,518,87,91,91,109,354,468,447,525,4e9a0555,4456,108725,73380
+60706,Adrián,San Miguel del Castillo,Adrián,450,438,399,526,245,223,497,289,,,f76e6b4e,527,71271,73399
+60772,Thibaut,Courtois,Courtois,73,94,111,,,,,,,,1840e36d,680,108390,73798
+60794,Adam,Matthews,Matthews,345,,,,,,,,,,d8bffa70,1034,108878,
+60914,Joel,Matip,Matip,199,219,243,185,246,224,276,305,,,b217ef29,332,82105,74341
+61256,Carlos Henrique,Casimiro,Casemiro,,,,,,,593,376,368,457,4d224fe8,2248,16306,88526
+61262,Oscar,dos Santos Emboaba Junior,Oscar,84,,,,,,,,,,57fe98dd,692,85314,41065
+61302,Ryan,Allsop,Allsop,600,,,,,,,,,,af615123,1050,111073,74586
+61316,Jose Luis,Mato Sanmartín,Joselu,338,488,327,261,,,,,,,6265208f,866,81999,74603
+61366,Kevin,De Bruyne,De Bruyne,235,252,273,215,272,251,301,349,345,,e46012d4,447,88755,73084
+61538,Callum,McManaman,McManaman,443,,,,,,,,,,1a5dbcc2,880,61711,
+61548,Manolo,Gabbiadini,Gabbiadini,643,327,349,,,,,,,,8f866fe8,1383,112343,74921
+61558,Thiago,Alcántara do Nascimento,Thiago,,,,,531,225,277,310,,,77e84962,229,60444,74939
+61566,Roberto,Pereyra,Pereyra,539,415,391,369,,,,,,,75f2c59f,1723,112302,90000
+61595,Marc,Muniesa,Muniesa,322,333,,,,,,,,,4db76f57,860,74228,75177
+61600,Romaine,Sawyers,Sawyers,,,,,413,,,,,,77bb1522,8757,113036,75200
+61603,Daniel,Drinkwater,Drinkwater,179,202,128,120,,,,,,,2649ff32,752,73491,75138
+61604,Matty,James,James,602,474,229,177,222,,,,,,ebd0a048,4441,73522,75198
+61739,Maxime,Le Marchand,Le Marchand,,,455,,173,,,,,,321a71a7,3304,60558,236523
+61760,Kristoffer,Nordfeldt,Nordfeldt,357,351,,,,,,,,,78549904,722,75890,26236
+61810,Pontus,Jansson,Jansson,,,,,,76,78,,,,172e52d8,1801,125314,121123
+61858,Mame Biram,Diouf,Diouf,337,348,,,,,,,,,7f4f3e49,868,62049,26013
+61916,Stefan,Johansen,Johansen,,,185,,174,,,,,,a48da055,6838,62008,27579
+61933,Shane,Duffy,Duffy,,56,49,37,58,56,105,,,,7314bba4,6047,119269,75692
+62398,Nemanja,Matic,Matic,87,107,296,247,295,271,,,,,eb7822d7,697,74683,38128
+62399,Dusan,Tadic,Tadic,308,318,,,,,,,,,2475dcc6,840,36139,29474
+62974,Erik,Lamela,Lamela,393,386,363,346,387,356,,,,,abe66106,644,111630,75830
+63370,James,McClean,McClean,444,430,,,,,,,,,53538b39,814,85935,76050
+63426,Enda,Stevens,Stevens,,,,291,347,,,,,,17d4507a,7707,85706,42266
+66242,Davy,Pröpper,Pröpper,,490,60,54,59,57,,,,,fdd85f94,6050,79027,77429
+66247,Marvin,Zeegelaar,Zeegelaar,,537,384,,,,,,,,8abd0c03,6303,92899,78152
+66588,Luke,Ayling,Ayling,,,,,197,185,222,,,,420d7c7d,8716,67420,82877
+66733,Juan,Cuadrado,Cuadrado,85,,,,,,,,,,0ab1f153,1089,91970,
+66749,Romelu,Lukaku Bolingoli,Lukaku,143,285,306,232,,529,,207,175,,5eae500a,594,96341,78498
+66797,Simon,Mignolet,Mignolet,188,213,237,190,,,,,,,d436eb94,487,50219,52197
+66838,Cenk,Tosun,Tosun,,592,177,146,153,622,,,,,9a104dee,6477,45671,77438
+66842,André,Schürrle,Schürrle,,,478,,,,,,,,ecbb3fdf,154,58205,77461
+66975,Luka,Milivojevic,Milivojevic,646,132,150,134,138,152,158,,,,2ce2508a,5549,74300,70493
+67089,Martin,Dúbravka,Dúbravka,,621,309,262,326,295,355,409,396,470,3a949a25,6532,74960,46092
+67184,Roderick Jefferson,Gonçalves Miranda,Miranda,,,429,,,,,,,,390ab439,,87856,
+67527,Allan-Roméo,Nyom,Nyom,412,422,,,,,,,,,97572117,565,111508,91434
+68312,Xherdan,Shaqiri,Shaqiri,333,342,462,194,247,226,,,,,6421ec64,888,86792,76304
+68983,Matthew,Lowton,Lowton,55,76,69,85,92,110,,,,,9a9c05db,1652,102258,80067
+69140,Shkodran,Mustafi,Mustafi,555,12,7,1,7,,,,,,3f2d59fe,1699,88590,80921
+69143,Juraj,Kucka,Kucka,,,,,,495,,,,,5aaef9ef,1123,74943,32514
+69752,Norberto,Murara Neto,Neto,,,,,,,574,77,73,66,a9dc785c,1297,111819,76202
+69960,Philipp,Wollscheid,Wollscheid,324,,,,,,,,,,c4cca587,858,53173,86173
+71738,Marco,Stiepermann,Stiepermann,,,,285,,316,,,,,b606638c,7694,45760,82699
+72147,Marco,Bizot,M.Bizot,,,,,,,,,,33,3d214e5f,9614,124884,83824
+72222,Mateusz,Klich,Klich,,,,,198,186,223,,,,282679b4,4381,92738,69638
+72681,Denis,Odoi,Odoi,,,181,,525,,,,,,f7750aa0,7077,59641,68335
+73314,Willian José,Da Silva,Willian José,,,,,642,,,,,,d87e2cae,2361,122155,77636
+73426,Andre,Gray,Gray,68,92,395,364,,383,,,,,c24dba2a,1660,120565,131487
+73459,Ashley Darel Jazz,Richards,Jazz Richards,,,96,,,,,,,,afef14da,4467,120241,78089
+73494,Grzegorz,Krychowiak,Krychowiak,,533,,,,,,,,,580d52dd,2414,45184,67424
+73889,Diafra,Sakho,Sakho,470,458,,,,,,,,,57c433c8,656,120610,83297
+74033,Sam,Clucas,Clucas,156,519,,,,,,,,,987718f5,1690,122223,134459
+74208,Paul,Pogba,Pogba,503,282,302,238,296,272,,,,,867239d3,1740,122153,97752
+74230,Patrick,van Aanholt,van Aanholt,344,124,142,123,139,,,,,,5f09991f,730,52119,78221
+74297,Leandro,Bacuna,Bacuna,,,589,,,,,,,,9dc69d38,674,126014,79967
+74375,Ezequiel,Schelotto,Schelotto,,538,53,546,,,,,,,a6e316c1,3873,119164,79442
+74471,Aaron,Mooy,Mooy,,172,199,516,60,,,,,,47b7e3af,6033,123951,318153
+74854,Simon,Moore,Moore,,,,436,348,,,,,529,e7434f04,7715,123536,131498
+74944,Sam,Morsy,Morsy,,,,,,,,,278,,a23c0949,12748,123551,134666
+75115,Callum,Wilson,Wilson,49,48,43,67,506,296,356,433,421,671,c596fcb0,468,123682,134115
+75773,Chung-yong,Lee,Lee Chung-yong,117,128,,,,,,,,,49b05a83,526,81801,42915
+75826,Danny,Ward,Ward,,,105,,,,,,,,cfb29823,6830,124172,78471
+75880,Daniel,Ayala,Ayala,275,,,,,,,,,,302560a0,1718,78966,78559
+76306,Lukas,Rupp,Rupp,,,,602,,317,,,,,3faa1780,62,82863,79533
+76357,Tom,Cairney,Cairney,,,182,,175,,200,268,243,331,a8748947,6835,123275,79583
+76359,Phil,Jones,Jones,245,264,285,231,297,632,328,,,,def899bd,951,117996,81726
+76360,Nathaniel,Mendez-Laing,Mendez-Laing,,,100,,,,,,,,b4b2f632,6824,125409,87393
+76542,Sung-yueng,Ki,Ki Sung-yueng,372,363,324,268,,,,,,,1d8c99b0,723,81796,42916
+77359,Florian,Lejeune,Lejeune,,294,314,257,327,,,,,,6eaed4eb,5073,127108,80758
+77454,Fabio,Borini,Borini,354,,,,,,,,,,ef5b337e,737,96754,80882
+77610,Danny,Batth,Batth,,,428,,,,,,,,f1d0fa63,,129049,
+77760,Cristian,Gamboa,Gamboa,435,,,,,,,,,,f27680d9,855,121686,
+77762,Bryan,Oviedo,Oviedo,140,,,,,,,,,,31faf295,598,124983,83455
+77777,Ahmed El-Sayed,Hegazy,Hegazi,,468,,,414,,,,,,5540c9dc,3979,111524,108724
+77794,Kieran,Trippier,Trippier,387,382,357,334,,678,357,430,418,478,21512407,652,95810,83078
+77818,James,Shea,Shea,,,,,,,,335,,,ee7c0a5e,11724,91340,94017
+78007,Joshua,King,King,48,51,45,68,651,468,,,,,43458538,465,91059,81026
+78056,Oriol,Romeu Vidal,Romeu,310,320,339,328,364,335,402,,,,4b511457,842,66100,90780
+78091,Gastón,Ramírez,Ramírez,491,,,,,,,,,,2c851997,952,123742,82923
+78315,Joel,Robles,Robles,123,136,,,,,578,,,,cda0b317,584,101118,81681
+78356,Charlie,Austin,Austin,314,326,348,312,415,,,,,,8d228291,848,129627,82102
+78412,Shinji,Okazaki,Okazaki,186,211,235,,,,,,,,68796d61,754,79642,26222
+78607,Kenny,McLean,McLean,,,,286,,318,,,,,471f16b3,7693,126600,82917
+78830,Harry,Kane,Kane,403,394,372,338,388,357,427,500,,,21a66f6a,647,132098,83532
+78911,Kadeem,Harris,Harris,,,535,,,,,,,,24396398,7120,136501,135772
+78916,Dan,Burn,Burn,,,582,475,61,58,358,407,395,476,b2d31e83,7382,134270,82277
+79228,Pape,Souaré,Souaré,108,122,443,,,,,,,,46b5375e,513,125868,79970
+79602,Daniel,Bentley,Bentley,,,,,,,717,546,536,629,68db6358,11361,136401,134543
+79619,Jonathan,Hogg,Hogg,,174,201,,,,,,,,9306d5ea,6301,61573,82593
+79733,Scott,Malone,Malone,,462,196,,,,,,,,f15a50e8,6040,101682,74077
+79852,Jed,Steer,Steer,,,,429,32,28,,,,,a8a3d139,4475,110867,82745
+79934,Oliver,Norwood,Norwood,,68,,302,349,,,488,,,43439614,7710,73547,90324
+80146,Jordan,Ayew,J.Ayew,642,373,505,468,140,153,159,221,192,,da052c14,672,108354,67491
+80179,Adam,Forshaw,Forshaw,286,,,,199,552,224,,,,9f1938ab,1711,121257,82972
+80183,Luke,Garbutt,Garbutt,,629,,,,,,,,,41017ad5,4437,110860,82965
+80201,Bernd,Leno,Leno,,,2,14,8,1,2,275,248,314,2628fd2b,181,72476,92173
+80226,Serge,Aurier,Aurier,,532,360,336,389,358,628,436,,,5c2b4f07,3600,127032,83683
+80254,Carl,Jenkinson,Jenkinson,9,9,581,9,,,,,,,874125a3,938,126321,91879
+80447,Maya,Yoshida,Yoshida,298,308,331,310,,,,,,,caffaf5a,845,81789,37204
+80498,Eunan,O'Kane,O'Kane,40,,,,,,,,,,b7f8b1fc,472,61583,
+80607,Christian,Eriksen,Eriksen,394,387,364,343,,699,519,379,370,,980522ec,646,69633,69344
+80711,Yaya,Sanogo,Sanogo,27,,,,,,,,,,11ced928,4402,127194,
+80755,Danny,Williams,Williams,,184,204,,,,,,,,ec9a28ce,6037,38383,83335
+80788,Daniel,Lafferty,Lafferty,502,,,,,,,,,,cfc41f7a,4428,85928,
+80789,Jordi,Amat,Amat,362,,,,,,,,,,d70a2141,721,85289,83357
+80792,Greg,Cunninghamm,Cunningham,,,467,,,,,,,,dc10b26c,6831,114093,83394
+80801,Idrissa Gana,Gueye,Gana,488,155,168,156,,,611,254,222,302,72c812f3,668,126665,80464
+80935,Papy,Djilobodji,Djilobodji,499,,,,,,,,,,083525e5,1071,136610,83456
+80954,Rodrigo,Moreno,Rodrigo,,,,,492,187,225,,,,1fb1c435,2381,131505,83459
+81012,Ryan,Fredericks,Fredericks,,,408,380,438,415,59,68,,,c067631c,6891,140191,83554
+81048,Josip,Drmic,Drmic,,,,434,,,,,,,15ea94de,209,140579,83588
+81061,Michael,Simões Domingues,Mika,577,,,,,,,,,,d74a54d1,1721,138285,83601
+81183,Matej,Vydra,Vydra,483,,495,92,93,111,,,,,0d4ceb32,1017,101500,84129
+81205,Mislav,Orsic,Orsic,,,,,,,692,,,,ee950928,11298,119150,141670
+81441,Mark,Gillespie,Gillespie,,,,,488,514,776,411,,471,e32958b7,8729,142389,134640
+81880,Alex,Oxlade-Chamberlain,Chamberlain,18,19,248,193,248,227,278,,,,38c7feef,966,143424,84146
+82078,Kenneth,Zohore,Zohore,,,107,,416,,,,,,5e508d0d,6928,135213,83621
+82143,Wes,Foderingham,Foderingham,,,,,350,,,482,522,601,96cf7b61,8776,61697,134482
+82257,Raphael,Spiegel,Spiegel,591,,,,,,,,,,050b9803,1005,111428,84796
+82263,Marcos,Alonso,Alonso,561,100,115,103,104,122,129,,,,f4290206,1621,112515,84008
+82403,Wilfried,Zaha,Zaha,111,126,151,133,141,154,160,,,,b2bc3b1f,522,145988,85059
+82428,Marten,de Roon,de Roon,290,,,,,,,,,,2a1beb34,1710,133179,85070
+82514,Tim,Ream,Ream,,,180,,176,,201,281,253,,28b40c9c,7184,145466,85006
+82660,Marco,Van Ginkel,Van Ginkel,93,,,,,,,,,,47681787,946,147034,
+82691,George,Baldock,Baldock,,,,294,351,,,473,,,394854c4,7706,146690,134244
+82738,Luke,Berry,Berry,,,,,,,,317,,,2aaadf33,11722,125685,139864
+82771,Markus,Henriksen,Henriksen,573,,,,,,,,,,26acecd2,1696,122011,69090
+83091,Borja,González Tomás,Bastón,507,,,623,,,,,,,8c44e37b,1701,85324,106872
+83283,Nathan,Redmond,Redmond,304,324,343,320,365,336,403,600,,,ab651565,790,129078,86425
+83299,Lewis,Dunk,Dunk,,55,48,42,62,59,106,129,120,146,282f75f3,6048,148153,86441
+83312,Ben,Gibson,Gibson,278,,491,89,94,456,,,,,bcfb0142,1707,128904,86458
+83314,Jeff,Hendrick,Hendrick,560,86,78,100,485,297,375,414,,,989d5705,1746,148262,86454
+83427,Jack,Robinson,Robinson,,,,611,352,,,576,,,7399c7a8,8286,128909,86594
+83428,Grant,Hanley,Hanley,,292,,277,,319,,,,,e9254eec,7690,121385,86593
+83543,Anthony,Knockaert,Knockaert,,62,55,52,177,,202,273,,,6c679c6d,4497,149237,86794
+84112,Collin,Quaner,Quaner,,186,209,,,,,,,,19b8b0b9,6035,123397,90996
+84182,Alphonse,Areola,Areola,,,,,516,489,473,524,513,600,2f965a72,2310,120629,92516
+84384,Timm,Klose,Klose,,,,272,,,,,,,5f1d07f6,162,65255,77114
+84395,Florin,Gardos,Gardos,300,,,,,,,,,,70eb7e9d,4405,57423,92331
+84450,Granit,Xhaka,Xhaka,24,23,17,18,9,7,3,30,,668,e61b8aee,204,111455,89401
+84583,Philippe,Coutinho Correia,Coutinho,203,226,,,,681,29,38,,,0ef89a37,488,80444,80767
+84915,Michael,Hector,Hector,,,,,178,,,,,,5f1a2f31,5274,157490,91840
+84939,Danny,Ings,Ings,216,237,258,313,366,337,30,535,523,,07802f7f,986,134294,91762
+85017,Tendayi,Darikwa,Darikwa,60,,,,,,,,,,beecc37c,1666,158700,134668
+85128,Connor,Goldson,Goldson,,61,,,,,,,,,56f6f826,6299,163656,134258
+85242,Conor,Hourihane,Hourihane,,,,28,33,29,,,,,fcab00a0,7721,61653,134172
+85352,Bruno,Martins Indi,Martins Indi,562,513,,,,,,,,,7bc34048,1743,112052,90810
+85368,Christopher,Schindler,Schindler,,164,192,,,,,,,,8ae9869d,6031,57842,132360
+85624,Christian,Kabasele,Kabasele,414,403,380,354,,384,,,,,914ab9a1,1725,81512,68393
+85633,Matz,Sels,Sels,,,,,,,,808,443,502,834b5c4c,6903,127202,78386
+85654,Jordy,Clasie,Clasie,309,319,,,,,,,,,31c01b85,837,104223,90802
+85955,Jorge Luiz,Frello Filho,Jorginho,,,459,118,105,123,130,9,7,,45db685d,1389,102017,106968
+85971,Son,Heung-min,Son,402,390,367,342,390,359,428,516,503,579,92e7e919,453,91845,91909
+86129,Kalidou,Koulibaly,Koulibaly,,,,,,,520,,,,da974c7b,1376,93128,90880
+86153,Martín,Montoya,Montoya,,,503,38,63,,,,,,5cec2487,1950,68645,91387
+86173,Manuel,Agudo Durán,Nolito,237,254,,,,,,,,,b2d0ec1b,1732,70934,91267
+86176,Tom,Ince,Ince,,182,203,,,,,,,,67d23ab0,4454,157368,90918
+86417,Jeffrey,Schlupp,Schlupp,169,123,141,137,142,155,161,240,214,,3312f911,757,157506,91822
+86431,Brice,Dja Djédjé,Dja Djédjé,481,,,,,,,,,,d8593687,3605,93690,
+86873,Benjamin,Lecomte,Lecomte,,,,,,,,,,664,2fa2a875,3451,127181,89928
+86881,Nampalys,Mendy,Mendy,183,205,527,179,518,203,252,,,,1598599e,1785,111051,90278
+86934,Manuel,Lanzini,Lanzini,462,453,414,391,439,416,460,,,,26f6dca8,535,135853,89998
+87107,Cyrus,Christie,Christie,,,460,,179,,,,,,7eb67dad,6833,158623,134111
+87121,Kieron,Freeman,Freeman,,,,292,,,,,,,c13c24c8,8046,158703,91825
+87396,Moritz,Leitner,Leitner,,,,288,,,,,,,9460aaed,1217,82243,91159
+87428,Elias,Kachunga,Kachunga,,181,212,,,,,,,,5bddccc9,248,49501,92804
+87447,Muhamed,Bešić,Bešić,139,152,,522,,,,,,,7ca9f0f0,908,93905,90983
+87835,Matt,Doherty,Doherty,,,425,401,457,360,429,598,543,632,d557d734,6852,171679,94042
+87856,Michael,Hefele,Hefele,,167,,,,,,,,,91bdc54a,6039,102382,104035
+87873,Stuart,Dallas,Dallas,,,,,200,188,226,,,,67ca8566,8718,158764,134143
+88170,Jiri,Skalak,Skalak,,67,,,,,,,,,beaec218,6106,148734,90549
+88175,Lovre,Kalinic,Kalinic,,,,474,,,,,,,3a74f92b,8253,46405,139533
+88248,Stefan,Ortega Moreno,Ortega Moreno,,,,,,,324,361,358,400,c1242d4e,8786,85941,133569
+88482,Álvaro,Morata,Morata,,472,134,,,,,,,,129af0db,1804,128223,91213
+88484,Pablo,Sarabia,Sarabia,,,,,,,704,570,565,,9744ff80,2199,74230,94868
+88498,Benik,Afobe,Afobe,52,49,,,,,,,,,b63f4077,826,110858,93647
+88734,Neil,Etheridge,Etheridge,,,88,,,,,,,,2642bf6c,6821,61694,91953
+88894,Ross,Barkley,Barkley,134,149,127,117,106,124,131,630,29,55,3a24769f,592,131978,92547
+88898,Moses,Odubajo,Odubajo,151,,,,,,,,,,761bc132,,163738,
+88900,Jack,Stephens,Stephens,504,313,333,308,367,338,404,,472,,6adbc307,1735,163744,92550
+88935,Steven,Berghuis,Berghuis,421,411,,,,,,,,,713c144a,744,129554,
+89068,Layvin,Kurzawa,Kurzawa,,,,,,,613,,,,41e7ef1c,3298,126710,92795
+89076,Remo,Freuler,Freuler,,,,,,,582,446,,,98d2c2c4,1488,148252,302691
+89085,Nathaniel,Chalobah,Chalobah,530,112,387,374,,385,203,,,,422862ea,1677,128900,92729
+89274,José Ignacio,Peleteiro Romallo,Jota,,,,36,34,,,,,,9f351459,2132,176591,10447
+89335,Saúl,Ñíguez,Saúl,,,,,,592,,,,,c14bc029,2266,148928,112161
+89470,Onel,Hernández,Hernández,,,,284,,320,,,,,007b39a5,7697,109751,92916
+89572,Denis,Suárez,Suárez,,,586,,,,,,,,12c50af5,2308,165007,106525
+90105,Ryan,Fraser,Fraser,536,47,40,75,507,298,359,410,397,,d56543a0,1683,146795,93160
+90152,Raphaël,Varane,R.Varane,,,,,,555,329,395,,,9f8e9423,2245,164770,93206
+90263,James,Husband,Husband,661,,,,,,,,,,33e2d513,5576,167393,93309
+90440,Tom,Trybull,Trybull,,,,290,,,,,,,552aa16c,7692,93831,96853
+90517,Robbie,Brady,Brady,640,87,79,98,95,,,,,,96bb8cc2,789,128229,93473
+90518,Ravel,Morrison,Morrison,,,,456,,,,,,,bf59c794,1883,128907,93475
+90585,Willy,Boly,Boly,,,423,405,458,428,474,439,425,514,a4ac4b8f,6850,142310,97587
+90714,Ahmed,Musa,Musa,187,207,,,,,,,,,b7084daf,1681,168337,93577
+91046,Cauley,Woodrow,Woodrow,,,,,,,,340,,,d3085b49,11721,169801,138641
+91047,Stuart,Armstrong,S.Armstrong,,,345,323,368,339,405,,,,97333cf5,6893,130765,93677
+91126,Will,Keane,Keane,557,,,,,,,,,,fc7f8f87,1047,118535,107940
+91651,Mateo,Kovačić,Kovačić,,,499,432,107,125,132,356,354,422,79c0821a,2254,51471,93894
+91889,Niclas,Füllkrug,Füllkrug,,,,,,,,,589,625,4f16405e,6098,75489,104058
+91972,Saido,Berahino,Berahino,448,349,,,,,,,,,25b166d0,811,128897,94024
+91979,Jon,Flanagan,Flanagan,194,514,,,,,,,,,f2428fd4,490,145922,94030
+92159,Jetro,Willems,Willems,,,,498,,,,,,,9050ddc4,6143,146258,94885
+92170,Massadio,Haidara,Haidara,,465,,,,,,,,,5167c97e,943,170929,94892
+92217,Roberto,Firmino,Firmino,209,235,257,187,249,228,279,,,,4c370d81,482,131789,96182
+92259,Neeskens,Kebano,Kebano,,,187,,180,,204,,,,18b999f4,6840,111422,94933
+92293,Omar,Elabdellaoui,Elabdellaoui,634,,,,,,,,,,4f56170e,5551,121404,94936
+92371,Pablo,Marí Villar,Pablo Marí,,,,617,10,8,20,,,,aa54ec6f,8380,210178,141032
+92383,Nahki,Wells,Wells,,185,86,,,,,,,,b070482d,6389,173483,122554
+93001,Konstantinos,Stafylidis,Stafylidis,,599,,,,,,,,,861e0116,368,148967,106486
+93100,Jannik,Vestergaard,Vestergaard,,,463,304,369,340,253,,307,,1900032e,111,99331,87182
+93127,Jesé,Rodríguez Ruiz,Jesé,,512,,,,,,,,,4a537185,2256,134936,106028
+93264,Eric,Dier,Dier,390,384,361,350,391,361,430,496,,,ac861941,643,175722,117973
+93284,Florin,Andone,Andone,,,66,46,64,500,,,,,dc008610,4068,177065,255183
+93464,Tom,Carroll,Carroll,397,367,,,,,,,,,5a1900a4,653,121279,90907
+94147,Conor,Coady,Coady,,,430,403,459,429,475,,288,,2928dca2,6851,128901,97710
+94245,Michy,Batshuayi,Batshuayi,96,113,592,461,108,126,,,,,2973d8ff,1678,179184,97803
+94248,Sergio,Rico,Rico,,,509,,,,,,,,5f0241b2,2072,207302,109338
+94924,Gerard,Deulofeu,Deulofeu,141,609,394,363,,,,,,,39583cfd,591,129476,98317
+94926,Freddie,Ladapo,Ladapo,508,505,,,,,,,276,,da2b8db3,1778,233998,141931
+95463,Danny,Ward,Ward,,530,457,170,223,204,254,,308,,d3ce0e89,473,203026,99165
+95508,Fredrik,Ulvestad,Ulvestad,65,575,,,,,,,,,8f160d73,1788,158022,78193
+95658,Harry,Maguire,Maguire,153,198,220,160,298,273,330,387,377,442,d8931174,1687,177907,99487
+95715,Lucas,Rodrigues Moura da Silva,Lucas Moura,,617,370,345,392,362,431,,,,2b622f01,3293,77100,92508
+96305,Jay,Fulton,Fulton,371,362,,,,,,,,,434ad289,896,171260,145999
+96306,Stephen,Kingsley,Kingsley,365,355,,,,,,,,,488cc9c7,892,184398,100718
+96764,M'Baye,Niang,Niang,637,,,,,,,,,,2054d037,1126,157501,58761
+96767,Dimitri,Foulquier,Foulquier,,,,542,,,,,,,45e17712,2509,170472,101084
+96778,Adam,Reach,Reach,285,,,,,,,,,,33a2d4dc,1768,163530,101135
+96784,Jordan,Clark,Clark,,,,,,,,320,,,7c5fa6cf,12187,184129,100594
+96787,Mohamed,Elyounoussi,Elyounoussi,,,346,322,,517,406,,,,68dc0dac,6894,186644,141732
+96994,Bobby,De Cordova-Reid,De Cordova-Reid,,,110,,181,,205,270,290,,0f7533cd,6827,186186,134332
+97032,Virgil,van Dijk,Virgil,303,311,246,183,250,229,280,313,339,373,e06683ca,833,139208,95408
+97296,Tommie,Hoban,Hoban,480,,,,,,,,,,45045170,1002,183161,101373
+97299,John,Stones,Stones,128,242,262,207,273,252,302,368,362,409,5eecec3d,586,186590,101374
+97485,Kevin,Wimmer,Wimmer,388,383,,,,,,,,,faf55ce4,650,122675,101550
+97615,Mike,van der Hoorn,van der Hoorn,366,356,,,,,,,,,25f50295,1702,187105,101605
+97846,Alex,Cairns,Cairns,,,,,,,,,,340,1a5e36e7,,194386,
+98745,Héctor,Bellerín,Bellerín,6,7,4,2,11,9,,,,,f874dd44,492,191217,125211
+98747,Nick,Pope,Pope,471,469,68,93,96,112,376,424,413,469,4b40d9ca,5552,192080,105720
+98770,Ørjan,Nyland,Nyland,,,,27,35,,,,,,bdedffac,250,73517,39187
+98780,Juan Carlos,Paredes,Paredes,410,,,,,,,,,,5d8c6afd,578,100507,
+98914,Guido,Carrillo,Carrillo,,607,350,,,,,,,,8f898ba8,3424,184672,125379
+98980,Emiliano,Martínez Romero,Martinez,657,3,542,427,12,30,31,49,47,32,7956236f,4401,111873,102248
+99127,Joel,Campbell,Campbell,23,,,,,,,,,,895ff3ca,506,131248,
+99323,Lazar,Markovic,Markovic,206,,594,,,,,,,,723ba189,4406,144303,105577
+100059,Alberto,Moreno,Moreno,192,216,240,,,,,,,,11b9265b,608,207917,113275
+100180,Danilo Luiz,da Silva,Danilo,,483,266,209,,,,,,,94b2001f,2244,145707,88300
+100412,André,Carrillo,Carrillo,,527,,,,,,,,,7527558b,6230,135057,97635
+100649,Bernard,Anício Caldeira Duarte,Bernard,,,507,152,154,167,,,,,ab4b3e35,7063,175169,101642
+101061,Philip,Heise,Heise,,,,484,,,,,,,ef66b362,70,112617,132922
+101105,Joe,Bryan,Bryan,,,510,,182,,206,,,,af69e7f0,6834,194460,134331
+101148,Jamaal,Lascelles,Lascelles,,290,312,258,328,299,360,419,407,480,450ab6fc,766,183318,105171
+101178,James,Ward-Prowse,Ward-Prowse,306,317,338,321,370,341,407,664,531,614,3515d404,843,181579,105172
+101179,Lloyd,Isgrove,Isgrove,584,,,,,,,,,,430696d5,1761,226965,130330
+101184,Calum,Chambers,Chambers,11,480,9,467,13,10,32,37,,,dc6f5bdd,508,215118,124316
+101188,Lucas,Digne,Digne,,,484,141,155,168,33,42,36,37,1b84dbe1,1823,126664,89925
+101338,Marcel,Sabitzer,Sabitzer,,,,,,,728,,,,e280527c,5248,106987,92051
+101394,Okay,Yokuslu,Yokuslu,,,,,654,,,,,,e49ce451,6932,137616,93805
+101537,Felipe Anderson,Pereira Gomes,Felipe Anderson,,,465,390,440,,,,,,9f1893b9,1208,159372,93026
+101582,Frederico,Rodrigues de Paula Santos,Fred,,,304,244,299,274,331,381,,,b853e0ad,6817,191614,114397
+101668,Jamie,Vardy,Vardy,184,209,234,166,224,205,255,,306,,45963054,755,197838,106981
+101982,Sam,Johnstone,Johnstone,,,,,417,,175,230,204,627,9e5708be,978,110864,105603
+102057,Raúl,Jiménez Rodríguez,Raúl,,,437,409,460,430,476,558,252,337,b561db50,4105,206040,108186
+102366,Moritz,Bauer,Bauer,,594,,,,,,,,,cfe6238d,5453,159692,103536
+102380,Antonio,Rüdiger,Rüdiger,,103,118,104,109,127,,,,,18b896d6,1822,86202,104010
+102549,Adam,Davies,A.Davies,,,,,,,,479,,,71894777,11733,121254,10894
+102738,Giannelli,Imbula,Imbula,334,343,,,,,,,,,b86fe156,861,130756,81959
+102747,Djibril,Sidibé,Sidibé,,,,511,,,,,,,4c5b714f,3357,161869,10454
+102826,Benjamin,Mendy,Mendy,,484,267,204,274,253,,,,,5271c8f1,3389,157495,105962
+102836,Brice,Samba,Samba,,,,,,,382,,,,60d90c55,4748,191056,
+102884,Paulo,Gazzaniga Farias,Gazzaniga,295,565,536,341,393,,207,,,,63d17038,973,195488,104732
+103025,Riyad,Mahrez,Mahrez,176,199,223,217,275,254,303,359,,,892d5bb1,750,171424,104749
+103100,Jonathan,Williams,Williams,116,,,,,,,,,,49b8432c,1060,170322,
+103123,Sébastien,Haller,Haller,,,,457,441,,,,,,ba115a40,6144,181375,236544
+103127,Molla,Wagué,Wagué,645,197,,,,,,,,,a440d8ca,1159,129893,105339
+103192,Kurt,Zouma,Zouma,79,99,526,459,110,128,461,544,532,,ce4246f5,935,157509,106086
+103912,Jordon,Ibe,Ibe,46,45,38,78,,,,,,,9f736ed2,481,195652,105797
+103914,Charlie,Taylor,Taylor,,81,74,87,97,113,,178,475,,cc2d7ad5,6044,195633,107462
+103955,Raheem,Sterling,Sterling,228,247,270,214,276,255,304,216,186,,b400bde0,618,134425,97692
+104047,Pelly Ruddock,Mpanzu,Mpanzu,,,,,,,,582,,,a9b1c319,11716,244338,135717
+104073,Joe,Ralls,Ralls,,,98,,,,,,,,3730fcbc,6825,195680,108093
+104535,Harry,Bunn,Bunn,,179,,,,,,,,,c8d840f0,,186290,
+104542,Loris,Karius,Karius,189,214,238,,,,626,580,,,32e7ce92,37,85864,107176
+104545,Tommy,Smith,Smith,,166,194,,,,,,,,e9208654,6029,121398,135837
+104547,Dwight,Gayle,Gayle,,301,325,554,329,300,361,,,,e58a03c6,743,196522,118326
+104953,Christian,Atsu,Atsu,,300,320,267,330,,,,,,8816329f,2344,186997,96257
+105377,Ezgjan,Alioski,Alioski,,,,,201,,,,,,1a7fcf39,8722,129604,137161
+105666,Jack,Butland,Butland,316,328,,,586,156,162,,,,cc70a1d5,856,128899,107395
+105700,Davide,Zappacosta,Zappacosta,,543,120,109,,,,,,,7fe90ccd,1178,173859,141312
+105717,Arthur,Masuaku,Masuaku,505,446,410,378,442,417,462,,,678,57df7a11,1760,181380,122980
+106449,Kevin,Stewart,Stewart,198,,,,,,,,,,ff674795,479,200782,107846
+106450,Alex,Pritchard,Pritchard,401,593,206,,,,,,,,ff9fcd4d,815,200777,107848
+106468,Álex,Moreno Lopera,Alex Moreno,,,,,,,694,32,26,43,16e9d0ea,4120,193098,135374
+106603,Ezekiel,Fryers,Fryers,580,,,,,,,,,,f58d6213,1671,141655,107942
+106606,Massimo,Luongo,Luongo,,,,,,,,,277,,967ac6e1,12747,181687,110555
+106611,Michael,Keane,Keane,58,146,162,143,156,169,180,257,228,295,c5b7c315,1653,118534,107941
+106617,Patrick,Bamford,Bamford,553,,,,202,189,227,,,363,93feac6e,822,183334,109670
+106618,Paul,Dummett,Dummett,,291,313,255,331,301,362,581,,,3fe6bd8c,853,170321,112009
+106757,Jürgen,Locadia,Locadia,,604,65,45,,595,,,,,6cc47ae1,6542,166240,107622
+106760,Luke,Shaw,Shaw,247,265,286,226,300,275,332,398,387,443,9c94165b,1006,183288,118244
+106824,Memphis,Depay,Depay,258,,,,,,,,,,8f696594,555,167850,110154
+106837,Dennis,Praet,Praet,,,,517,225,206,549,,,,86695068,1234,129588,106413
+106899,Roque,Mesa,Mesa,,370,,,,,,,,,7c4243d4,2356,202984,108176
+107265,Angus,Gunn,Gunn,668,,452,319,371,448,,,,675,e082af5b,5544,201574,318896
+107613,Romain,Saïss,Saïss,,,426,407,461,431,,,,,9fbbcf39,3491,204198,236519
+108053,Conor,Townsend,Townsend,,,,,418,,,,583,,4dc4f138,8905,146509,108640
+108093,Luciano,Vietto,Vietto,,,513,,,,,,,,2513a588,2274,214316,125543
+108156,Björn,Engels,Engels,,,,455,36,31,,,,,4fdf1fd9,7152,193469,108493
+108411,Dan,Potts,Potts,,,,,,,,333,,,3595affe,12309,207037,108630
+108413,Will,Hughes,Hughes,,416,392,370,,386,163,229,203,270,a0666d3e,6104,207014,108638
+108416,John,Egan,Egan,,,,295,353,,,480,,,debe38a0,7703,121324,108632
+108438,Sandro,Ramírez,Sandro,,160,470,,,,,,,,833fb62e,2537,199369,135242
+108796,Tom,Lockyer,Lockyer,,,,,,,,575,,,37118440,11714,207742,134360
+108813,Christian,Walton,Walton,,,,,503,,,,283,,c666574f,9251,208379,140906
+108823,Dele,Alli,Dele,398,388,365,344,394,363,181,248,,,cea4ee8f,645,207929,131519
+108824,Brendan,Galloway,Galloway,129,,,,,,,,,,321506b3,909,208244,131523
+109065,Davy,Klaassen,Klaassen,,158,171,,,,,,,,15fd5593,6045,182932,108860
+109322,Jesse,Lingard,Lingard,266,279,300,241,301,276,527,,,,810e3c74,558,141660,109000
+109345,Solly,March,March,,66,58,55,65,60,107,140,132,159,bb5fbd2b,6049,209212,122926
+109434,Terence,Kongolo,Kongolo,,591,198,,585,,208,274,,,1f9a3a04,6067,152651,109117
+109528,Javier,Manquillo Gaitán,Manquillo,538,477,315,256,332,302,363,422,,,758dd7f0,1719,162029,109227
+109533,Emerson,Palmieri dos Santos,Emerson,,614,121,107,111,539,545,532,520,604,e0bc6fdc,1245,181778,101955
+109638,Kean,Bryan,Bryan,,,,,603,,,,,,c684d3c9,9163,214928,318890
+109646,Tosin,Adarabioyo,Tosin,607,586,,,572,,209,286,187,232,c81d773d,5590,258878,136464
+109745,Kepa,Arrizabalaga Revuelta,Arrizabalaga,,,498,111,112,129,133,187,152,2,28d596a0,5061,192279,113880
+109788,João Mário,Naval Costa Eduardo,João Mário,,608,,,,,,,,,f0021247,1512,149729,125476
+109999,Ibrahima,Cissé,Cissé,,,521,,,,,,,,be4fede9,6839,160380,109479
+110504,Bertrand,Traoré,Traoré,91,,,,540,32,34,59,,735,c47541e0,695,131996,109807
+110735,Adam,Webster,Webster,,,,493,66,61,108,153,147,153,c40b6180,7699,212847,109922
+110979,Sadio,Mané,Mané,212,230,251,192,251,230,,,,,c691bfe2,838,200512,109915
+111234,Jordan,Pickford,Pickford,340,135,154,148,157,170,182,263,235,287,4806ec67,741,130164,110189
+111291,Fernando,Marçal,Marçal,,,,,505,432,,,,,9ae9eaea,5708,137745,121718
+111317,David,Brooks,Brooks,,,42,76,,,60,64,62,86,dc4cae05,6820,277033,295084
+111452,Odysseas,Vlachodimos,Odysseas,,,,,,,,710,412,472,03df04ff,375,124419,110273
+111457,Sead,Kolasinac,Kolasinac,,13,8,3,14,11,,,,,3935e52e,342,94005,110260
+111478,Joël,Veltman,Veltman,,,,,67,62,109,151,145,152,dad4b285,8780,111195,110290
+111773,Emil,Krafth,Krafth,,,,519,333,303,364,417,405,479,77cf6852,1545,184528,100599
+111782,Robin,Olsen,Olsen,,,,,573,691,35,53,51,,e7ee38c3,6962,75458,41554
+111787,Modou,Barrow,Barrow,379,368,,,,,,,,,75783f5f,720,189070,248351
+111847,Adama,Diomande,Diomande,164,,,,,,,,,,336dbcb2,1694,93145,243562
+111931,Ricardo,Barbosa Pereira,Ricardo,,,221,159,226,207,256,,302,,75a72a99,3303,215876,120763
+112139,James,Wilson,Wilson,270,,,,,,,,,,b0d786ee,992,214104,
+112316,Jakob,Haugaard,Haugaard,317,569,,,,,,,,,142741bb,870,138335,298599
+112338,Emre,Can,Can,204,227,,,,,,,,,a65ce836,604,119296,111212
+112507,Jack,Rose,Rose,548,,,,,,,,,,eb338814,1009,186923,260780
+112516,Isaiah,Brown,Brown,,481,,,,,,,,,bf54c8cc,4481,245805,127119
+112520,Alex,Palmer,Palmer,601,557,,,,,,,764,,6ea97fd5,1038,245625,280770
+113534,Matt,Macey,Macey,660,559,,646,527,,,323,,,136e7649,903,220491,254550
+113564,Sam,Byram,Byram,457,445,404,454,,321,,,,346,1bf811d4,902,236953,118303
+113688,Oumar,Niasse,Niasse,145,548,176,570,,,,,,,af721f98,599,209781,111141
+114000,George,Honeyman,Honeyman,587,,,,,,,,,,84afeaff,1046,218140,278129
+114054,Omar,Bogle,Bogle,,,108,,,,,,,,c334bcfc,,134657,
+114093,Matthew,Pennington,Pennington,131,141,,,,,,,,,0ff967f7,920,220755,141451
+114128,Jonathan,Castro Otto,J.Otto,,,483,402,462,433,477,560,,,e28868f3,2280,175446,115917
+114241,Harry,Toffolo,Toffolo,,,,,,,523,465,444,,a105d46a,10758,198516,298659
+114243,Jacob,Murphy,J.Murphy,,478,321,483,497,304,365,423,402,489,de112b84,6063,199527,141486
+114245,Josh,Murphy,Murphy,,,106,,,,,,,,b30c7426,6828,199528,136783
+114283,Jack,Grealish,Grealish,,,,29,37,33,305,354,349,419,b0b4fd3e,675,203460,113069
+114536,Ryan,Inniss,Inniss,,,,,534,,,,,,600ae8cb,8822,183284,113249
+115357,Mouez,Hassen,Hassen,650,,,,,,,,,,fd481f3f,3313,215677,116615
+115382,Neal,Maupay,Maupay,,,,502,68,63,110,258,229,,4bcf39f6,3621,217115,119822
+115556,Ben,Davies,Davies,386,381,356,329,395,364,432,495,484,571,44781702,660,192765,103837
+115854,Duncan,Watmore,Watmore,353,,,,,,,,,,2b2bae51,919,248045,141512
+115858,Rachid,Ghezzal,Ghezzal,,,492,173,,,,,,,dc3a9a0d,3276,118287,95423
+115918,Rúnar Alex,Rúnarsson,Rúnarsson,,,,,547,2,,18,,,8fa8f8d2,6875,205657,141841
+116216,Leandro,Trossard,Trossard,,,,421,69,64,111,26,23,20,38ceb24a,7698,144028,113994
+116404,Felipe Augusto,de Almeida Monteiro,Felipe,,,,,,,730,445,,,51a3c4c8,7921,156501,102173
+116535,Alisson,Becker,A.Becker,,,468,189,252,231,281,291,310,366,7a2e46a8,1257,105470,114147
+116543,Valentino,Lazaro,Lazaro,,,,614,,,,,,,016ff750,6352,186368,114323
+116594,N'Golo,Kanté,Kanté,95,111,126,119,113,130,134,,,,b9fbae28,751,225083,114075
+116643,Fabio Henrique,Tavares,Fabinho,,,255,197,253,232,282,296,,,7f3b388c,3420,225693,115916
+118335,Abdul Rahman,Baba,Baba,80,,,,,,,190,,,e4086af3,684,224884,
+118342,Mark,Flekken,Flekken,,,,,,,,101,91,,a92ab7be,7047,125714,115131
+118748,Mohamed,Salah,M.Salah,,234,253,191,254,233,283,308,328,381,e342ad68,1250,148455,108226
+118884,Erik,Durm,Durm,,,461,,,,,,,,cf623c78,2640,93922,115165
+119471,Fabian,Schär,Schär,,,482,252,334,305,366,427,415,474,c8aa95da,76,135343,82726
+119765,Allan,Marques Loureiro,Allan,,,,,502,171,183,,,,cc700722,1379,126422,82438
+120202,Wout,Weghorst,Weghorst,,,,,,700,701,183,,,c4e87b8b,7052,228645,115479
+120250,André,Tavares Gomes,André Gomes,,,508,422,158,172,184,244,,,1961b2aa,2383,221025,118123
+120447,Bradley,Smith,Brad Smith,197,37,,,,,,,,,c76c717c,477,175745,141414
+120721,Kevin,Mbabu,Mbabu,,,,,,,532,277,250,,493924a7,983,183321,115230
+121145,João,Cavaco Cancelo,João Cancelo,,,,518,277,256,306,346,353,,bd6351cd,2379,182712,128967
+121160,Ederson,Santana de Moraes,Ederson M.,,240,260,212,278,257,307,352,347,399,3bb7b8b4,6054,238223,121774
+121221,Ramiro,Funes Mori,Funes Mori,132,142,,,,,,,,,89cbc961,597,11111,121454
+121570,Julian,Jeanvier,Jeanvier,,,,,,722,,,,,5cb215fc,10545,134277,120000
+121599,Abdoulaye,Doucouré,A.Doucoure,482,414,390,368,512,173,185,249,217,,02b29014,1726,127187,116317
+121709,Walter,Benítez,Benitez,,,,,,,,,,254,8a2248b4,5652,296802,130304
+122074,Marcus,Bettinelli,Bettinelli,,,178,,183,606,635,192,155,401,0d85a4e8,7076,116648,135768
+122342,Emerson,Hyndman,Hyndman,45,584,41,,,,,,,,3be1a627,6457,223047,231119
+122411,Cameron,Burgess,Burgess,,,,,,,,,263,,da61ca98,12755,255788,231118
+122775,Morgan,Sanson,Sanson,,,,,647,34,36,56,,,6e7f1353,3696,174094,115508
+122797,Callum,Paterson,Paterson,,,101,,,,,,,,d2583bce,6826,169555,253843
+122798,Andrew,Robertson,Robertson,152,475,247,181,255,234,284,307,335,372,2e4f5f03,1688,234803,115726
+122806,John,McGinn,McGinn,,,,31,38,35,37,50,48,54,90f91999,7723,193116,318449
+123125,Viktor,Fischer,Fischer,289,,,,,,,,,,b5920350,1713,95755,101862
+123354,Kortney,Hause,Hause,,,525,25,39,36,38,45,40,,bf8fad51,6859,233124,134207
+124165,Patrick,Roberts,Roberts,,,,435,,,,,,545,59d93937,925,225452,136462
+124183,Hakim,Ziyech,Ziyech,,,,,114,131,135,218,,,6622454d,8992,217111,115868
+126184,Nathan,Aké,Aké,36,38,31,59,279,258,308,342,341,405,eaeca114,579,177476,122945
+126187,Ruben,Loftus-Cheek,Loftus-Cheek,88,108,132,115,115,132,136,,,,e97fd090,688,202886,255777
+126407,Nabil,Bentaleb,Bentaleb,395,,,612,,,,,,,3189f61a,914,245537,137521
+126468,Tokelo,Rantie,Rantie,50,,,,,,,,,,7ef25942,958,198495,
+128198,Sofiane,Boufal,Boufal,551,322,341,508,372,,,,,,b0c71810,1734,232271,234363
+128295,Christian,Nørgaard,Nørgaard,,,,,,77,79,110,101,24,df0a4c90,7083,148367,101856
+128309,Jamal,Lowe,Lowe,,,,,,,61,73,,,b2856bc0,10865,239949,362126
+128340,Kieffer,Moore,Moore,,,,,,,62,76,,,01ce9e70,10743,275590,133190
+128348,Ibrahim,Amadou,Amadou,,,,507,,,,,,,9260926b,3358,205503,118885
+128389,Aleksandar,Mitrović,Mitrović,,303,480,,184,,210,278,,,3925dbd6,773,51152,115279
+130025,Luis,Hernández,Hernández,175,,,,,,,,,,02d2c436,1680,62945,294139
+130036,Ozan,Tufan,Tufan,,,,,,557,,,,,17d45fb2,9957,236471,115639
+130103,Hiram,Boateng,Boateng,543,,,,,,,,,,929917ce,1059,244125,135732
+131304,William,Troost-Ekong,Troost-Ekong,,,,,,387,,,,,7ed4921e,6996,192875,133400
+131403,Rhys,Healey,Healey,,,573,,,,,,,,07ace8c3,7340,238185,119026
+131897,Mathew,Ryan,Ryan,,54,47,47,70,65,,,,,4535e4bb,2385,128969,81523
+132015,Pierre-Emile,Højbjerg,Højbjerg,312,321,340,325,396,365,433,499,490,,8b04d6c1,343,167799,101859
+133085,Lawrence,Vigouroux,Vigouroux,,,,,,,,181,,,a949d040,12196,243591,137804
+133798,Serge,Gnabry,Gnabry,19,,,,,,,,,,88e357ef,993,159471,
+133801,Jerome,Sinclair,Sinclair,428,499,398,,,,,,,,1695c659,972,236513,274630
+133845,Emiliano,Marcondes,Marcondes,,,,,,,63,74,,,4d960fc3,10745,232964,115085
+134383,Connor,Randall,Randall,196,,,,,,,,,,412e1445,474,262545,296522
+135363,Andreas,Christensen,Christensen,,470,119,108,116,133,,,,,1cb49278,200,196948,130331
+135365,Jeremie,Boga,Boga,,509,,,,,,,,,fe012aca,3544,216569,280766
+135720,Kevin,Danso,Danso,,,,532,,,,,767,570,6e33125f,5261,263236,330816
+138001,Tom,King,King,,,,,,,,564,556,630,5791b997,12245,215810,243164
+138009,Sullay,Kaikai,Kaikai,494,515,477,,,,,,,,fc166e49,1070,244130,260451
+139110,Ondrej,Duda,Duda,,,,601,,,,,,,79ca3e23,5240,232418,115257
+140200,Thomas,Strakosha,Strakosha,,,,,,,517,116,,,339fe0e8,1214,222209,121480
+140941,Stipe,Perica,Perica,,,,,,388,,,,,269b4638,1154,245072,
+141020,Max,Meyer,Meyer,,,486,136,143,,,,,,eba42d2b,338,146164,124598
+141569,Léo,Bonatini,Bonatini,,,438,,463,,,,,,da23d58d,6855,181781,137269
+141746,Bruno,Borges Fernandes,B.Fernandes,,,,618,302,277,333,373,366,449,507c7bdf,1228,240306,123761
+141921,Oluwaseyi,Ojo,Sheyi Ojo,207,229,,,,,,,,,7b9a86e6,478,236510,
+143877,Alexander,Sørloth,Sørloth,,620,153,,,,,,,,e92cd3f7,6531,238407,302497
+144485,Ivan,Toney,Toney,,,,,,78,80,117,108,,e09f279b,998,251664,134240
+144660,Didier,Ndong,Ndong,559,618,,,,,,,,,885b7aa7,1720,210081,149599
+145212,Clinton,N'Jie,N'Jie,404,,,,,,,,,,77f278a0,960,241119,
+145235,José Ángel,Esmorís Tasende,Angeliño,498,,,440,,,,,,,30941e96,1040,277179,255089
+146426,Oluwasemilogo Adesewo Ibidapo,Ajayi,Ajayi,,,,,419,,,,,,d6192210,4490,251912,247815
+146610,Jack,O'Connell,O'Connell,,,,293,354,,,,,,312626c1,7705,212829,134473
+146941,Aymeric,Laporte,Laporte,,612,268,202,280,259,309,357,,,119b9a8e,2498,176553,122117
+147303,Laurent,Depoitre,Depoitre,,187,210,,,,,,,,aa5859cb,6038,90583,106880
+147611,Paul,Onuachu,Onuachu,,,,,,,732,,470,,c06d1086,11360,272855,122182
+147612,Richairo,Zivkovic,Zivkovic,,,,622,,,,,,,d2d74d9c,8472,252755,122206
+147668,Cameron,Brannagan,Brannagan,210,,,,,,,,,,9220e731,1023,261357,
+147675,Chuba,Akpom,Akpom,493,,,,,,,,,,e2b384d2,1790,197642,122294
+148179,Enner,Valencia,Valencia,469,460,,,,,,,,,fb485406,539,139503,83895
+148225,Anthony,Martial,Martial,267,280,301,239,303,278,345,390,,,8b788c01,553,182877,122366
+148508,Mahmoud Ahmed,Ibrahim Hassan,Trézéguet,,,,465,40,37,,,,,3ae14ed1,7722,234189,313545
+149016,Lynden,Gooch,Gooch,520,,,,,,,,,,1ea00b03,1027,307781,294849
+149051,Ethan,Robson,Ethan Robson,615,,,,,,,,,,961a5164,5581,258199,332124
+149065,José,Malheiro de Sá,José Sá,,,,,,475,478,569,554,628,903b6e8b,9740,249994,122714
+149266,Alfie,Mawson,Mawson,558,357,487,,185,,,,,,d368feb8,1727,287431,135727
+149468,Tyias,Browning,Browning,130,,532,,,,,,,,c4e180f0,977,156934,123138
+149484,Tyrone,Mings,Mings,35,36,30,445,41,38,39,51,49,40,8397a50c,1024,253677,123167
+149519,Maxwel,Cornet,Cornet,,,,,,578,575,527,515,617,beb391dd,3278,234781,125004
+149736,Chancel,Mbemba,Mbemba,,494,316,,,,,,,,e76cb9cc,849,203348,104368
+149828,Islam,Slimani,Slimani,567,212,,,579,,,,,,ffec9769,1682,174915,108055
+149915,Diego,Llorente,Llorente,,,,,549,190,228,,,,bba30585,2163,246291,123232
+149929,Wes,Burns,Burns,,,,,,,,,264,,b3fe23c6,12749,255731,135729
+151086,Mario,Lemina,Mario Jr.,,500,344,324,493,,698,565,557,,2b471f99,1299,170934,123481
+151119,DeAndre,Yedlin,Yedlin,389,288,310,253,335,,,,,,ae0a7ddf,727,255916,126958
+151589,Leander,Dendoncker,Dendoncker,,,519,420,464,434,479,40,33,61,5a7301ae,7236,168157,124106
+152015,Guillermo,Varela,Varela,246,,,,,,,,,,5c961282,547,188862,
+152551,Jefferson,Lerma Solís,Lerma,,,494,82,,,64,231,206,272,9b5ce51a,2182,262980,133464
+152590,Alex,Telles,Alex Telles,,,,,568,279,334,370,,,e73c9bb2,1828,255755,125793
+152760,Divock,Origi,Origi,217,238,543,188,256,235,,714,,,43a166b4,484,148368,124688
+152898,Ben,Davies,Davies,,,,,653,248,499,,,,c9009a1f,9318,257097,124204
+153127,Isaac,Hayden,Hayden,,496,323,271,336,306,,413,400,495,c951a6df,6062,206225,136356
+153133,Alex,Iwobi,Iwobi,21,21,15,17,159,174,186,256,247,324,6ca5ec4b,500,242631,136824
+153256,Mohamed,Elneny,M.Elneny,22,22,16,20,526,12,4,3,,,47a34c4f,496,160438,125209
+153366,Harrison,Reed,Reed,307,,,,373,,211,282,254,336,803ae100,910,226973,135724
+153371,Sam,Gallagher,Gallagher,,,574,316,,,,,,,44361ade,4483,227183,138027
+153373,Sam,McQueen,McQueen,592,314,334,,,,,,,,b27b49b4,1733,226968,142438
+153379,Josh,Sims,Sims,604,323,342,,374,,,,,,6d6f09dc,5565,286919,330916
+153477,Conor,Masterson,Masterson,,639,,,,,,,,,db975607,6664,293784,302215
+153601,Carlos,De Pena,De Pena,287,,,,,,,,,,6b915aa1,,257740,
+153673,Jonjoe,Kenny,Kenny,616,145,161,,160,502,,,,,099e666f,1084,258883,255961
+153678,Chris,Long,Long,72,,,,,,,,,,52c8b203,,183298,
+153682,Harry,Wilson,Wilson,653,,,505,257,,212,288,259,329,c6dc9ecd,5596,279455,333044
+153723,John,Lundstram,Lundstram,,,,297,355,,,,,,0df2b165,7708,156941,126149
+153772,Luke,McGee,McGee,529,,,,,,,,,,bfa6049d,1769,183301,251136
+154043,Ainsley,Maitland-Niles,Maitland-Niles,593,546,20,4,15,13,21,,,,e3a5814e,1750,285845,255169
+154048,Stephy,Mavididi,Mavididi,,,,,,,,,298,,30144daa,7484,340328,318750
+154050,Olufela,Olomola,Olomola,589,,,,,,,,,,313ba4ae,911,356569,312920
+154051,Oviemuno,Ejaria,Ejaria,582,,,,,,,,,,a801669e,1762,337284,327852
+154131,Jack,Stacey,Stacey,,,,446,,,65,,,,558807c0,7823,249356,231080
+154138,Tariqe,Fosu-Henry,Fosu,,,,,,79,,,,,3dcef539,10092,249873,240848
+154296,João Maria,Lobo Alves Palhares Costa Palhinha Gonçalves,J.Palhinha,,,,,,,220,280,,673,a78ff07f,10715,257455,322774
+154506,Daniel,Bachmann,Bachmann,,582,,,,389,,,,,1c0eea98,1025,120186,141468
+154558,Thomas,Robson,Thomas Robson,537,,,,,,,,,,a18298ff,1079,257968,252285
+154559,Michael,Ledger,Ledger,624,,,,,,,,,,a3354171,5591,320228,332418
+154561,David,Raya Martín,Raya,,,,,,80,81,113,15,1,98ea5115,9676,262749,276366
+154566,Dominic,Solanke-Mitchell,Solanke,590,239,259,69,,,66,85,82,596,e77dc3b2,1679,258889,136459
+154976,Adnan,Januzaj,Januzaj,261,,,,,,,,,,4737cebe,323,177847,130334
+154998,Takuma,Asano,Asano,28,,,,,,,,,,13ddc856,6087,245744,
+155197,Max,Lowe,Lowe,,,,,511,,,484,,,7af88b33,8918,258885,136452
+155405,Kalvin,Phillips,Phillips,,,,,204,191,325,364,359,429,4f565d77,8719,351749,270446
+155408,Lewis,Cook,Cook,47,46,39,79,,,67,66,64,88,2afc7272,1789,249089,136456
+155503,Freddie,Woodman,Woodman,,529,553,264,,513,,,,369,19e50035,852,226049,136466
+155509,Greg,Olley,Olley,514,,,,,,,,,,784b9507,1773,257533,322594
+155511,Adam,Armstrong,Armstrong,,,,,,525,408,,453,817,68c720b5,4419,250426,136460
+155513,Rolando,Aarons,Aarons,,467,,499,337,,,,,,c5942695,915,258188,235743
+155529,Marek,Rodák,Rodák,,,,,186,,213,284,,,17acc2ed,8704,186901,256125
+155561,Ludwig,Augustinsson,Augustinsson,,,,,,,525,,,,9fec8860,6083,170646,282994
+155569,Daniel,Amartey,Amartey,182,204,226,178,227,208,257,,,,1a4ef233,759,214056,243552
+155651,Adam,Masina,Masina,,,386,355,,390,,,,,de0f152c,1441,286949,137512
+155706,Dionatan do Nascimento,Teixeira,Teixeira,326,,,,,,,,,,f7f09bee,869,107617,
+155851,Lucas,Pérez,Lucas,549,27,502,,,,,,,,a300ac7e,1700,73185,135663
+156069,Liam,Gibson,Gibson,,,,610,,,,,,,b51f8aee,1076,312553,303109
+156074,Rob,Holding,Holding,484,11,6,10,16,14,5,7,202,264,d79a8c87,1749,253341,288795
+156658,Reece,Burke,Burke,534,596,,,,,,318,,,a681b7b7,1771,264220,141510
+156660,Moses,Makasi,Makasi,664,580,,,,,,,,,4ae7add0,5566,242644,336236
+156683,Pierluigi,Gollini,Gollini,,,,,,486,,,,,f0f7f62f,1841,244192,240990
+156685,Joe,Rothwell,Rothwell,,,,,,,505,81,,,10a10454,561,183293,260784
+156686,James,Weir,Weir,566,,,,,,,,,,c8d651c1,562,251058,302386
+156687,Ben,Pearson,Pearson,,,,,,,68,79,,,a6b461e7,10742,183302,302391
+156689,Andreas,Hoelgebaum Pereira,Andreas,263,476,481,246,304,511,346,267,240,327,6639e500,922,203394,243254
+156690,Joshua,Harrop,Harrop,674,,,,,,,,,,00e1cf8f,5597,289844,338496
+156700,Carlton,Morris,Morris,,,,,,,,326,,,2da834f1,11717,246963,263188
+157665,Filip,Lesniak,Lesniak,671,,,,,,,,,,5348fe7c,5571,186383,320639
+157668,Harry,Winks,Winks,513,391,368,347,397,366,434,,309,,2f7acede,971,249126,143990
+157775,Ken,Sema,Sema,,,446,372,,391,,,,,1770bd68,6841,252345,145392
+157882,Takumi,Minamino,Minamino,,,,590,258,236,,,,,f833a830,8239,165793,262838
+158074,Gabriel Armando,de Abreu,Gabriel,5,6,,,,,,,,,b7ca5c51,493,149498,76810
+158499,Ryan,Christie,Christie,,,,,,,69,65,63,87,26ce2263,10744,188077,128882
+158534,Kyle,Walker-Peters,Walker-Peters,,498,358,337,375,342,409,,476,659,984a5a64,885,341051,313672
+158544,Jake,Hesketh,Hesketh,586,,,,,,,,,,4c83c9f8,1755,315185,255505
+158983,Endo,Wataru,Endo,,,,,,,,668,320,392,c149016b,8808,146310,86829
+159039,Antonio,Barreca,Barreca,,,588,,,,,,,,6a189491,1181,241889,143524
+159506,Ola,Aina,Aina,487,,,,562,,,604,422,507,246d153b,725,236490,315543
+159533,Adama,Traoré Diarra,Adama,563,,500,417,465,435,491,662,239,326,9a28eba4,900,204103,140088
+160190,Kasey,Palmer,Palmer,,183,,,,,,,,,453f566a,705,258216,315544
+160729,Jason,Denayer,Denayer,476,,,,,,,,,,47af88b8,1039,277114,243511
+160816,Donald,Love,Love,506,,,,,,,,,,160599ed,1048,179451,303379
+160817,Patrick,McNair,McNair,249,,,,,,,,,,8ac454b5,559,167268,244565
+160987,Jean-Philippe,Gbamin,Gbamin,,,,497,161,504,187,251,,,6bd603db,4764,182894,129758
+162344,Philip,Zinckernagel,Zinckernagel,,,,,,392,,,,,a5ea254c,,271098,
+162651,Samir,Caetano de Souza Santos,Samir,,,,,,677,,,,,92b4758e,1142,255744,131337
+163463,Papa Alioune,Ndiaye,Badou Ndiaye,,619,,,,,,,,,960acc0a,6525,211325,112698
+163526,Edimilson,Fernandes,Fernandes,542,456,416,,,,,,,,3bb625ac,1673,247555,130964
+163776,Erdal,Rakip,Rakip,,606,,,,,,,,,e150254d,6541,230746,131030
+163793,Matt,Miazga,Miazga,81,,,,,,,,,,9fc0f253,683,245893,
+164011,Mbaye,Diagne,Diagne,,,,,648,,,,,,dda3969e,9290,271966,142072
+164484,Zack,Steffen,Steffen,,,,,538,260,310,367,,,42130443,7817,221624,145473
+164511,Yerry,Mina,Mina,,,506,142,162,175,188,,,,6d5701f2,6521,289446,318432
+164555,Vladimír,Coufal,Coufal,,,,,558,418,463,528,516,,fdf3cb77,8965,157672,111372
+165152,Glen,Rea,Rea,,,,,,,,334,,,5c3f2f39,,337640,
+165153,Timo,Werner,Werner,,,,,117,134,137,776,509,,49fe9070,65,170527,130903
+165183,Amari'i,Bell,Bell,,,,,,,,316,,,399e9474,11713,278166,141209
+165210,Alireza,Jahanbakhsh,Jahanbakhsh,,,476,50,71,66,,,,,08452314,6842,213268,133390
+165659,Diego Carlos,Santos Silva,Diego Carlos,,,,,,,50,41,35,,b4a014b1,5712,329145,134984
+165808,Hélder Wander,Sousa de Azevedo e Costa,Costa,,,435,418,205,192,,,,,f13d02a6,3428,173900,118127
+165809,Bernardo,Mota Veiga de Carvalho e Silva,Bernardo,,256,276,218,281,261,311,344,342,416,3eb22ec9,3635,241641,136741
+165911,Bartosz,Kapustka,Kapustka,497,,,,,,,,,,7364c4d1,1786,246579,295603
+165990,Vincent,Janssen,Janssen,405,395,614,339,,,,,,,31dce0c8,1730,207015,133381
+166324,Ivan,Neves Abreu Cavaleiro,I.Cavaleiro,,,434,419,187,,214,269,,,979b811d,3683,149716,137386
+166325,Carlos,Ribeiro Dias,Cafú,,,,,,,383,,,,85322440,5646,203655,118121
+166477,Timothy,Castagne,Castagne,,,,,498,209,258,688,244,319,197640fd,6157,262226,141169
+166640,Fabián,Balbuena,Balbuena,,,464,382,443,,,,,,3626f7d9,6892,285548,282871
+166989,Youri,Tielemans,Tielemans,,,591,448,228,210,259,58,57,48,56f7a928,5956,249565,136345
+167074,Kenny,Tete,Tete,,,,,517,,215,285,257,322,77d7c96f,5973,206746,145996
+167075,Wesley,Hoedt,Hoedt,,525,336,485,,,,,,,875898c7,1203,253765,141172
+167191,Marcus,Myers-Harness,Harness,,,,,,,,,271,,90e9ca3d,12753,288323,135714
+167199,Thomas,Partey,Thomas,,,,,567,15,6,15,20,,529f49ab,2328,230784,238940
+167473,José,Izquierdo,Izquierdo,,517,61,51,72,,,,,,ca2bc3df,6231,147094,243548
+167512,Luke,O'Nien,O'Nien,,,,,,,,,,539,8092d497,14099,282939,134373
+167522,Jordan,Hugill,Hugill,,622,420,,444,322,,,,,a36d4785,6526,291544,139334
+167541,Jack,Payne,Payne,,177,,,,,,,,,edfbda18,,278092,
+167767,Robert Kenedy,Nunes do Nascimento,Kenedy,94,110,458,462,,690,138,,,,5eebbfdf,689,281404,132838
+167789,Baily,Cargill,Cargill,649,,,,,,,,,,6dbe8f69,976,293450,140889
+167878,Ben,Osborn,Osborn,,,,472,356,,,489,,,79bc4c45,7714,218087,140667
+167887,Josh,Laurent,Laurent,,,,,,,,,,209,f0068e0f,13728,314241,142676
+167888,Joe,Lumley,Lumley,,,,,,,,,466,,bdf3a08e,12762,336367,288788
+168035,Fred,Onyedinma,Onyedinma,,,,,,,,329,,,387d06b2,12549,305274,141431
+168090,Mahmoud,Dahoud,Dahoud,,,,,,,,128,119,,db4ed67b,205,191422,135092
+168172,Joe,Lolley,Lolley,,176,,,,,384,,,,c5f13182,6139,287167,138785
+168196,Joel Dinis,Castro Pereira,Joel Pereira,662,262,,,,,,,,,881e5db7,5575,192611,312584
+168281,Scott,McKenna,McKenna,,,,,,,385,455,,,4e5a4cbc,10757,255906,364624
+168287,Jonathan,Calleri,Calleri,526,,,,,,,,,,6922f806,1672,284727,133445
+168290,Ignacio,Pussetto,Pussetto,,,,604,,,,,,,62437b4f,6997,283528,134698
+168399,Will,Norris,Norris,,,422,413,583,114,,,,,c73ada83,7459,285033,139866
+168547,Ethan,Horvath,Horvath,,,,,,,,449,,,3f65d5ce,11708,242284,296544
+168566,Georges-Kévin,Nkoudou,Nkoudou,565,392,497,527,,,,,,,76c131da,1729,215679,134887
+168580,Ayoze,Pérez,Pérez,,302,326,265,229,211,260,,,,819aa8e7,770,246968,135366
+168636,Enes,Ünal,Enes Ünal,,,,,,,,804,65,98,f8eca1b6,6219,251106,134695
+168717,Maksymilian,Stryjek,Stryjek,547,,,,,,,,,,bfc2e586,1770,240457,259134
+168763,Cameron,Carter-Vickers,Carter-Vickers,501,511,,,521,,,,,,88ced02c,1758,341049,301029
+168764,Luke,Amos,Amos,,,523,351,,,,,,,77128f7e,6819,258912,329492
+168765,Josh,Onomah,Onomah,399,,,,188,,216,,,,6612cd8c,661,243589,136455
+168977,Joel,Coleman,Coleman,,162,598,,,,,,,,b73e459a,6041,285551,135179
+168991,Philip,Billing,Philip,,175,202,476,,,70,63,76,89,d328a254,6034,320411,145277
+169061,Dael,Fry,Fry,277,,,,,,,,,,43e79bbc,5577,314140,288989
+169102,Tiemoué,Bakayoko,Bakayoko,,463,129,,,,,,,,59bf127b,3429,182618,135211
+169130,Joel,Taylor,Taylor,631,,,,,,,,,,3a6e34b9,5588,258310,332836
+169141,Steve,Mounie,Mounie,,188,211,,,,,,,,19ba6c6d,3800,238639,135259
+169187,Trent,Alexander-Arnold,Alexander-Arnold,523,223,245,182,259,237,285,290,311,,cd1acf9d,1791,314353,318871
+169359,Matt,Targett,Targett,299,309,479,309,42,39,367,428,416,484,e514ab62,884,250478,136776
+169432,Oliver,McBurnie,McBurnie,546,372,,501,357,,,485,,,78b8ac63,1736,298477,138695
+169527,Joe,Williams,Joe Williams,658,,,,,,,,,,44c38f2e,5547,268185,255962
+169528,Antonee,Robinson,Robinson,,,,,484,,217,283,255,316,289601e6,8940,349701,306581
+169535,Julien,de Sart,de Sart,288,,,,,,,,,,33332e0b,1751,129592,136396
+169593,Remi,Matthews,Matthews,,,,,,561,495,233,209,255,27f4f772,9834,196722,229492
+169735,Noor,Husin,Husin,611,,,,,,,,,,9035308b,5582,320220,331923
+169743,Connor,Mahoney,Mahoney,,585,,,,,,,,,38df681f,6458,287528,135773
+170137,Allan,Saint-Maximin,Saint-Maximin,,,,500,338,307,368,426,,,2b16cb1a,101,272642,135891
+170154,Pablo,Maffeo,Maffeo,528,,,,,,,,,,5db04597,1003,251876,294848
+170271,Jean Michaël,Seri,Seri,,,456,,189,,,,,,10efd0e1,3312,178614,136262
+170851,Josh,Robson,Josh Robson,532,,,,,,,,,,e10308d3,1781,357958,294516
+171099,Hassane,Kamara,Kamara,,,,,,676,,,,,19a12bed,3729,290017,239881
+171101,Clément,Lenglet,Lenglet,,,,,,,513,699,,,4f28a6ff,5050,182904,236511
+171129,Diego,Rico,Rico,,,473,65,,,,,,,d9ba39fc,5065,249513,323352
+171162,Charly,Musonda,Musonda,,471,,,,,,,,,62a0089e,2147,177862,303172
+171270,Kieran,Dowell,Dowell,,,528,,,323,,,,,2f6ec02a,1032,258916,136458
+171273,Cameron,Borthwick-Jackson,Borthwick-Jackson,252,,,,,,,,,,ff61102d,1037,258879,
+171277,Demetri,Mitchell,Mitchell,669,,,,,,,,,,c286f3c2,5574,258886,136457
+171287,Joe,Gomez,Gomez,195,218,242,184,260,238,286,298,322,376,7a11550b,987,256178,136451
+171314,Rúben,dos Santos Gato Alves Dias,Rúben,,,,,556,262,312,350,361,408,31c69ef1,8961,258004,313171
+171317,Rúben,da Silva Neves,Neves,,,433,414,466,436,480,,,,44bfb6c5,6853,225161,238244
+171319,Renato,Sanches,Sanches,,535,,,,,,,,,032f894e,5228,258027,299450
+171422,Alan,Browne,Browne,,,,,,,,,,555,25dea15a,,277697,
+171771,Jan,Bednarek,Bednarek,,315,335,307,376,343,410,,455,,4115ce4e,6042,243028,136742
+171975,Callum,Robinson,Callum Robinson,,,,453,358,,,,,,e75750a3,4476,183299,138768
+171982,Brian,Lenihan,Lenihan,148,,,,,,,,,,7f1df59b,,241916,
+172246,Florent,Hadergjonaj,Hadergjonaj,,521,197,,,,,,,,9aa186b2,5215,238809,136896
+172453,Sam,Szmodics,Szmodics,,,,,,,,,611,,39944392,12752,292139,138686
+172551,Callum,Roberts,Roberts,,,577,,,,,,,,8e9caf48,7347,288952,256534
+172567,Josh,Cullen,Cullen,463,597,,,,,,165,,205,f6d7d690,1018,242606,273292
+172632,Demarai,Gray,Gray,181,203,225,175,230,484,189,253,,,4468ec10,762,292417,136945
+172649,Dean,Henderson,Henderson,,,,471,305,280,398,385,201,253,e5a76dfe,7702,258919,304008
+172780,James,Maddison,Maddison,,,233,171,231,212,261,504,494,581,ee38d9c5,6818,294057,137015
+172782,Josh,Brownhill,Brownhill,,,,620,98,115,,161,,,47369df8,8323,293569,138929
+172841,Saïd,Benrahma,Benrahma,,,,,587,419,464,525,,,5a04fd92,3585,290532,137021
+172850,Ben,Chilwell,Chilwell,496,196,219,161,232,135,139,195,160,,d2424d1b,782,316125,299272
+172912,Sofyan,Amrabat,Amrabat,,,,,,,,709,,,5a2cb25d,7927,287579,248144
+173268,Ivo,Grbic,Grbić,,,,,,,,790,,,3f034750,8923,226073,377309
+173271,Duje,Caleta-Car,Caleta-Car,,,,,,,623,,,,94f8d10c,7007,238266,251134
+173399,Mohamed,Dräger,Dräger,,,,,,,386,444,,,8954fddc,6476,192167,
+173514,Isaac,Success Ajayi,Success,424,413,524,365,,393,,,,,f573a8bf,1724,295331,145940
+173515,Kelechi,Iheanacho,Iheanacho,241,258,236,167,233,213,262,,,,c92e1a31,620,295330,289253
+173792,Reece,Oxford,Oxford,455,611,407,,,,,,,,8b6e0db2,543,314295,260779
+173804,Layton,Ndukwu,Ndukwu,,647,,,,,,,,,2219083d,6755,314284,357426
+173807,Tom,Davies,T.Davies,512,156,169,154,163,176,190,666,,,9228b07c,1042,314210,316077
+173809,Jonathan,Leko,Leko,445,431,,,420,,,,,,76b5cbbd,879,314266,315290
+173810,Darnell,Johnson,Johnson,,,,662,,,,,,,8eaf6aea,8564,314372,396318
+173818,Nathan,Broadhead,Broadhead,,,,,680,545,,,262,,43309491,9406,344009,349671
+173821,Tyler,Roberts,Roberts,,,,,206,193,229,,,,6c17e046,1014,296986,280771
+173879,Tammy,Abraham,Abraham,,374,496,460,118,136,,,,808,f586779e,702,331726,317506
+173904,Davinson,Sánchez,Sánchez,,520,359,333,398,367,435,512,,,da7b447d,6249,341429,322655
+173954,Jairo,Riedewald,Riedewald,,482,144,539,144,157,164,239,,,7a1f2c08,6027,241481,141246
+174248,George,Thomas,Thomas,,587,,,,,,,,,7ef24097,6462,298240,138445
+174254,Pedro,Chirivella,Chirivella,211,,,,,,,,,,68a26d51,1022,242273,
+174292,Marco,Asensio,M.Asensio,,,,,,,,,762,,45af8a54,2117,296622,137467
+174310,Elijah,Adebayo,Adebayo,,,,,,,,314,,,0480ebc7,11718,319900,362145
+174590,Jacob,Maddox,Maddox,,,,663,,,,,,,ff97076d,8565,314268,362196
+174592,Marcus,Edwards,Edwards,,,,,,,,,,206,57760e66,13730,314367,279177
+174593,Kyle,Edwards,Edwards,,,,,421,,,,,,1566e437,8758,314366,297020
+174594,Lukas,Nmecha,Nmecha,,627,,,,,,,,365,0cc5f4a5,6544,314288,347340
+174595,Admiral,Muskwe,Muskwe,,,,,,,,327,,,ee2b9a18,,314378,
+174597,Andre,Green,Green,,,,32,,,,,,,6e287b7a,874,309841,
+174874,Joachim,Andersen,Andersen,,,,,571,488,165,220,191,317,e34fc66d,6314,260827,231135
+174932,Sergi,Canós Tenés,Canós,,,,,,81,82,95,,,1137759d,1078,251845,295964
+175351,Demeaco,Duhaney,Duhaney,,,601,,,,,,,,5ef608f7,7437,380913,349568
+175353,Ayotomiwa,Dele-Bashiru,Dele-Bashiru,,,,563,,394,,,,,0666f848,8162,346472,350062
+175592,Naby,Keita,Keita,,,256,196,261,239,287,,,,f25c8e3a,5247,302215,243510
+175941,Alfie,Whiteman,Whiteman,,566,538,543,,,,521,510,,3f2587ee,6397,282823,328106
+175946,Víctor,Camarasa,Camarasa,,,504,510,,,,,,,b2d03887,2390,263856,140957
+176295,Matthew,Willock,Willock,655,,,,,,,,,,7e4985b2,5579,289845,335593
+176296,Ashley,Fletcher,Fletcher,535,459,,,,395,,,,,eeb6551f,1675,289846,302206
+176297,Marcus,Rashford,Rashford,271,284,305,233,306,281,335,396,385,451,a1d5bd30,556,258923,300299
+176413,Christian,Pulisic,Pulisic,,,,431,119,137,140,213,,,1bf33a9a,2662,315779,302692
+176414,Luca,De La Torre,De La Torre,,,621,,,,,,,,e9241b40,7600,315762,322406
+176420,Darnell,Furlong,Furlong,,,,,422,,,,,,3ec9195b,4391,351755,262401
+176706,Alfie,Jones,Jones,,,595,,,,,,,,e5c107a1,7391,340990,323793
+177815,Dominic,Calvert-Lewin,Calvert-Lewin,595,159,175,147,164,177,191,246,220,691,59e6e5bf,5555,306024,141469
+178173,Matt,Clarke,Clarke,,,,43,73,,543,,,,8ea2227a,,307497,
+178186,Jarrod,Bowen,Bowen,516,,,626,445,420,465,526,514,624,79c84d1c,1776,314875,322596
+178301,Ollie,Watkins,Watkins,,,,,514,40,40,60,58,64,aed3a70f,8865,324358,148503
+178304,Lys,Mousset,Mousset,53,50,44,70,359,,,,,,d9cfca3d,1748,291422,296332
+178867,Antonio,Martinez Lopez,Martínez,,567,,,,,,,,,f3945e07,6400,302371,280060
+178871,Aleix,García Serrano,García,578,,,,,,,,,,a10361d2,1055,261504,280663
+178876,Jesús,Vallejo Lázaro,Vallejo,,,,473,,,,,,,c2111b45,5234,251896,238901
+179018,Miguel,Almirón Rejala,Almirón,,,587,266,339,308,369,402,391,,862a1c15,7420,272999,303924
+179261,Zachary,Dearnley,Dearnley,673,,,,,,,,,,0484975a,5600,396284,338499
+179268,Marc,Cucurella Saseta,Cucurella,,,,,,584,112,198,163,224,1daec722,7134,284857,363496
+179276,Mathias,Normann,Normann,,,,,,581,,,,,8996350d,7470,257805,320959
+179456,Oskar,Buur,Buur,,,,587,467,,,,,,aa6f2f2c,8227,293283,345769
+179458,Jacob,Bruun Larsen,Bruun Larsen,,,,,,,,608,,202,4e204552,5355,293281,307202
+179519,Orel,Mangala,Mangala,,,,,,,536,453,651,,a572e291,6088,289592,344073
+179587,Dennis,Srbeny,Srbeny,,,,279,,,,,,,1fdec858,7822,159239,142470
+179596,Elliott,Moore,Moore,670,,,,,,,,,,328bcff5,5570,341993,338118
+179620,Mamadou Obbi,Oularé,Oularé,427,,,,,,,,,,9e49c320,898,314959,
+179725,Carl,Stewart,Stewart,622,613,,,,,,,,,9e5c080a,5578,479945,332412
+179829,Josh,Pask,Pask,,635,,,,,,,,,ccd1bb4d,6650,339789,284122
+179830,Grady,Diangana,Diangana,,636,539,398,446,,,,,,f522d7ec,6651,342048,306943
+180135,Sean,Longstaff,Longstaff,,,531,270,480,309,370,421,410,493,a2b105e0,7078,346707,342811
+180151,Nikola,Vlašić,Vlašić,,539,173,,,582,466,543,,,aa8e289e,6276,293200,343975
+180184,Donny,van de Beek,Van de Beek,,,,,495,282,336,400,,,50dc94ce,8821,288255,275035
+180294,Karlan,Grant,Grant,,,585,,582,,,,,,87f7500e,7390,314183,244568
+180736,Trevoh,Chalobah,Chalobah,,632,,,,527,141,194,159,226,5515376c,6615,346314,353292
+180804,Axel,Tuanzebe,Tuanzebe,656,272,,481,307,283,,,282,198,2baec6ce,934,342046,299271
+180974,Joelinton Cássio,Apolinário de Lira,Joelinton,,,,466,340,310,371,416,403,490,c17bfb65,87,333241,201755
+181008,Albian,Ajeti,Ajeti,,,,514,447,,,,,,2b1c4abd,2673,195906,143693
+181284,Gonçalo Manuel,Ganchinho Guedes,Guedes,,,,,,,579,554,548,647,e6bc67d7,5682,225122,247995
+181397,Jamie,Sterry,Sterry,,,530,,,,,,,,f13d0f83,779,250431,276986
+181489,Alex,Pike,Pike,608,,,,,,,,,,90a8927f,5589,345960,284123
+181911,Kyle,Scott,Scott,,504,,,,,,,,,1c24aacf,6043,258888,342565
+182156,Leroy,Sané,Sané,489,255,275,216,,,,,,,2b114be3,337,192565,144711
+182436,Ben,Woodburn,Woodburn,603,233,,,696,553,,,,,8aadeaef,5557,344015,330818
+182539,Daniel,Ceballos Fernández,Ceballos,,,,469,501,,,,,,c0617e2b,2446,319745,144890
+182960,Pau,López Sabata,Pau López,564,,,,,,,,,,20b9f052,2107,286415,145427
+183015,Cedric,Kipre,Kipre,,,,,499,,,,,,9f30e7ed,8785,364827,361329
+183487,Nathan,Holland,Holland,665,,611,568,,,,,,,45ab2170,5567,337321,336237
+183656,Josh,Dasilva,Dasilva,,,,,,82,83,99,90,748,60344e4f,10405,340321,318744
+183751,Manuel,Benson Hedilazio,Benson,,,,,,,,159,,201,d7f99582,11702,322702,400244
+184029,Martin,Ødegaard,Ødegaard,,,,,645,558,7,14,13,17,79300479,2517,316264,247454
+184193,Jordan,Smith,Smith,,,,,,,675,,,,cfca9c4e,11245,452707,322566
+184254,Guglielmo,Vicario,Vicario,,,,,,,,520,508,565,77d6fd4d,8858,286047,147863
+184259,Richard,Nartey,Nartey,,,,,658,,,,,,de6cafb8,9313,396861,382369
+184341,Mason,Mount,Mount,,,,463,120,138,142,209,382,455,9674002f,7768,346483,343346
+184349,Ryan,Sessegnon,Sessegnon,,,184,524,399,368,436,514,579,328,6aa3e78b,6837,392775,322611
+184386,James,Bree,Bree,,,,,43,,716,,457,,c07b7c5c,11359,324223,148474
+184667,Victor,Lindelöf,Lindelöf,,273,292,225,308,284,337,386,376,719,f5deef4c,6080,184573,100008
+184704,Marvelous,Nakamba,Nakamba,,,,491,44,41,41,52,,,de5b5570,8040,324882,243249
+184754,Hwang,Hee-chan,Hee Chan,,,,,,583,481,557,550,642,169fd162,8845,292246,262854
+185056,Mateusz,Hewelt,Hewelt,596,,,,,,,,,,d8fc24c9,5546,318547,329677
+185253,Gustavo Henrique,Furtado Scarpa,G.Scarpa,,,,,,,681,462,,,2964fd20,11284,330085,149738
+185431,Ali,Gabr,Gabr,,610,,,,,,,,,10331f88,6652,122980,333025
+185478,Jarosław,Jach,Jach,,605,442,,,158,,,,,99246027,6621,327755,339499
+189627,Dimitris,Giannoulis,Giannoulis,,,,,,457,,,,,112c495e,9745,295630,296838
+189776,Samuel,Bastien,Bastien,,,,,,,,158,,,ec30b9c8,1343,289510,
+191769,Jonathan,Benteke,Jonathan Benteke,579,,,,,,,,,,5c59bc47,1765,273773,326414
+191866,Kristoffer,Ajer,Ajer,,,,,,483,84,90,86,108,a8c0acb7,9677,328658,321085
+192182,Kieran,O'Hara,O'Hara,681,,,,,,,,,,80cbe60b,5599,289791,295133
+192290,Connor,Roberts,Roberts,654,598,,,,585,,176,,186,24fae784,5568,214666,135865
+192301,Jon Gorenc,Stankovic,Stankovic,,169,522,,,,,,,,9c74fa25,2641,245034,254128
+192303,Christoph,Zimmermann,Zimmermann,,,,275,,324,,,,,2d5f03bf,7990,77812,228569
+192895,Kieran,Tierney,Tierney,,,,515,17,16,8,24,21,,fce2302c,8089,300716,297403
+193109,Callum,Slattery,Slattery,,,570,327,,,,,,,059948df,7335,332342,368415
+193111,Todd,Cantwell,Cantwell,,,,287,,325,,,,,f63d8a4b,7695,332341,346738
+193195,Allan,Campbell,Campbell,,,,,,,,319,,,858409be,11727,347619,397153
+193204,Joe,Aribo,Aribo,,,,,,,512,,452,,328f7d51,10766,468198,342877
+193488,Anwar,El Ghazi,El Ghazi,,,,30,45,42,51,,,,ffa90327,5612,183720,232261
+193645,Robin,Koch,Koch,,,,,491,194,230,,,,ea6bc03a,6273,328784,276205
+194010,Rico,Henry,Henry,,,,,,83,85,103,92,109,8a3c1dc7,9679,339556,229562
+194126,Michael,Verrips,Verrips,,,,521,580,,,,,,424595d5,8169,288259,298805
+194164,Mason,Holgate,Holgate,495,144,160,478,165,178,192,255,225,,d0042ab9,985,348623,297544
+194190,Harry,Souttar,Souttar,,550,,,,,727,,303,,0a6cb1b1,6329,298091,344380
+194252,Steven,Bergwijn,Bergwijn,,,,615,400,369,437,,,,a29b1131,8300,284165,279425
+194401,Adalberto,Peñaranda,Peñaranda,,,554,648,,,,,,,4b3f2936,1548,308801,300438
+194634,Diogo,Teixeira da Silva,Diogo J.,,,432,410,468,240,288,294,317,,178ae8f8,6854,340950,235755
+194794,Fikayo,Tomori,Tomori,,503,,529,121,,,,,,7edfbb8a,703,303254,317507
+194798,Bernard,Ashley-Seal,Ashley-Seal,,,,559,,,,,,,4f187520,8128,322089,363974
+194799,Jamal,Lewis,Lewis,,,,276,513,311,372,420,408,,efb9215a,7691,346018,350138
+195064,Mace,Goodridge,Goodridge,,,,571,551,,,,,,6abefdff,8194,382552,389088
+195384,Mikel,Merino Zazón,Merino,,495,322,,,,,,633,22,d080ed5e,5304,338424,238916
+195471,Anthony,Driscoll-Glennon,Driscoll-Glennon,,,615,572,536,,,,,,6a39bd42,7572,503683,373461
+195473,Rhian,Brewster,Brewster,666,,,464,262,,,477,,,30e81a88,5569,406560,336285
+195480,Josh,Maja,Maja,613,,,,665,,,,,,bc0bfc64,5587,453824,325156
+195546,Emiliano,Buendía Stati,Buendía,,,,283,,43,42,35,31,50,66b76d44,2203,321247,260592
+195728,Alex,Kral,Kral,,,,,,589,,,,,e717705a,8017,337333,369861
+195735,Nicolas,Pépé,Pepe,,,,488,18,17,9,16,,,57e3f0c7,5656,343052,239872
+195774,Gedson,Carvalho Fernandes,Fernandes,,,,605,401,,,,,,e2dde94c,8257,337800,361726
+195851,Scott,McTominay,McTominay,667,283,303,248,309,285,338,392,381,,d93c2511,5560,315969,336915
+195855,Beni,Baningime,Baningime,,563,174,557,,,,,,,ca9178af,6384,399369,347436
+195859,Marcus,Browne,Browne,609,631,,,,,,,,,7358a89a,1052,391470,303387
+195860,Joe,Powell,Powell,,,547,,,,,,,,a0961a90,7238,354134,364017
+195864,Sam,Field,Field,511,433,,,423,,,,,,bd8a7d05,1013,387331,317243
+195899,Gianluca,Scamacca,Scamacca,,,,,,,529,541,,,8790f988,6253,315867,302650
+196100,Gustavo,Hamer,Hamer,,,,,,,,663,,,eebacc07,11839,322985,332143
+196118,Yoshinori,Muto,Muto,,,488,260,341,,,,,,5343eb4e,47,230541,132210
+196411,Conor,Chaplin,Chaplin,,,,,,,,,265,,4ec55b87,12750,349503,256129
+197024,Guido,Rodríguez,G.Rodriguez,,,,,,,,,588,618,34e393f2,8267,342385,303876
+197030,Aboubakar,Kamara,Kamara,,,189,,190,,,,,,4047c976,4866,290951,243076
+197365,Eric,Bailly,Bailly,255,271,291,228,310,286,339,375,,,a1232f4e,1739,286384,243814
+197464,Nathaniel,Phillips,N.Phillips,,,,589,589,241,501,306,332,,515ebe8d,8228,371814,381527
+197469,Hamza,Choudhury,Choudhury,,571,230,180,234,214,263,,287,,7d2d3329,6418,341501,312670
+197937,Oliver,Burke,Burke,,524,,,424,,,,,,f631c17f,5256,341317,244303
+198044,Harry,Lewis,Lewis,623,,,548,625,637,,,,,c35e99d8,5592,341043,329820
+198501,Sead,Haksabanovic,Haksabanovic,,526,,,,,,,,,d2fd7c14,6393,349300,330545
+198504,Kazaiah,Sterling,Sterling,,643,578,,,,,,,,230255f5,6684,357397,349567
+198826,Ben,Godfrey,Godfrey,,,,273,566,179,193,252,715,,9f7c837d,7689,343475,287504
+198842,Connor,Ronan,Ronan,,,,,,,567,,,,1b804500,10753,337787,294524
+198847,Bright,Enobakhare,Enobakhare,,,436,,,,,,,,dccefdd4,6858,345772,294003
+198849,Lucas,Torreira di Pascua,Torreira,,,450,19,19,18,22,,,,52611641,1227,318077,248109
+198869,Benjamin,White,White,,,559,,74,67,10,29,24,11,35e413f1,7298,335721,322036
+199056,Gabriel,Osho,Osho,,,,,,,,330,,,cd889153,12151,364409,366080
+199170,Moussa,Niakhaté,Niakhaté,,,,,,,507,457,,,00242715,5989,291200,296319
+199249,Sergio,Reguilón,Reguilón,,,,,542,370,438,508,496,,3353737a,7187,282429,362275
+199404,Tashan,Oakley-Boothe,Oakley-Boothe,,531,,,,,,,,,d73892ac,6250,406637,344695
+199583,Dujon,Sterling,Sterling,,600,,,,,,,,,54dd7308,6491,346315,345846
+199584,Japhet,Tanganga,Tanganga,,,,583,402,371,439,518,,,e9971f2d,8222,346478,384063
+199598,Ethan,Ampadu,Ampadu,,558,130,121,509,139,151,185,,354,10b9fa99,6369,392771,322418
+199670,Odsonne,Édouard,Édouard,,,,,,586,166,225,198,285,0562b7f1,3697,344152,317504
+199796,Matty,Cash,Cash,,,,,496,44,43,36,32,36,2389cdc2,8864,425334,322043
+199798,Ezri,Konsa Ngoyo,Konsa,,,,452,46,45,44,48,44,38,0313a347,7726,413403,301440
+199806,Dion,Henry,Henry,,555,,,,,,,,,156bb589,6358,345899,249848
+200088,Daniel,N'Lundulu,Nlundulu,,,,535,590,344,,,,,30040f5d,7983,346482,382519
+200089,Joe,Willock,Willock,,634,566,490,20,19,373,432,420,494,a3b03921,6630,340329,342563
+200370,Matt,Butcher,Butcher,,588,620,,,,,,,,b170cfa2,1069,391132,300771
+200402,Nélson,Cabral Semedo,N.Semedo,,,,,546,437,482,572,559,,d04b94db,6163,231572,296363
+200428,Mateusz,Lis,Lis,,,,,,,421,,465,,fd78b105,11103,345437,
+200439,Che,Adams,Adams,,,,437,377,345,411,,,,f2bf1b0f,7700,346779,256419
+200455,Julien,Ngoy,Ngoy,544,562,,,,,,,,,87449a74,1777,286005,323564
+200600,Daniel,Castelo Podence,Podence,,,,619,469,438,483,568,562,,7fcc71d8,8291,256977,300513
+200617,Daniel,James,James,598,,,243,311,287,231,,,353,c931d9f9,5595,319301,302313
+200641,Reiss,Nelson,Nelson,,489,19,489,21,531,23,578,10,27,c5bdb6e3,6492,340325,342564
+200720,Caoimhín,Kelleher,Kelleher,,,,531,560,242,289,301,325,101,62d7ef38,7904,340918,322176
+200785,Tyler,Adams,Adams,,,,,,,506,673,60,85,2b09d998,7352,332705,315275
+200826,Giovani,Lo Celso,Lo Celso,,,,523,403,372,,503,493,,d7553721,5681,348795,303908
+200834,Nordi,Mukiele,Mukiele,,,,,,,,,,694,ac73ec79,5659,348026,299077
+200878,Filip,Krovinovic,Krovinovic,,,,,555,,,,,,c2dfedeb,8966,261988,322579
+200884,Tyrese,Campbell,Campbell,,628,,,,,,,,,38aefb74,6561,382554,353665
+201057,Thilo,Kehrer,Kehrer,,,,,,,588,537,,,51dbeea9,2674,228948,255167
+201084,Timothy,Fosu-Mensah,Fosu-Mensah,253,269,511,658,312,,,,,,a9142dc3,549,315131,312739
+201410,Auston,Trusty,Trusty,,,,,,,,27,,,cddf767b,11732,389253,298687
+201440,Hwang,Ui-jo,Ui-jo,,,,,,,,466,446,,a2d873dd,7746,260166,127571
+201595,Lucas Estella,Perri,Perri,,,584,,,,,,,665,5dbd461a,12369,352041,307564
+201658,Marcus,Tavernier,Tavernier,,,,,,,535,86,83,84,5c0da4a4,10741,399434,344314
+201666,Harvey,Barnes,Barnes,,642,571,172,235,215,264,603,392,487,3ea50f67,6681,398065,331382
+201667,Josh,Knight,Knight,,,558,,,,,,,,5c0c30cc,7294,425026,344317
+201895,Omar,Alderete,Alderete,,,,,,,,,,683,bb08bce9,8986,353032,344639
+202174,Greg,Luer,Luer,518,,,,,,,,,,82865517,1780,356195,288783
+202641,André,Onana,Onana,,,,,,,,597,383,432,e9c0c1b2,10913,234509,260843
+202993,Rodrigo,Bentancur,Bentancur,,,,,,702,440,492,480,585,3b8674e6,6108,354362,303657
+203325,André-Frank,Zambo Anguissa,Anguissa,,,512,,191,,,,,,6bb2c084,6434,354361,349561
+203341,Wilfred,Ndidi,Ndidi,628,206,227,176,236,216,265,,300,,6b47c5db,5545,274839,327683
+203368,Frédéric,Guilbert,Guilbert,,,,458,47,46,56,,,,5d8d7454,3253,354352,260493
+203389,Nathan,Tella,Tella,,,,633,524,346,412,,,,f1e94cd6,8456,340322,395472
+204043,Arthur Henrique,Ramos de Oliveira Melo,Arthur,,,,,,,620,,,,48b3dd60,6942,362842,284114
+204120,Olivier,Boscagli,Boscagli,,,,,,,,,,143,403f5d20,3645,318508,260809
+204214,Pervis,Estupiñán Tenorio,Estupiñan,,,,,,,586,131,122,147,d38fdf53,5136,349599,298694
+204216,Keshi,Anderson,Anderson,509,528,,,,,,,,,864a3eba,1779,353674,297165
+204380,Juninho,Bacuna,Bacuna,,,208,,,,,,,,aaf1bf05,7219,348863,261143
+204454,Isaac,Mbenza,Mbenza,,,514,,,,,,,,aa1a8c7e,5662,260806,296317
+204480,Declan,Rice,Rice,618,510,406,395,448,421,467,540,16,21,1c7012b8,5553,357662,332325
+204481,Tyreke,Johnson,Johnson,,,562,326,,,,,,,4701e130,7314,404586,367927
+204580,Vitaly,Janelt,Janelt,,,,,,84,86,105,94,125,8449d35e,9680,270171,298689
+204642,Jay-Roy,Grot,Grot,,,,,207,,,,,,9a8241af,,360517,
+204646,Donyell,Malen,Malen,,,,,,,,,725,53,116c35df,9749,326029,351354
+204676,Andi,Zeqiri,Zeqiri,,,,,574,535,,155,,,d01231f0,9099,345468,280621
+204716,Ibrahima,Konaté,Konaté,,,,,,243,290,302,326,374,5ed9b537,6326,357119,345957
+204727,Malang,Sarr,M.Sarr,,,,,,501,143,214,176,,4315f30d,5648,344596,322747
+204760,Michael,Folivi,Folivi,620,581,,,,,,,,,a7b41270,5586,479939,332416
+204814,Ben,Brereton Díaz,Brereton Díaz,,,,,,,,775,584,,57827369,11815,426192,332839
+204819,Elliot,Embleton,Embleton,617,,,,,,,,,,e8a427a3,5564,364828,332326
+204820,George,Marsh,Marsh,,,612,,,,,,,,49deb548,7542,431424,365589
+204822,Omar,Richards,O.Richards,,,,,,,511,461,438,512,f9b1b7bf,9675,424881,
+204863,Ryan,Manning,Manning,,,,,,,,,467,,847b53eb,13134,262300,332402
+204936,Gianluigi,Donnarumma,Donnarumma,,,,,,,,,,736,08f5afaa,1116,315858,262515
+204968,Ryan,Yates,Yates,,,,,,,387,470,449,522,c1fe2a48,11003,425902,342830
+205102,Ramadan,Sobhi,Sobhi,486,345,207,,,,,,,,98be0d02,1764,312017,260289
+205135,Samuel,Shashoua,Shashoua,672,,,,,,,,,,df855e4b,5572,387313,338119
+205533,Eddie,Nketiah,Nketiah,,560,552,13,22,20,11,13,11,284,a53649b7,6482,340324,345845
+205651,Gabriel,Fernando de Jesus,G.Jesus,625,259,281,211,282,263,28,8,2,31,b66315ae,5543,363205,279379
+205836,Saman,Ghoddos,Ghoddos,,,,,,85,87,701,,,f7b1d4e0,7069,204294,320575
+206325,Oleksandr,Zinchenko,Zinchenko,238,551,279,206,283,264,313,31,25,12,51cf8561,2958,203853,273257
+206882,Pontus,Dahlberg,Dahlberg,,,374,367,,,,,,,2475b06e,,365544,
+206915,Curtis,Jones,C.Jones,,640,597,569,263,244,291,300,324,388,4fb9c88f,6665,433188,355354
+207189,Sander,Berge,Berge,,,,621,360,,,475,622,330,d0b6129f,8285,333014,321020
+207270,Daniel,Iversen,Iversen,,,,,,,548,,294,,10d221cd,10808,260841,339672
+207283,Mathias,Jensen,Jensen,,,,,,86,88,106,95,126,0f134faf,7166,319859,339674
+207300,Mihai-Alexandru,Dobre,Dobre,,,,574,,,,,,,a1f3f5a0,8208,365770,362805
+207722,Jack,Walton,Walton,,,,,,,,338,,,3df50652,,368629,
+207725,Daniel,Agyei,Agyei,651,,,,,,,,,,5c374509,5563,367195,275887
+208706,Bruno,Guimarães Rodriguez Moura,Bruno G.,,,,,,697,374,406,394,488,82518f62,8327,520624,338780
+208904,Mads Juel,Andersen,Andersen,,,,,,,,315,,,f098c03e,11715,407021,379632
+208912,Joe,Worrall,Worrall,,,,,,,388,469,448,199,a5212312,10756,415970,315714
+208973,Francisco,Sierralta,Sierralta,,,,,,396,,,,,0f933743,7081,371436,362761
+208987,Jeff,Reine-Adelaide,Reine-Adelaide,588,,,,,,,,,,d504b3e1,1056,326300,277239
+208998,Zeze Steven,Sessegnon,Sessegnon,,,541,,192,,,,,,4e229bf9,7205,406558,342888
+209035,Jonathan,Panzo,Panzo,,,,,,,389,460,441,,c795c408,7247,392777,
+209036,Marc,Guéhi,Guéhi,,,624,545,,477,167,228,200,260,d0706b27,7603,392757,374631
+209037,Zech,Medley,Medley,,,546,636,,,,,,,692e9958,7231,392761,365239
+209040,Timothy,Eyoma,Eyoma,,,561,,,,,,,,449949f4,7311,406559,365588
+209041,Angel,Gomes,Angel,680,,568,245,,,,,,816,645a3363,5598,392770,338497
+209042,Oliver,Skipp,Skipp,,,540,352,404,373,441,515,501,,6250083a,7198,406638,364215
+209043,Nya,Kirby,Kirby,,630,,588,,,,,,,96b99d13,6563,406633,353696
+209045,Taylor,Richards,Richards,,,,,,537,121,,,,e0243d23,9735,484551,369230
+209046,Callum,Hudson-Odoi,Hudson-Odoi,,583,131,116,122,140,144,205,434,516,15f3ec41,6456,392768,350088
+209212,Thomas,Edwards,Edwards,648,556,,,,,,,,,1b780599,5593,430788,333311
+209243,Jadon,Sancho,Sancho,,,,,,485,340,397,386,456,dbf053da,6345,401173,346300
+209244,Phil,Foden,Foden,,492,277,220,284,265,314,353,348,414,ed1e53f3,6055,406635,331254
+209288,Tom,McGill,McGill,,,,,662,688,756,141,,140,4eb2d015,9319,406556,391266
+209289,Emile,Smith Rowe,Smith Rowe,,,545,576,23,21,12,22,19,325,17695062,7230,392765,363686
+209293,Daiki,Hashioka,Hashioka,,,,,,,,798,,,10cb48b7,12509,387191,411101
+209353,Patrick,Cutrone,Cutrone,,,,487,626,523,,,,,a4fe8cda,4918,265078,329681
+209362,Bernardo,Fernandes Da Silva Junior,Bernardo,,,440,39,75,68,,,,,17370b95,5245,364258,302588
+209365,Matthijs,de Ligt,De Ligt,,,,,,,,,593,436,d6e53a3a,7902,326031,320374
+209400,Daichi,Kamada,Kamada,,,,,,,,,205,271,15b287da,6145,356141,344166
+209411,Joe,Tupper,Tupper,,,576,,,,,,,,7d675f6f,7348,424901,369071
+209413,Jordi,Osei-Tutu,Osei-Tutu,,644,,,,,,,,,0a16eb36,6723,397099,347048
+209418,Tobi,Omole,Omole,,,,,,598,,,,,296904e8,9950,503687,425052
+209419,Max,Melbourne,Melbourne,,572,,,,,,,,,7ad65188,6423,460255,349444
+209420,Joy,Mukena,Mukena,,625,,,,,,,,,8bfcc23b,6539,506213,351777
+209925,Xande,Nascimento da Costa Silva,Xande Silva,,,560,387,,,390,,,,15d561fa,7312,258011,323096
+210156,Taiwo,Awoniyi,Awoniyi,,,,,,,397,437,424,527,e5478b87,7814,295313,281049
+210207,Fousseni,Diabaté,Diabaté,,601,232,,,,,,,,d07e3b41,5767,364861,332135
+210237,Marko,Grujic,Grujic,475,231,,,,,,,,,8b8e759d,1669,222813,244779
+210407,Matheus,Pereira,Pereira,,,,,481,,,,,,b04ee927,7153,225984,297389
+210462,Ibrahim,Sangaré,Sangaré,,,,,,,,713,442,521,bced0375,5722,375885,328075
+210494,Nayef,Aguerd,N.Aguerd,,,,,,,472,522,529,607,288e1e13,6935,361914,362434
+211975,Manuel,Akanji,Akanji,,,,,,,610,341,340,404,89ac64a6,6490,284730,297390
+212314,Saša,Lukić,Lukić,,,,,,,726,276,249,332,c6e8cf1f,1537,245056,297395
+212319,Richarlison,de Andrade,Richarlison,,501,393,150,166,180,454,509,497,597,fa031b34,6026,378710,317804
+212325,Pierre,Lees-Melou,Lees-Melou,,,,,,471,,,,,f5044e54,5619,377393,301243
+212701,Denis,Zakaria,Zakaria,,,,,,,616,,,,384d58d9,6147,334526,252419
+212721,Lyanco,Silveira Neves Vojnovic,Lyanco,,,,,,567,413,,,,b5bf1770,6252,379807,284115
+212723,Milot,Rashica,Rashica,,,,,,449,,,,,6c6a3300,6523,291739,289014
+213056,Tudor,Baluta,Baluta,,,,536,,,,,,,ed33f42d,8019,433976,363200
+213198,Christopher,Nkunku,Nkunku,,,,,,,,212,181,240,7c56da38,3300,344381,300945
+213280,Jake,Eastwood,Eastwood,,,,299,,,,,,,54d9b72d,8233,526873,342494
+213345,Wesley,Moraes Ferreira da Silva,Wesley,,,,428,48,47,,61,,,bfae110f,7724,381362,328362
+213384,Josh,Clackstone,Clackstone,515,,,,,,,,,,25dfa9be,1774,453306,322595
+213405,Filip,Benkovic,Benkovic,,,501,597,237,,,,,,305a3820,8238,293168,296451
+213482,Yan,Valery,Valery,,,556,306,378,546,414,,,,531a4aa8,7280,406008,323791
+213687,Charlie,Goode,Goode,,,,,,87,96,102,,,7aee4dd3,9687,376856,283345
+213999,Edson,Álvarez Velázquez,Álvarez,,,,,,,,642,511,616,8b3ab7ad,11926,401356,322696
+214048,Maximilian,Kilman,Kilman,,,567,408,470,439,484,563,524,605,d0f72bf1,7332,525247,368310
+214225,Joe,Rodon,Rodon,,561,,,584,374,442,510,,348,8d62d31a,6377,297212,302312
+214285,Konstantinos,Tsimikas,Tsimikas,,,,,242,245,292,311,337,377,f315ca93,8852,338070,301455
+214466,Will,Smallbone,Smallbone,,,,584,379,347,415,,471,,5e105217,8224,444211,390036
+214470,Jake,Vokins,Vokins,,,,645,380,,,,,,d484c261,8493,421424,386857
+214572,Brandon,Austin,Austin,,,,558,,659,451,491,479,566,5e253986,8093,428016,386134
+214590,Aaron,Wan-Bissaka,Wan-Bissaka,612,579,145,122,313,288,341,401,388,610,9e525177,5584,477758,331924
+214964,George,Edmundson,Edmundson,,,,,,,,,269,,46ff3923,12947,385848,287300
+214987,Kamil,Miazek,Miazek,,,,,208,,,,,,ab20668a,,237632,
+215059,Robert,Lynch Sánchez,Sánchez,,,,,597,69,113,145,185,220,6a713852,9098,403151,362151
+215062,Max,Sanders,Sanders,,,572,,632,,,,,,4871d0e8,7341,411495,354539
+215066,Alex,Cochrane,Cochrane,,,,666,,,,,,,8a08585e,8581,392773,382374
+215136,Neco,Williams,N.Williams,,,,575,264,246,295,467,437,508,dd323728,8204,503680,386969
+215379,Elliot,Anderson,Anderson,,,,,602,609,552,403,423,517,de31038e,9154,567576,402596
+215407,Alfie,Lewis,Lewis,,,,651,,,,,,,548e5d9f,8521,423571,320684
+215409,Cameron,John,John,,,596,,,,,,,,6c753e99,7389,425894,369508
+215413,Kiernan,Dewsbury-Hall,Dewsbury-Hall,,,,,,505,266,,166,242,5c74c0f5,9739,475188,391256
+215439,Tomáš,Souček,Souček,,,,616,449,422,468,542,530,613,6613c819,8288,283628,143595
+215457,Kane,Wilson,Wilson,510,508,,,,,,,,,a3f1897f,1766,392774,319889
+215460,Ian,Poveda-Ocampo,Poveda,,,,,209,195,,,,550,55b4f1d6,8723,392763,369229
+215476,Joshua,Sargent,Sargent,,,,,,516,,,,,a8d4428b,7295,393325,367480
+215531,Ionuț,Radu,Radu,,,,,,,,607,,,67f649be,1830,303657,296723
+215610,Marcel,Lavinier,Lavinier,,,,,,724,,,,,6b3e4b53,10549,392772,410514
+215711,Leon,Bailey,Bailey,,,,,,492,45,34,28,49,3a233281,5221,387626,327682
+215885,Michael,Phillips,Phillips,606,,,,,,,,,,2a1c8e89,5583,378629,331515
+216051,Diogo,Dalot Teixeira,Dalot,,,294,229,314,510,342,377,369,440,d9565625,7281,357147,353418
+216054,Rúben,Nascimento Vinagre,Vinagre,,,431,406,471,,531,,,,b937e490,6856,357158,342863
+216055,Florentino Ibrain,Morris Luís,Florentino,,,,,,,,,,722,881cd6be,8969,357162,369712
+216058,Domingos,Quina,Quina,610,568,517,375,,397,,,,,41fb0f4e,5573,391719,331582
+216094,Jeremie,Frimpong,Frimpong,,,,,,,,,,370,74f2e748,9328,484547,392644
+216183,Brahim,Diaz,Diaz,,493,278,,,,,,,,407feb71,6421,314678,317541
+216208,Matija,Šarkić,Šarkić,,,,,472,,492,571,,,a89e7b29,10754,293257,331107
+216554,Sam,Hughes,Hughes,,645,,,,,,,,,286f5a8e,6729,395797,357025
+216616,Dara,O'Shea,O'Shea,,,,,425,,,173,630,,1d042188,8756,401320,362826
+216620,Marcus,Forss,Forss,,,,,,88,97,,,,82c215a0,9684,404584,362215
+216646,Yoane,Wissa,Wissa,,,,,,524,89,119,110,135,2500cef9,5786,388165,296240
+217331,Sam,Surridge,Surridge,679,,599,71,,,391,464,,,b017b770,5602,398402,296870
+217401,Josh,Benson,Benson,,,583,653,535,116,,,,,bf3aeb61,7383,397102,369466
+217487,Mbwana Ally,Samatta,Samatta,,,,613,49,48,,,,,dae8623e,8287,182201,327685
+217593,Pablo,Fornals Malla,P.Fornals,,,,399,450,423,469,534,,,82927de4,2335,357885,297203
+217989,Rafael,Camacho,Camacho,,641,557,201,,,,,,,91b43c98,6666,400831,355358
+218023,Jimmy,Dunne,Dunne,,,,638,519,,,,,,1fdfd6da,8481,396174,366743
+218031,Çaglar,Söyüncü,Söyüncü,,,515,164,238,217,267,,,,21166ff4,5264,320141,317998
+218112,Jason,Lokilo,Lokilo,,491,,,,,,,,,fad4d5e8,6028,325200,343270
+218218,Wout,Faes,Faes,,,,,,,612,,291,,9c221d14,8646,292808,299693
+218328,Samuel,Chukwueze,Chukwueze,,,,,,,,,,727,b8a642fc,7208,401922,363665
+218364,Borna,Sosa,Sosa,,,,,,,,,,259,af0d79a9,7075,293194,270829
+218430,Gonzalo,Montiel,G.Montiel,,,,,,,,679,,,374d5158,9897,402733,316883
+218997,Ellis,Simms,Simms,,,,667,596,602,686,264,,,26d3b5be,8582,511550,396483
+219002,Dodi,Lukebakio,Lukebakio,,615,,,,,,,,,0c61c77c,5706,303259,299490
+219168,Alexander,Isak,Isak,,,,,,,594,415,401,499,8e92be30,5232,349066,299254
+219249,Matt,O'Riley,O'Riley,,,,,,,,,629,164,fb495bb8,13206,406634,342889
+219265,Felix,Nmecha,Nmecha,,,,,609,,,,,,091c86e2,9202,406640,367783
+219279,Sugawara,Yukinari,Sugawara,,,,,,,,,474,,580bcd18,12761,405385,379783
+219291,Claudio,Gomes,Gomes,,,,,659,,599,,,,22f6ed2c,9314,395239,361434
+219352,Ademola,Lookman,Lookman,627,157,170,155,557,587,,,,,7c104bb7,5556,406040,299451
+219727,Joel,Asoro,Asoro,521,,,,,,,,,,13e827f8,1754,375391,322652
+219847,Kai,Havertz,Havertz,,,,,500,141,145,6,4,30,fed7cb61,5220,309400,326413
+219924,Issa,Diop,Diop,,,409,381,451,424,470,271,245,320,a712ca2b,3203,272622,300359
+219929,Rafa,Mir,Mir,,,449,,,,,,,,bbf5c11b,2589,361254,
+219937,Rhys,Williams,R.Williams,,,,,594,247,498,,334,379,012c975a,9086,503679,401782
+219961,Raphael,Dias Belloli,Raphinha,,,,,570,196,232,,,,3423f250,8026,411295,300447
+220037,Bailey,Peacock-Farrell,Peacock-Farrell,,,,495,99,117,,175,,,4879f8cb,8482,410436,300567
+220087,Maximilian,Wöber,Wöber,,,,,,,691,,,,4b803b3c,7366,263361,301024
+220166,Marc,Navarro,Navarro,,,385,360,,398,,,,,c2846353,5085,335245,280157
+220237,Sven,Botman,Botman,,,,,,,377,405,393,475,ccce7025,8635,361093,379732
+220307,Arnaut,Danjuma Groeneveld,Danjuma,,,,492,,,713,601,,,f08490a6,8066,355861,323625
+220362,Axel,Disasi,Disasi,,,,,,,,611,167,815,ad82197c,6885,386047,300426
+220394,Tommy,Doyle,Doyle,,,,644,285,566,,351,544,,5526deb1,8496,433183,386856
+220566,Rodrigo 'Rodri',Hernandez Cascante,Rodrigo,,,,443,286,266,315,365,360,421,6434f10d,2496,357565,303139
+220583,Luke,Woolfenden,Woolfenden,,,,,,,,,284,,e28e9bec,12746,527425,356599
+220585,Flynn,Downes,Downes,,,,,,,509,531,518,,69fdb896,10845,506189,337428
+220598,Michael,Obafemi,Obafemi,,603,550,314,381,348,,174,,219,caa1a7f0,6504,444208,351355
+220627,James,Justin,Justin,,,,433,239,218,268,,295,706,fb614c44,7753,413220,301441
+220650,Thibaud,Verlinden,Verlinden,599,,,,,,,,,,e5c026d6,5594,338673,329842
+220682,Arthur,Okonkwo,Okonkwo,,,,,,572,,,,,75834acc,9909,503769,411834
+220684,Aji,Alese,Alese,,,,,,644,,,,533,182a8b9d,10165,502065,383538
+220686,Bali,Mumba,Mumba,,,,,,515,,,,,2d760d7b,9747,433186,356473
+220688,Mason,Greenwood,Greenwood,,,608,234,315,289,,,,,58eee997,7490,532826,367782
+220693,Rayhaan,Tulloch,Tulloch,,577,,,,,,,,,bddd8ba3,6432,433184,349750
+220695,Paris,Maghoma,Maghoma,,,,,,614,,,674,132,8a3ddcd2,10053,470596,399525
+220738,Jayson,Molumby,Molumby,,553,617,,550,,,,,,c908a1bc,6350,357656,344324
+221239,Keinan,Davis,Davis,,,,34,50,49,52,39,,,9deaf2c8,1053,412660,303107
+221245,Levi,Lumeka,Lumeka,,544,,,,,,,,,199ff86e,6283,537182,345336
+221267,Josh,Tymon,Tymon,519,336,,,,,,,,,efe6f6ac,1745,419929,303743
+221268,Ben,Hinchcliffe,Hinchcliffe,545,,,,,,,,,,6261bd48,1775,49597,323442
+221271,Ben,Wynter,Wynter,585,,,,,,,,,,86334f1a,1756,464738,333888
+221272,Sam,Woods,Woods,,,609,578,522,,,,,,a62da625,7534,611650,362820
+221275,Luke,Dreher,Dreher,581,,618,140,,,,,,,d1c509d9,636,432293,316536
+221286,Charlie,Rowan,Rowan,619,,,,,,,,,,d129989d,5585,479944,332410
+221389,John Victor,Maciel Furtado,John,,,,,,,,,,715,33a235af,,432914,318689
+221399,Jack,Harrison,Harrison,,,,,203,267,233,661,224,352,aa849a12,8720,417346,317896
+221403,Richie,Laryea,Laryea,,,,,,,392,452,,,276fdbe4,,417348,
+221466,Marcos,Senesi Barón,Senesi,,,,,,,576,83,79,72,35141f4c,10864,469781,328330
+221568,Daniel,Kemp,Kemp,675,,,,,,,,,,82362769,5605,396857,338500
+221610,Jamie,Shackleton,Shackleton,,,,,210,197,234,,,,8d03ca5a,8721,534700,361787
+221632,Cristian,Romero,Romero,,,,,,494,443,511,498,569,a3d94a58,7218,355915,323663
+221820,Lisandro,Martínez,Martinez,,,,,,,533,391,380,437,bac46a10,10802,480762,340105
+222017,Conor,Coventry,Coventry,,,548,664,668,522,556,529,,,a5ca9127,7239,419025,364018
+222018,Ben,Johnson,Johnson,,573,605,384,452,425,471,536,275,,9319781b,6424,468002,349484
+222434,Jack,Simpson,Simpson,,570,32,66,,,,,,,76fa5f80,6410,419930,302862
+222531,Morgan,Gibbs-White,Gibbs-White,,,448,416,473,440,493,447,433,515,32f60ed8,6857,429014,332867
+222564,Francisco,Machado Mota de Castro Trincão,Trincão,,,,,,461,,,,,77e39b04,8934,412669,368409
+222625,George,Hirst,Hirst,,,,661,,,,,272,,78e87179,8563,420808,317547
+222627,João,Neves Virgínia,J.Virginia,,,,629,167,181,,266,227,,728e9b2e,8366,329813,362852
+222677,Tahith,Chong,Chong,,,603,249,316,,,586,,,2696b6a9,7439,344830,365244
+222683,Justin,Kluivert,Kluivert,,,,,,,,72,71,81,4c3a6744,6963,330659,331579
+222690,Tyrell,Malacia,Malacia,,,,,,,504,389,379,448,6b6c793c,10803,339340,345303
+222694,Pascal,Struijk,Struijk,,,,,211,198,235,,,343,f4d296e4,8717,410708,355609
+222786,Panagiotis,Retsos,Retsos,,,,625,,,,,,,4bd00a50,6316,324351,302402
+223081,Kristoffer,Klaesson,Klaesson,,,,,,490,236,,,,3f70db80,9700,418561,335718
+223094,Erling,Haaland,Haaland,,,,,,,318,355,351,430,1f44ac21,8260,418560,315227
+223175,Matthew,Longstaff,M.Longstaff,,,,540,487,312,,,,,c0027d2d,8016,484387,382434
+223332,Faustino,Anjorin,Anjorin,,,,630,605,,,,,,b105919e,8383,433181,384133
+223333,Louie,Watson,Watson,,,,,,,,339,,,d4f63087,,505548,
+223335,Sylvester,Jasper,Jasper,,,,,707,,,,,,a9f04944,9553,502074,390213
+223336,Dan,Neil,Neil,,,,,,,,,,549,a47ad0f5,13720,570336,399427
+223337,Jamie,Bowden,Bowden,,,,,,717,,,,,9a5675c9,10537,504051,410513
+223340,Bukayo,Saka,Saka,,,563,541,24,22,13,19,17,16,bc7dc64d,7322,433177,367185
+223349,Indiana,Vassilev,Vassilev,,,,600,51,,,,,,04e195ee,8254,469860,390215
+223434,Igor Julio,dos Santos de Paulo,Igor,,,,,,,,606,128,149,a4e85758,7943,380350,382241
+223541,Federico,Chiesa,Chiesa,,,,,,,,,636,385,b0f7e36c,1433,341092,322971
+223723,Tomiyasu,Takehiro,Tomiyasu,,,,,,590,14,25,22,,b3af9be1,7931,331560,377283
+223824,Reece,Hannam,Hannam,,,,,675,540,,,,,974b8e7f,9394,503241,411070
+223827,Daniel,Ballard,Ballard,,,,,,,,,,531,38f300f3,13715,503686,371761
+223911,Chris,Mepham,Mepham,,,580,61,,,71,75,72,79,fed96827,7384,480987,342842
+224024,Lucas,Tolentino Coelho de Lima,L.Paquetá,,,,,,,603,539,527,612,9b6f7fd5,7365,444523,319756
+224068,Matt,Turner,Turner,,,,,,,24,28,445,504,4a51ba65,10700,425306,319712
+224117,Viktor,Gyökeres,Gyökeres,,,551,,,,,,,666,4d5a9185,7254,325443,362815
+224209,Rasmus,Kristensen,Kristensen,,,,,,,244,,,,39769cff,10750,369684,302812
+224444,Ferran,Torres,Torres,,,,,287,268,,,,,9e1035f8,6441,398184,349760
+224860,Carlos,Soler,C.Soler,,,,,,,,,654,,fed17f5a,2478,372246,313542
+224946,Matthew,Worthington,Worthington,678,,,,,,,,,,8c8b941f,5601,493607,338498
+224967,Vitalii,Mykolenko,Mykolenko,,,,,,675,194,260,231,292,30d4a2e5,10291,404842,345516
+224995,Luis,Sinisterra Lucumí,Sinisterra,,,,,,,508,705,80,91,8e16dd48,10866,512385,361879
+225000,Dion,Sanderson,Sanderson,,,,,,686,,,,,b3fa76c5,10294,495993,384128
+225295,Mateus,Cardoso Lemos Martins,Tetê,,,,,,,715,,,,7120a04d,10536,371256,387417
+225321,Aaron,Ramsdale,Ramsdale,677,549,,494,483,559,15,17,14,674,466fb2c5,5603,427568,316858
+225368,Meritan,Shabani,Shabani,,,,,553,,,,,,012c38ec,6642,379980,354599
+225702,Samuel,Kalu,Kalu,,,,,,698,,,,,b8d22478,6947,424051,312705
+225796,Reece,James,James,,,,506,123,142,146,206,172,225,1265a93a,8067,472423,361330
+225897,Fodé,Ballo-Touré,Ballo-Touré,,,,,,,,707,,,f449640d,,296422,328968
+225902,Boubakary,Soumaré,B.Soumaré,,,,,,458,269,,285,,ae59b359,6310,344605,345664
+226029,Lasse,Sorenson,Sorenson,,637,,,,,,,,,ce9c203e,6657,357967,355133
+226182,Jayden,Bogle,Bogle,,,,,510,,,476,,342,ae5019e6,9205,465717,354291
+226473,Scott,Twine,Twine,,,,,,,,180,,,5a425cab,,433818,
+226597,Gabriel,dos Santos Magalhães,Gabriel,,,,,494,23,16,5,3,5,67ac5bb8,5613,435338,334087
+226944,Boubacar,Kamara,Kamara,,,,,,,53,47,42,58,cc77354e,5789,394327,331790
+226956,Mads,Roerslev Rasmussen,Roerslev,,,,,,89,90,114,105,112,57c94db2,9685,391005,329554
+227127,Yves,Bissouma,Bissouma,,,466,53,76,70,444,493,482,587,6c203af0,5609,410425,303096
+227444,Nikola,Milenković,Milenković,,,,,,,,,573,505,bee704fc,6174,413507,319785
+227560,Oghenekaro Peter,Etebo,Etebo,,,,,,467,,,,,b579e83d,6538,409106,323669
+228044,Mads,Bech Sørensen,Bech,,,,,,90,91,93,,,30db8574,9683,372240,346304
+228286,Edouard,Mendy,Mendy,,,,,548,143,147,,,,33887998,6880,442531,321390
+228798,Cengiz,Ünder,Ünder,,,,,541,,,,,,1880614f,6162,341647,255071
+229164,Chiedozie,Ogbene,Ogbene,,,,,,,,328,632,,788c0277,11719,392591,352908
+229384,Andy,Irving,Irving,,,,,,,,,576,621,b1be9fc0,12774,430310,451945
+229415,Jon,McCracken,McCracken,,,,,,666,,,,,47188db7,10207,403564,
+229600,Mark,Travers,Travers,,,616,74,,,72,88,84,288,fe558029,7582,357658,362806
+230001,Noussair,Mazraoui,Mazraoui,,,,,,,,,594,438,b74277a0,10696,340456,349932
+230046,Douglas Luiz,Soares de Paulo,Douglas Luiz,,,,470,52,50,46,43,,699,6f7d826d,6122,447661,337883
+230127,Percy,Tau,Tau,,,,,627,,,,,,4d0eb7d2,9249,312239,229654
+230251,Emmanuel,Dennis,Dennis,,,,,,450,585,443,430,,2c44a35d,9301,448854,329811
+230348,Ross,Stewart,Stewart,,,,,,,,,473,,18986367,13060,447995,397143
+230376,Jhon,Arias,J.Arias,,,,,,,,,,663,86d96066,13741,588989,424039
+230428,Philippe,Sandler,Sandler,,,604,,,,,,,,60740e70,7440,340460,321959
+231057,Jean-Ricner,Bellegarde,Bellegarde,,,,,,,,715,535,644,10f0fdd3,7762,450050,320242
+231065,Ethan,Pinnock,Pinnock,,,,,,91,92,112,104,111,e541326e,9678,442248,342499
+231172,Brandon,Mason,Mason,621,406,,,,,,,,,1415840f,5558,479942,332411
+231372,Tanguy,Ndombélé Alvaro,Ndombele,,,,442,405,375,,505,,,5cdddffa,5962,450936,321389
+231416,Ferdi,Kadıoğlu,F.Kadıoğlu,,,,,,,,,628,148,66c52a77,13066,369316,321958
+231480,Santiago,Ignacio Bueno,S.Bueno,,,,,,,,697,564,636,edc98fac,10945,438001,444241
+231747,Jean-Philippe,Mateta,Mateta,,,,,641,159,168,232,207,283,50e6dc35,5735,420002,328096
+231899,Jack,Taylor,Taylor,,,,,,,,,281,,48eed8d5,12754,458178,323713
+232112,Manuel,Ugarte Ribeiro,Ugarte,,,,,,,,,652,459,c9817014,11766,476701,408962
+232185,Ismaïla,Sarr,Sarr,,,,525,,399,,,585,267,bfdb33aa,5675,410225,322670
+232223,Folarin,Balogun,Balogun,,,,,,530,,1,,,31822f8c,9690,503770,384065
+232228,Harry,Clarke,H.Clarke,,,,,,,,,266,,a64f2573,13133,528892,404080
+232229,Vontae,Daley-Campbell,Daley-Campbell,,,,,660,639,,,,,192d4c3d,9312,530732,409879
+232233,Tyreece,John-Jules,John-Jules,,,,585,,,,,,,247e5cfc,8225,503768,367184
+232241,Matthew,Smith,Smith,,,,647,,,607,,,,54b6eed9,8494,528894,395690
+232245,Zak,Swanson,Swanson,,,,,,711,,,,,5b7381b5,10436,540687,433403
+232247,Dominic,Thompson,Thompson,,,,,,498,98,,,,235a62f8,9915,503688,381114
+232351,Ryan,Giles,Giles,,,555,607,,687,,553,,,73b1d65b,7277,504581,362831
+232356,Jenson,Jones,Jenson Jones,,,,,,,,,,774,4776da26,14276,990997,581394
+232361,Taylor,Perry,Perry,,,,560,611,,,,,,01ba3996,8139,502073,384129
+232391,Jeremy,Ngakia,Ngakia,,,,593,,400,,,,,3631ad41,8235,503795,390700
+232398,Nathan,Trott,Trott,,574,,,674,,,,,,7494bea9,6425,431422,349485
+232413,Eberechi,Eze,Eze,,,,,489,160,169,226,199,266,ae4fc6a4,8706,479999,332403
+232423,Nathan,Ferguson,Ferguson,,578,,,145,161,174,,,,2f8d27bc,6451,507254,349891
+232427,Rekeem,Harper,Harper,614,507,,,426,,,,,,3c066877,5562,456877,331928
+232456,Dilan,Markanday,Markanday,,,,,,597,,,,,4f242e0e,9949,530807,410796
+232477,Elliot,Thorpe,Thorpe,,,,,,,,337,,,9b1da146,,496661,
+232571,Anthony,Patterson,Patterson,,,,,,,,,,528,b2470c6f,13721,475946,382438
+232620,Lewis,Brunt,Brunt,,,,,,646,273,,,,a2081c6b,10168,533657,429681
+232653,Jacob,Ramsey,J.Ramsey,,,,,554,51,47,55,53,52,1544f145,8941,503749,369813
+232667,Akin,Famewo,Famewo,,,,552,,,,,,,9d9a71c1,8080,425713,322465
+232787,Conor,Gallagher,Gallagher,,,,,544,144,148,202,169,796,c2731c10,9040,488362,375621
+232792,Tariq,Lamptey,Lamptey,,,,586,77,71,114,139,131,150,f4e433d4,8226,504148,386979
+232797,Kayne,Ramsay,Ramsay,,,565,311,598,,,,,,dc31b84c,7326,530879,368253
+232820,Joe,Anderson,Anderson,,,,,,,,,,534,4fa3a3a4,,511551,
+232826,Anthony,Gordon,Gordon,,,,561,168,503,195,412,398,485,2bd83368,8150,503733,349669
+232829,Kyle,John,John,,,,,679,,637,,,,c9093a1a,9408,504507,411125
+232859,Djed,Spence,Spence,,,,,,,522,517,504,573,9bc9a519,10764,483348,362219
+232881,Thakgalo,Leshabela,Leshabela,,,,,661,,,,,,383e68b1,9311,461882,367151
+232892,Calvin,Bassey,Bassey,,,,,,,,610,241,318,a36524bf,11728,461883,396976
+232917,Arijanet,Muric,Muric,,,529,,,,,172,568,,99aa1a84,7027,371021,362426
+232928,James,Garner,Garner,,,602,250,317,,570,250,223,303,4e015693,7438,505219,367781
+232937,Brandon,Williams,B.Williams,,,,549,318,290,343,374,,,5e74d6c8,8075,507700,384143
+232957,Thomas,Allan,Allan,,,,598,,,,,,,e95726c1,8237,484390,390202
+232960,Lewis,Cass,Cass,,,623,,,,,,,,711a6e59,7601,474382,374629
+232964,Lewis,Gibson,Gibson,,,,477,,,,,,,cdf0f2db,8262,419325,391026
+232977,Kell,Watts,Watts,,,622,599,342,,,431,,,603e4f0b,7602,484389,374630
+232979,Jack,Young,Young,,,,656,,,,,,,ad7cd1fa,8538,507235,396048
+232980,Max,Aarons,Aarons,,,,274,,326,,643,59,,774cf58b,7688,471690,362103
+233420,Renan Augusto,Lodi dos Santos,Renan Lodi,,,,,,,602,,,,ed9f7cfe,7891,476352,326646
+233425,Aaron,Connolly,Connolly,,,,534,78,72,,127,,,27c01749,7991,434207,344325
+233489,Leighton,Clarkson,Clarkson,,,,,601,,,,,,d5dafedb,9151,470606,384123
+233497,Adama,Diakhaby,Diakhaby,,,471,,,,,,,,65585e3a,5740,453594,322750
+233821,Anel,Ahmedhodžić,Ahmedhodžić,,,,,,,,471,,,eab957a3,10386,377468,326642
+233849,Archie,Mair,Mair,,,,551,,,,,,,70e9afd8,8081,447063,384632
+233963,Konstantinos,Mavropanos,Mavropanos,,595,10,8,,24,,676,528,606,00963611,6722,415912,351127
+234370,Marc,Roca Junqué,Roca,,,,,,,245,,,,da27e268,5086,336869,323148
+234483,Aiden,O'Neill,O'Neill,531,623,,,,,,,,,c7aee75b,1662,385918,323097
+234720,Giovanni,McGregor,McGregor,,,,608,,,,,,,1b138e25,8261,611651,362821
+234908,Juan,Foyth,Foyth,,534,549,335,406,,,,,,6c7762c3,6306,480763,335107
+235382,Steven,Alzate,Alzate,,,,537,79,73,115,123,,,ad1f61f3,8020,476237,362146
+235448,Ellery,Balcombe,Balcombe,,,,,,92,100,91,,102,e827567f,11985,456292,329831
+235449,George,Wickens,Wickens,,,,,,,747,,,,eafaafa5,11459,502070,476060
+235530,Lloyd,Kelly,Kelly,,,,64,,,73,70,404,,f31def1e,8090,480116,332419
+235546,Jacob,Sørensen,Sørensen,,,,,,327,,,,,953c30b0,9748,390664,404572
+235599,Nikola,Tavares,Tavares,,,619,635,,,,,,,0beeb166,7599,487428,374634
+235640,Harry,Boyes,Boyes,,,,,704,,,,,,467bf546,9541,746778,416026
+235674,Manor,Solomon,Solomon,,,,,,,562,583,502,589,886f9aac,10716,396638,345022
+235826,Joël,Piroe,Piroe,,,,,,,,,,362,1f0072a6,13835,369962,369542
+240143,Ibrahima,Diallo,Diallo,,,,,565,349,416,,,,11ff3d56,6736,413032,357101
+240299,Joe,Hodge,Hodge,,,,,,,566,555,551,653,bd8a5d95,10755,503975,443578
+240499,Daniel,Batty,Batty,676,,,,,,,,,,96c92a74,5604,509268,338495
+240514,Kjell,Scherpen,Scherpen,,,,,,476,542,147,,142,f0e4c69e,9960,463527,361867
+240796,Álvaro,Fernández,Fernández,,,,,,556,,,,,f127d782,5191,453704,328315
+241157,Emerson,Leite de Souza Junior,E.Royal,,,,,,588,445,497,487,,df8b52a5,7430,476344,328512
+241231,Jordan,Beyer,Jordan,,,,,,,,160,,194,9af1f9ff,6557,403898,353412
+241289,Ben,Wilmot,Wilmot,,,544,,,401,,,,,2876eaa3,7216,467599,362851
+241519,Weston,McKennie,McKennie,,,,,,,720,,,,01c3aff5,5360,332697,338275
+241791,Ryan,Schofield,Schofield,,,533,,,,,,,,74947a21,7111,495441,362817
+242058,Moise,Kean,Kean,,,,496,169,564,,,,,3d50bcdb,1304,364135,328990
+242166,Mattéo,Guendouzi,Guendouzi,,,451,21,25,25,,,,,5ea8ef20,5759,465830,328983
+242183,James,Morris,Morris,,,,,,633,,,,,59e3e314,990,610621,425565
+242453,Jacob,Brown,Brown,,,,,,,,631,,,ca18c8f1,11720,469958,329328
+242500,Joe,Taylor,Taylor,,,,,,,,336,,,bfd3801e,,944551,
+242510,Louie,Moulden,Moulden,,,,,,611,,,,,7b7de75a,10030,444641,425600
+242880,Benoît,Badiashile Mukinayi,B.Badiashile,,,,,,,689,191,153,229,06df8256,7240,463603,365406
+242882,Bafodé,Diakité,Diakité,,,,,,,,,,685,1bfb6fef,7268,463605,366875
+242885,Loïc,Mbe Soh,Mbe Soh,,,,,,,393,454,,,8f534f8e,7577,463610,373555
+242898,Brennan,Johnson,Johnson,,,,,,,394,450,491,580,0cd31129,10760,470607,379688
+243016,Alexis,Mac Allister,Mac Allister,,,,627,80,74,116,304,329,386,83d074ff,8379,534033,345319
+243298,Cody,Gakpo,Gakpo,,,,,,,680,297,321,384,1971591f,11296,434675,352825
+243343,Jake,Cain,Cain,,,,,607,,,,,,a33ce8e2,9192,565420,391820
+243345,Lewis,O'Brien,O'Brien,,,,,,,524,458,439,520,089667a5,10759,560694,366083
+243505,Jakub,Moder,Moder,,,,,628,75,117,144,137,,f230bc30,9284,384461,399378
+243526,Gabriel,Gudmundsson,Gudmundsson,,,,,,,,,,347,d5d22a58,9944,362108,330549
+243531,Andrew,Eleftheriou,Eleftheriou,605,,,,,,,,,,0878b548,5548,476532,331089
+243532,Dion,Pereira,Pereira,659,,,,,,,332,,,8aab04dc,5559,499604,335753
+243557,Moussa,Diaby,Diaby,,,,,,,,599,34,,aeed5c06,6556,395516,353397
+243568,Billy,Gilmour,Gilmour,,,,533,124,145,149,133,124,,df10e27c,7988,423744,381255
+243569,Adedapo,Awokoya-Mebude,Mebude,,,,,,469,,,,,b7996fe0,,424021,
+243571,Nathan,Patterson,Patterson,,,,,,674,197,262,234,296,230f0471,10292,424015,396975
+243710,Bernardo,Costa Da Rosa,Rosa,,,,595,,,,,,,cd3112d5,8236,476367,390701
+244042,Rodrigo,Muniz Carvalho,Muniz,,,,,,,218,279,251,338,a755db8c,10717,735571,403649
+244085,Siriki,Dembélé,Siriki,,,,,,,74,67,,,11f54bd5,10749,488656,342868
+244262,Alfie,Doughty,Doughty,,,,,,,,321,,,bf33b257,11723,608175,362246
+244560,Romain,Perraud,Perraud,,,,,,460,417,,,,6dfd8f05,6500,318523,331466
+244619,Luke,Thomas,Thomas,,,,660,240,219,270,693,305,,fc027d02,8562,505194,396317
+244704,Matías,Viña,Viña,,,,,,,718,,,,08eb3b58,9892,439072,397846
+244716,Juan Camilo,Hernández Suárez,Cucho,,,,,,472,,,,,71b47ab9,6954,459463,362501
+244723,Tyrick,Mitchell,Mitchell,,,,579,146,162,170,234,210,258,5cbd1eb0,8214,730893,389579
+244731,Luis,Díaz Marulanda,Luis Díaz,,,,,,696,293,303,327,383,4a1a9578,10408,480692,377168
+244845,Nathan,Wood-Gordon,Wood,,,,,,,,,477,,4ccf2d5b,12763,503990,361334
+244848,Teddy,Jenks,Jenks,,,,,631,,,,,,a96ba40b,9253,530915,384135
+244850,Morgan,Rogers,Rogers,,,,,,,,803,54,47,2e5915f1,12412,503743,362824
+244851,Cole,Palmer,Palmer,,,,643,552,507,316,362,182,235,dc7f8a28,8497,568177,395692
+244856,Teden,Mengi,Mengi,,,,,319,,,393,,,91748070,12073,548470,388671
+244858,Fábio,Freitas Gouveia Carvalho,Carvalho,,,,,695,,296,,314,123,966e28d0,9501,559263,401385
+244890,Joseph,Hungbo,Hungbo,,,,,,402,,,,,fdf9edec,,725703,
+244930,Alex,Mighten,Mighten,,,,,,,395,456,435,,10ec4169,10761,503988,381101
+244932,Ben,Knight,Knight,,,,,,,600,,,,190163f3,11032,568007,421976
+244954,Pau,Torres,Pau,,,,,,,,584,52,41,532e1e4f,6221,399776,344259
+245414,Nicolò,Zaniolo,Zaniolo,,,,,,,,672,,,9907b1c8,6686,392085,332398
+245419,Patson,Daka,Daka,,,,,,455,271,,289,,ca45605e,9738,365172,345560
+245719,Taylor,Harwood-Bellis,Harwood-Bellis,,,,642,623,,,,461,,47327321,8495,503977,384061
+245824,Carlos Vinícius,Alves Morais,Vinicius,,,,,564,,618,287,258,,8b529245,7395,525287,363077
+245830,Josh,Bowler,Bowler,,,,,,,,440,426,,ea39a081,,506470,
+245923,Luke,Cundle,Cundle,,,,567,614,547,485,550,540,,cc3b8e78,8179,532541,384130
+246265,Corrie,Ndaba,Ndaba,,,,,,,,,279,,4db55657,13876,433329,
+246301,Jorge,Cuenca Barreno,J.Cuenca,,,,,,,,,586,321,0abc51f2,8489,494880,333182
+246799,Jackson,Smith,Smith,,,,,,,557,,,,15fdac60,,511964,
+246878,Abdelhamid,Sabiri,Sabiri,,522,205,,,,,,,,4830e0af,6296,340394,333255
+247245,Hannes,Delcroix,Delcroix,,,,,,,,674,,188,b737f944,11998,338635,367189
+247286,Kyle,Jameson,Jameson,,624,,,,,,,,,3e61e488,6527,494684,351683
+247348,Daniel,Muñoz Mejía,Muñoz,,,,,,,,792,211,256,778ef829,12408,493003,400496
+247412,Jørgen,Strand Larsen,Strand Larsen,,,,,,,,,566,654,f553b2b3,11070,429983,333048
+247632,Pedro,Lomba Neto,Neto,,,,528,474,441,486,567,560,236,7ba2eaa9,6382,487465,337916
+247664,Terry,Ablade,Ablade,,,,,,,591,,,,d524dcd7,11004,434015,426328
+247670,Valentín,Castellanos,Taty,,,,,,,,,,791,da76bab4,10948,522784,361406
+247693,Randal,Kolo Muani,Kolo Muani,,,,,,,,,,726,c0b3669f,5743,487969,333542
+247955,Lutsharel,Geertruida,Geertruida,,,,,,,,,,724,242e1043,13064,420210,345441
+248056,Tanaka,Ao,Tanaka,,,,,,,,,,358,1d36d6b6,13834,489359,423347
+248164,Viljami,Sinisalo,Sinisalo,,,,,,596,707,57,55,,a48635b8,9967,484838,406444
+248853,Dynel,Simeu,Simeu,,,,,,665,,,,,6df49f02,10204,503976,397467
+248854,Josh,Brooking,Brooking,,,,,,,,723,,,330f638c,12130,566832,467970
+248857,Noni,Madueke,Madueke,,,,,,,708,208,177,18,bf34eebd,11357,503987,389935
+248859,Amadou,Diallo,Diallo,,,,,,,,738,,,e31708b2,12200,533086,444998
+248865,Armstrong,Oko-Flex,Oko-Flex,,,,,,652,572,,,,ab77d10d,10179,531461,409111
+248875,Jérémy,Doku,Doku,,,,,,,,678,346,418,fffea3e5,8981,486049,388098
+248937,Sam,Greenwood,Greenwood,,,,,692,550,237,,,355,f3354c07,9493,532178,409078
+249231,Keane,Lewis-Potter,Lewis-Potter,,,,,,,515,107,98,107,41f08ac8,10809,644401,368512
+250199,Nicolás,Domínguez,Dominguez,,,,,,,,712,431,519,20b3a502,8252,497291,334653
+250370,Nathan,Bishop,Bishop,,,,,686,,656,,,,bf713136,9433,495033,362214
+250604,Owen,Otasowie,Otasowie,,,,566,581,442,,,,,6956ff08,8180,511815,388673
+250735,Darko,Churlinov,Churlinov,,,,,,,,162,,204,c6608135,7790,386786,
+420922,Jan,Zamburek,Zamburek,,,,,,93,,,,,395880a4,,487924,
+421796,Sidnei,Tavares,Tavares,,,,,676,,,,,,3add8ed8,9395,511813,410174
+422287,Kofi,Balmer,Balmer,,,,,,,642,,,,0284bd0d,11169,504518,403113
+422303,John,McAtee,McAtee,,,,,,,,324,,,5c42b6b6,11726,504855,381124
+422306,Will,Ferry,Ferry,,,,654,634,,,,,,f4765c97,8535,504856,395960
+422612,Ryan,Astley,Astley,,,,,681,,,,,,0eb884e1,9407,511552,411124
+423649,Enock,Mwepu,Mwepu,,,,,,462,118,,,,1d5cab82,9734,490307,353191
+424001,Vini,de Souza Costa,Vini Souza,,,,,,,,638,,,6a8a7af8,10872,663581,373964
+424044,Hamed,Traorè,H.Traorè,,,,,,,723,87,67,93,570bb4b9,6986,391065,362551
+424876,Dominik,Szoboszlai,Szoboszlai,,,,,,,,309,336,387,934e1968,9788,451276,369875
+427420,Giovanni,Reyna,Reyna,,,,,,,,801,,,7fa4e703,8191,504215,389087
+427623,Chris,Richards,Richards,,,,,,,530,238,194,261,0a3d6d2b,8430,578539,395401
+427637,Brenden,Aaronson,Aaronson,,,,,,,246,,,350,5bc43860,10751,393323,371012
+428399,João,Félix Sequeira,João Félix,,,,,,,690,,621,,8aafd64f,7892,462250,362431
+428580,Frank,Onyeka,Onyeka,,,,,,479,93,111,102,128,2944f86f,9681,421637,404109
+428610,Bruno,Cavaco Jordão,Jordão,,,,609,475,661,,561,,,41ff002d,6336,415646,346000
+428626,Przemyslaw,Placheta,Placheta,,,,,,328,,,,,3c33f9d9,10097,383109,377190
+428971,Steven,Benda,Benda,,,,,,,,692,242,315,caaa7fab,12735,381469,362371
+429414,Saša,Kalajdžić,Kalajdžić,,,,,,,608,562,555,656,15f24fe7,8812,369567,377271
+430367,Joel,Mumbongo,Mumbongo,,,,665,613,,,,,,f8e588df,8566,381156,341419
+430871,Matheus,Santos Carneiro da Cunha,Cunha,,,,,,,682,590,541,450,dc62b55d,7080,517894,362758
+430992,Owen,Beck,Beck,,,,,,627,,782,,,a011a1e9,10119,551001,424814
+431019,Karlo,Ziger,Ziger,,,,,593,,,,,,53b781b9,9083,526258,404602
+431131,Moussa,Djenepo,Djenepo,,,,438,382,350,418,,,,254147d4,7701,485424,363676
+431248,Ladislav,Krejcí,Krejčí,,,,,,,,,,709,5b5c2228,1447,345911,404245
+431639,Zian,Flemming,Flemming,,,,,,,,,,215,b3f36e72,13729,411537,361694
+431774,Kyle,Taylor,Taylor,,602,600,,,,,,,,0bb6d386,6493,562254,351320
+431924,Daniel,Adshead,Adshead,,,,669,,,,,,,8f817fc7,8590,532464,344381
+431960,Bendegúz,Bolla,Bolla,,,,,,,,547,,,b6ca3ab3,,439351,
+432160,Shandon,Baptiste,Baptiste,,,,,,499,94,92,,,2886c9b5,9914,533916,362124
+432422,Sandro,Tonali,Tonali,,,,,,,,429,417,491,0db169ae,7958,397033,343501
+432656,Eric,Garcia,Garcia,,,,544,288,,,,,,2bed3eab,8045,466794,368091
+432705,James,Daly,Daly,,638,,581,,,,,,,435c44b3,6668,577779,355373
+432711,CJ,Egan-Riley,Egan-Riley,,,,,,651,,166,,,d313e8ff,10174,581669,425574
+432712,Owen,Hesketh,Hesketh,,,,,,,,769,,,3f991cbb,12289,550995,484870
+432714,James,McAtee,McAtee,,,,,,629,317,360,357,426,96593e89,10126,583199,425576
+432720,James,Trafford,Trafford,,,,,595,,,596,,182,259fea27,9077,566799,404852
+432735,Adam,Idah,Idah,,,,538,,329,,,,,291e3ec3,8021,434223,382368
+432793,Abd-Al-Ali Morakinyo Olaposi,Koiki,Koiki,,,564,596,,,,,,,82726be5,7323,641441,368210
+432830,Nathan,Collins,Collins,,,,,,451,516,96,88,106,a8c19eb8,9733,469050,372724
+432927,Daniel,Langley,Langley,,,,,606,,,,,,096d1e60,9188,532824,408004
+432931,Tyrese,Francois,Francois,,,,,708,,521,272,,,6722d4f0,9552,528888,382367
+432987,Vítezslav,Jaros,Jaros,,,,,,,,,660,,12bb4d6a,13103,486604,391831
+432990,Yasser,Larouci,Larouci,,,,,,,,592,,,0ed063d6,10041,554251,386971
+433019,Liam,Hughes,Hughes,,,,,677,,,,,,54ae11f8,9404,494284,409388
+433036,Tijjani,Reijnders,Reijnders,,,,,,,,,,427,afb61630,11965,460939,343382
+433138,Marc,Leonard,Leonard,,,,,,654,,,,,bd8afa3d,10176,463751,423719
+433154,Dwight,McNeil,McNeil,,646,534,97,100,118,534,259,230,300,fc15fb84,6756,584769,357427
+433312,Marshall,Munetsi,Munetsi,,,,,,,,,770,648,2acf0cd7,7908,414908,377411
+433589,Haydon,Roberts,Roberts,,,,,,560,122,,,,a731e8a0,9845,533523,382375
+433590,Cody,Drameh,Drameh,,,,,694,562,547,,,,e0d1510a,9499,531957,414473
+433952,Largie,Ramazani,Ramazani,,,,,,,,,,357,cc9256ef,10975,518644,447229
+433979,Cameron,Archer,Archer,,,,,,568,54,33,27,,05e8ca6d,9912,533662,382363
+434024,Patrik,Gunnarsson,Gunnarsson,,,,,,94,,,,,4d39152d,9688,429563,370992
+434043,Alex,Robertson,Robertson,,,,,,,772,,,,3434ac72,11593,609887,421238
+434044,Cieran,Slicker,Slicker,,,,,,615,,,280,,02aed921,10052,621997,425320
+434138,Jordan,Stevens,Stevens,,,,,212,,,,,,7d3dc53e,,533913,
+434399,Reinildo,Mandava,Reinildo,,,,,,,,,,541,c20bdcd7,7432,240692,361812
+434662,Halil,Dervişoğlu,Dervişoğlu,,,,,,95,541,100,,,9d8cf204,9686,465606,357083
+434752,Jaka,Bijol,Bijol,,,,,,,,,,344,6fdac234,6807,371851,360941
+435973,Lyle,Foster,Foster,,,,,,,,168,,217,f84a807c,7498,467623,371447
+435997,Noah,Okafor,Okafor,,,,,,,,,,698,ca607d59,11966,346890,376090
+436234,Bryan,Gil Salvatierra,Bryan,,,,,,487,554,494,483,590,7b5ab7f2,7338,537382,368519
+436416,Christos,Mandas,Mandas,,,,,,,,,,806,f794e9ab,12043,481675,418171
+436680,Jakub,Stolarczyk,Stolarczyk,,,,,,,,,304,,a4a76b3d,13301,486144,407587
+436893,Julián,Araujo Zúñiga,J.Araujo,,,,,,,,,592,78,8f4541c2,11745,513970,371039
+437468,Sergio,Gómez,Sergio Gómez,,,,,,,587,366,,,01e5f06e,6656,366930,355110
+437476,Braian,Ojeda Rodríguez,Ojeda,,,,,,,396,459,,,60953af0,,491596,
+437495,Illan,Meslier,Meslier,,,,,213,199,238,,,339,6b625ac2,8715,542586,380580
+437499,Maxence,Lacroix,Lacroix,,,,,,,,,650,257,277c49ed,8853,434224,401130
+437505,Wilson,Isidor,Isidor,,,,,,,,,,560,a671316d,7148,494237,363535
+437626,Nuno,Varela Tavares,Tavares,,,,,,466,17,23,,,a65c844b,9691,535955,379790
+437688,Lewis,Richards,Richards,,,,,615,,,,,,ae0e6ba7,9082,571827,386974
+437730,Antoine,Semenyo,Semenyo,,,,,,,714,82,78,82,efd2ec23,11363,583255,357073
+437738,Sebastiaan,Bornauw,Bornauw,,,,,,,,,,345,01834aa0,7791,338629,364235
+437742,Albert,Sambi Lokonga,Sambi,,,,,,478,18,21,,29,1b4f1169,9689,381967,349102
+437748,Mike,Trésor Ndayishimiye,Trésor,,,,,,,,706,,214,b2a81fc6,12094,381963,383581
+437753,Giulian,Biancone,Biancone,,,,,,,399,438,,,de40e38c,7282,536507,367162
+437757,Han-Noah,Massengo,Massengo,,,,,,,,694,,,eba1e557,7264,536508,365831
+437858,Vitor,Ferreira,Vitinha,,,,,515,,,,,,3b029691,8777,487469,384887
+438098,Fábio,Ferreira Vieira,Fábio Vieira,,,,,,,25,4,1,23,6412cc03,11007,537598,394924
+438234,Omar,Marmoush,Marmoush,,,,,,,,,755,413,0e0102eb,8393,445939,394749
+438277,Ozan,Kabak,Kabak,,,,,652,580,,,,,2d61d13a,7376,361260,356743
+438405,Billy,Crellin,Crellin,,,,,,,,863,,,1a85a237,12634,536794,381103
+438464,Cheick,Doucouré,Doucouré,,,,,,,514,223,193,268,ce4f40c7,8666,543387,374993
+439135,Eiran,Cashin,Cashin,,,,,,,,,763,154,f557c3b8,13459,581330,414168
+439242,Taylor,Gardner-Hickman,Gardner-Hickman,,,,,701,,,,,,f05ee68d,9522,546944,415368
+439482,Miguel,Azeez,Azeez,,,,,689,721,,,,,660e71be,9468,547533,407112
+439483,Hubert,Graczyk,Graczyk,,,,,,,,,783,,aa41418a,13473,587018,467915
+439485,Josh,Martin,Martin,,,,632,,330,,,,,3f072a68,8455,547534,391268
+439509,Christos,Tzolis,Tzolis,,,,,,528,,,,,9f333379,9746,451677,399296
+439510,Luke,Mbete-Tabu,Mbete,,,,,622,603,320,,,,387e1d35,9228,609883,408822
+440089,Mikkel,Damsgaard,Damsgaard,,,,,,,580,98,89,121,215f3907,8859,540941,401168
+440113,Aaron,Rowe,Rowe,,,607,,,,,,,,4b6bcb0d,7487,657994,371276
+440120,Daniel,Chesters,Chesters,,,,,,710,,,,,240c8ab6,10424,561452,426831
+440123,James,Furlong,Furlong,,,,,,,652,,,,ab18d1b0,11194,580030,423723
+440148,Tyler,Morton,Morton,,,,,,620,,,331,395,2bc28bb9,10091,618494,425568
+440241,Jensen,Weir,Weir,,,,,633,,,,,,2ae8e967,9252,520651,362189
+440323,Armando,Broja,Broja,,,,631,,518,150,193,156,680,97220da2,8384,571743,393407
+440854,Jakub,Kiwior,Kiwior,,,,,,,710,10,8,9,dc3e663e,10012,425918,424462
+440955,Nazarii,Rusyn,Rusyn,,,,,,,,,,564,dab75831,,366729,
+440993,Iliman,Ndiaye,Ndiaye,,,,,656,,,486,232,299,5ed97752,9307,623570,366116
+441024,Harrison,Ashby,Ashby,,,,,,617,555,404,,482,b391383a,10061,559130,400604
+441164,Pedro,Porro Sauceda,Pedro Porro,,,,,,,733,506,495,568,27d0a506,6912,553875,362352
+441191,Tino,Livramento,Livramento,,,,,698,491,419,633,409,477,afed6722,9512,503981,415174
+441192,Jeremy,Sarmiento Morante,Sarmiento,,,,,,612,119,146,141,171,ac0d576d,10036,568005,425603
+441240,Romain,Faivre,Faivre,,,,,,,,799,66,92,745ca0a3,6420,555076,349368
+441264,Brian,Brobbey,Brobbey,,,,,,,,,,730,4c184730,9789,473169,404568
+441266,Ryan,Gravenberch,Gravenberch,,,,,,,,708,323,390,b8e740fb,10697,478573,363884
+441271,Ki-Jana,Hoever,Hoever,,,,628,545,443,,556,552,638,9a71e978,8351,485583,368547
+441302,Ian,Maatsen,Maatsen,,,,,,,,609,45,39,cab9634e,11807,485585,384134
+441428,Jarell,Quansah,Quansah,,,,,,660,,626,333,,4125cb98,10187,632349,430019
+441455,Victor,da Silva,Vitinho,,,,,,,,182,,,9295dc1c,11700,468249,349504
+442229,Michał,Karbownik,Karbownik,,,,,663,536,,136,,,1b280c66,9320,401604,399379
+442335,Edo,Kayembe,Kayembe,,,,,,679,,,,,f99b71de,10290,486477,363718
+443211,Rhys,Norrington-Davies,Norrington-Davies,,,,,,,,487,,,ca76b087,12291,543164,361752
+443261,Jack,Clarke,J.Clarke,,,,,,,,,631,,e16932d8,13019,559794,363516
+443296,Theo,Corbeanu,Corbeanu,,,,,610,,,,,,25b82f9a,9209,568535,408423
+443629,Marcelo,de Araújo Pitaluga Filho,Pitaluga,,,,,,656,,756,,,b3cafda8,10180,662334,389027
+443661,Michael,Olise,Olise,,,,,,464,171,236,,,c4486bac,9948,566723,371281
+443967,Junior,Firpo Adames,Firpo,,,,,,463,239,,,,24f59bb2,6485,374139,351252
+444102,Francisco Evanilson,de Lima Barbosa,Evanilson,,,,,,,,,617,97,6f3cc2fe,12963,711337,384430
+444145,Gabriel,Martinelli Silva,Martinelli,,,,504,26,26,19,12,9,19,48a5a5d6,7752,655488,380706
+444172,Will,Dennis,Dennis,,,,,,,77,,599,68,d8edc4be,10748,582078,384131
+444180,Jaidon,Anthony,Anthony,,,,,,,75,62,61,200,e4238fb1,10746,684210,400610
+444181,Nnamdi,Ofoborh,Ofoborh,,,613,,,,,,,,76bca47e,7564,611906,362807
+444183,Gavin,Kilkenny,Kilkenny,,,,565,,,,71,,,3eeda7dd,8172,469064,382442
+444253,Jordan,Thomas,Thomas,,,,650,,,,,,,b547f08c,8518,563306,395835
+444463,Wesley,Fofana,Fofana,,,,,561,220,272,201,189,230,132a82f1,7589,475411,373946
+444575,Toby,King,King,,,,,706,,,,,,25671a6a,9542,614826,416042
+444765,Sepp,van den Berg,Van den Berg,,,,,,,500,312,338,113,7bf9400b,10721,541231,351705
+444880,Mika,Biereth,Biereth,,,,,,694,,,,,a1d95db3,10349,565821,430909
+444884,Harvey,Elliott,Elliott,,,610,550,265,506,294,295,319,389,c8387671,7546,565822,363982
+445044,Dejan,Kulusevski,Kulusevski,,,,,,701,446,501,492,583,df3cda47,6691,431755,355855
+445122,Jurriën,Timber,J.Timber,,,,,,,,585,6,8,41034650,11707,420243,388650
+445548,Odeluga,Offiah,Offiah,,,,,,712,736,845,139,,65c3efa2,10453,567597,423721
+445550,Thomas,Dickson-Peters,Dickson-Peters,,,,,,649,,,,,f119a610,10171,566888,406950
+445896,Kgaogelo,Chauke,Chauke,,,,,624,680,,,,,06791660,9232,703577,408859
+446008,Bryan,Mbeumo,Mbeumo,,,,,,96,95,108,99,119,6afaebf2,6552,413039,353377
+446189,Matej,Kovár,Kovár,,,,,,,615,,,,bc67a0e1,11069,550829,388668
+446281,Tony,Springett,Springett,,,,,,716,,,,,35be8087,10525,570864,435986
+447093,Allan,Tchaptchet,Tchaptchet,,,,,635,,,,,,ab7d7882,9257,465294,409246
+447107,Ethan,Wady,Wady,,,,,,,771,,,,fe80cc4a,11584,573132,460643
+447203,Darwin,Núñez Ribeiro,Darwin,,,,,,,297,293,316,397,4d77b365,10720,546543,400828
+447235,Troy,Parrott,Parrott,,,,509,,,453,,,,4357f557,8145,552655,384064
+447261,Mackenzie,Hunt,Hunt,,,,,,,,719,,,a7a688d7,12103,574420,450748
+447325,Harry,Tyrer,Tyrer,,,,,682,616,,,,289,af49fb14,9411,574448,410179
+447372,Ryan,Finnigan,Finnigan,,,,,655,,648,,,,9610c9c1,9309,807318,409323
+447373,Shane,Flynn,Flynn,,,,,684,,,,,,862cc23f,9418,583258,407586
+447715,Aaron,Ramsey,A.Ramsey,,,,,,496,,675,,211,e1618c22,9913,646658,423732
+447720,Imari,Samuels,Samuels,,,,,,,765,,663,,8218e831,11571,565846,399475
+447879,Joseph,Anang,Anang,,,,582,,,739,647,,,21a866b7,8223,576099,390006
+447880,Josh,Wilson-Esbrand,Wilson-Esbrand,,,,,,604,322,,675,,c19a2df1,10005,576121,425406
+447932,Jordan,Zemura,Zemura,,,,,,,76,,,,e8271ad9,10740,633530,400609
+448047,Enzo,Fernández,Enzo,,,,,,,724,199,168,237,5ff4ab71,11356,648195,369430
+448089,João Victor,Gomes da Silva,J.Gomes,,,,,,,721,559,553,646,8b57ad2c,11384,735570,403693
+448104,Piero,Hincapié,Hincapie,,,,,,,,,,725,0c7a48f8,9911,659813,404832
+448482,Robert,Street,Street,,,,,,542,,,,,b4390912,9736,703474,422721
+448487,Andreas,Söndergaard,Söndergaard,,,,,617,444,,,,,43f9b4ba,9223,462820,389362
+448496,Ed,Turns,Turns,,,,,,653,640,,,,9bbef03e,10178,580809,425602
+448514,Rayan,Aït-Nouri,Aït-Nouri,,,,,563,470,487,545,533,402,9b398aea,6674,578391,355401
+448791,Harvey,White,White,,,,634,,668,449,,,,4d90ce8c,8458,581598,395511
+449027,Giorgi,Mamardashvili,Mamardashvili,,,,,,,,,,367,d4b73232,9693,502676,401633
+449133,Harvey,Griffiths,Griffiths,,,,,,,658,787,,,6e4cb264,11209,670558,443579
+449429,Jacob,Greaves,Greaves,,,,,,,,,270,,1f169636,12745,693095,381161
+449434,Anthony,Elanga,Elanga,,,,,702,512,344,378,432,486,2fba6108,9524,583189,413211
+449444,Mazeed,Ogungbo,Ogungbo,,,,,,719,,,,,bacf9d43,10541,581445,436287
+449781,Alexandre,Jankewitz,Jankewitz,,,,649,643,,,,,,7c39363f,8511,507472,395769
+449871,Amadou,Onana,Onana,,,,,,,577,261,233,59,828657ff,9667,485706,400815
+449926,Adrián,Bernabé,Bernabé,,,,,537,,,,,,548672b4,8867,466802,363978
+449974,Lukas,Jensen,Jensen,,,,641,,,,,,,47ed3795,8484,581890,395617
+449988,Fábio,Soares Silva,Fábio Silva,,,,,504,445,488,552,545,655,e7aa9d7c,8778,505653,380655
+450070,Crysencio,Summerville,Summerville,,,,,693,551,240,,587,615,df04eb4b,9492,474701,382564
+450072,Shurandy,Sambo,Sambo,,,,,,,,,,196,4b1d5a70,,412937,
+450197,George,Shelvey,G.Shelvey,,,,,,,749,636,,,5ab61aea,11462,565684,390265
+450314,Matthew,Daly,Daly,,,606,,,,,,,,03e48abb,7458,566349,370989
+450434,Deniz,Undav,Undav,,,,,,,123,149,143,,dd549382,10804,339314,357091
+450527,Mohammed,Salisu,Salisu,,,,,479,351,420,,,,0b33f6ad,6923,563963,362357
+450529,Lewis,Bate,Bate,,,,657,,624,241,,,,cd4256d3,8544,587003,396114
+450535,Malcolm,Ebiowei,Ebiowei,,,,,,,173,224,197,277,fa9fa773,10698,512354,431867
+450539,Myles,Peart-Harris,Peart-Harris,,,,,,662,,744,103,133,ea1a5662,10205,587002,423730
+450541,Luke,Plange,Plange,,,,,,,496,237,,,2140e999,10699,586986,429310
+450542,Jesurun,Rak-Sakyi,J.Rak-Sakyi,,,,,688,541,172,657,213,278,45685411,9461,586834,413291
+450544,Charlie,Patino,Patino,,,,,,664,,,,,e71aac2c,10202,581674,430270
+450550,Fin,Stevens,Stevens,,,,,,569,540,,,,7e003182,9916,587019,399526
+450553,Alex,Kirk,Kirk,,,,,,730,,,,,ace36a62,10582,586980,437776
+451302,Altay,Bayındır,Bayindir,,,,,,,,695,367,431,072e68ed,12054,336077,361707
+451310,Jonathan,Tomkinson,Tomkinson,,,,,,643,,,,,4ba27cea,10162,696762,429651
+451340,Mitoma,Kaoru,Mitoma,,,,,,,124,143,136,157,74618572,10806,504849,425142
+451432,David,Mota Veiga Teixeira do Carmo,David Carmo,,,,,,,,,,509,3ce20eda,,498237,
+453537,Carlos,Mendes Gomes,Mendes,,,,,,,,325,,,d90a63ec,,588412,
+454667,Jens,Cajuste,Cajuste,,,,,,,,,619,,928a4a61,10301,468066,404108
+455084,Leif,Davis,Davis,,,,,214,,,,267,,8574c61f,8919,596446,366211
+456350,Gavin,Bazunu,Bazunu,,,,,,,422,,454,,c91441dc,10765,585550,384868
+456512,Dan,Ndoye,Ndoye,,,,,,,,,,669,8e697a8f,8662,365108,398414
+456966,Caleb,Watts,Watts,,,,,636,,,,,,c7170b46,9256,610665,409245
+457569,Đorđe,Petrović,Petrović,,,,,,,,687,183,67,0cf321c8,12032,465555,406564
+458249,Joshua,Zirkzee,Zirkzee,,,,,,,,,389,466,028e70b9,8044,435648,383956
+458297,Pierre,Ekwah Elimby,Ekwah,,,,,,682,,,,556,830371be,10284,538994,431184
+459373,Gonçalo Bento,Soares Cardoso,Cardoso,,,,594,,,,,,,47760615,8234,587106,363057
+460028,Levi,Samuels Colwill,Colwill,,,,,,,559,197,162,227,700783e7,10805,614258,421351
+460029,Nathan,Young-Coombes,Young-Coombes,,,,,,640,,,,,f9682888,10150,581679,429388
+460842,Mohammed,Kudus,Kudus,,,,,,,,689,525,582,b62878a5,12027,543499,400166
+461012,Cameron,Plain,Plain,,,,,,,649,,,,8c45f10e,11196,655136,462130
+461013,Euan,Pollock,Pollock,,,,,,,706,,,,ea0271ee,11316,655142,471873
+461017,Christian,Saydee,Saydee,,,,564,,,597,,,,af102dc3,8173,655835,388716
+461023,Ryan,Alebiosu,Alebiosu,,,,,,695,,,,,ce048fb8,10350,610649,431521
+461025,Nathan,Butler-Oyedeji,Butler-Oyedeji,,,,,,,685,,665,,3a686640,11272,638964,467919
+461026,Chem,Campbell,Campbell,,,,,,548,568,,,,6f711f67,9741,614603,386973
+461080,Joseph,McGlynn,McGlynn,,,,,,735,,,,,f6b1bcd6,10598,704801,430746
+461096,Lewis,Richardson,Richardson,,,,,592,533,,,,,4fa62ae4,9082,657863,382437
+461102,Bobby,Thomas,Thomas,,,,639,520,534,,179,,,6a471ee8,8483,788283,395615
+461188,Bashir,Humphreys,Humphreys,,,,,,,673,671,,193,d2b32e91,11243,612517,467968
+461195,Dennis,Cirkin,Cirkin,,,,655,,,,,,535,307ea3b6,8537,568006,390876
+461199,Romaine,Mundle,Mundle,,,,,,,748,,,548,597610cd,11461,696181,450254
+461201,Matthew,Craig,Craig,,,,,,729,764,,,,bc914523,10579,633659,437758
+461212,Nile,John,John,,,,,710,,,,,,376d4a41,9555,581683,410795
+461358,Julián,Álvarez,J.Alvarez,,,,,,,319,343,352,,15ab5a2b,10846,576024,365409
+461382,John-Kymani,Gordon,Gordon,,,,668,,,634,658,,,d7e24aa1,8583,659331,396485
+461416,Tom,Cannon,Cannon,,,,,,,662,649,286,,4506aec5,11232,669366,463991
+461421,Lewis,Dobbin,Dobbin,,,,,,607,,624,37,57,e814e1cf,10027,627248,425711
+461446,Tyler,Onyango,Onyango,,,,,644,630,,650,,704,d86a1f3e,9287,663225,409497
+461450,Max,Thompson,Thompson,,,,640,591,,,,,,fa38722f,8480,598958,395616
+461453,Lewis,Warrington,Warrington,,,,,,,561,841,,,8e633970,10775,652979,432082
+461484,Joe,White,White,,,,,,599,,794,419,498,d60c03a9,9959,614811,425059
+461508,Lucas,De Bolle,De Bolle,,,,,,707,,,,,430e09c0,10416,626291,432569
+461529,Charlie,Savage,Savage,,,,,,737,,,,,e07398f8,10617,686837,429512
+461533,Ademipo,Odubeko,Odubeko,,,,,638,,,,,,dcba03f6,9255,655880,409116
+461537,Dermot,Mee,Mee,,,,,,,,835,788,435,caa32820,12531,620362,439471
+461548,Zidane,Iqbal,Iqbal,,,,,,,551,,,,6fa3c28e,11173,686845,429514
+461558,Maxwell,Haygarth,Haygarth,,,,,,628,,,,,2294d430,10114,596216,408006
+461566,William,Fish,Fish,,,,,713,,,,,,b2ee9d2c,9557,640245,413631
+461567,Owen,Dodgson,Dodgson,,,,,,565,,622,,189,2e590065,9827,686839,423378
+461584,Wanya,Marçal-Madivádua,Marcal,,,,,,,735,,297,,6faae64f,11368,670988,427133
+461585,Tawanda,Maswanhise,Maswanhise,,,,,703,,,,,,4f622ca3,9525,670987,415595
+461587,Kasey,McAteer,McAteer,,,,,,647,687,,299,,b2c66859,10166,621193,429531
+461682,Brandon,Aguilera Zamora,B.Aguilera,,,,,,,,434,,,938fa024,12034,631996,447270
+462116,Jean-Clair,Todibo,Todibo,,,,,,,,,591,609,88f130ed,6816,605184,361710
+462381,Filip,Marschall,Marschall,,,,,,650,670,670,46,35,a79abd8b,10173,610863,429724
+462384,Jamal,Baptiste,Baptiste,,,,,669,554,,,,,41d3704d,9347,610706,409114
+462387,Ali,Al-Hamadi,Al-Hamadi,,,,,,,,,260,,8450467d,12751,610581,429636
+462424,William,Saliba,Saliba,,,,,27,27,26,20,18,6,972aeb2a,6888,495666,361822
+462438,Micah,Hamilton,Hamilton,,,,,,,,771,,,0b059e15,12292,652797,450769
+462491,Luke,Chambers,Chambers,,,,,,,563,726,,,7d6af698,10722,670861,444539
+462492,Joe,Gauci,Gauci,,,,,,,,818,39,34,5600c774,12445,591844,476543
+462635,Joe,Gelhardt,Gelhardt,,,,,667,577,242,,,360,01962d0d,9339,503980,362192
+462831,Scott,Banks,Banks,,,,,,543,,,,,d01f8942,9737,596821,422722
+463034,Liam,Delap,Delap,,,,,539,704,323,,268,250,dd897ee7,8868,610849,401254
+463067,Georginio,Rutter,Georginio,,,,,,,700,,618,158,c64c01fc,6937,538977,362433
+463210,Shea,Charles,Charles,,,,,,,773,348,458,,5cc3ce65,11594,747951,428060
+463212,Carlos Roberto,Forbs Borges,Forbs,,,,,,,,,655,,8a310070,13092,742451,468850
+463748,Karl,Hein,Hein,,,,,,532,655,646,5,3,aa81d8f8,9692,493513,399501
+463903,Jesper,Lindstrøm,Lindstrøm,,,,,,,,,577,,37dc1a48,9752,513245,403646
+463912,Elia,Caprile,Caprile,,,,,532,,,,,,97d7afbd,7087,421873,362780
+463936,Jamie,Bynoe-Gittens,Gittens,,,,,,,,,,239,10745192,10542,670882,436425
+463981,James,Hill,Hill,,,,,,,539,69,68,77,69942fb3,10747,611793,362837
+464353,Harvey,Davies,Davies,,,,,,,592,,669,,fd08a24b,11028,706815,411519
+464618,Liam,McCarron,McCarron,,,,,,576,,,,,076bb352,9933,614082,366056
+465247,Senne,Lammens,Lammens,,,,,,,,,,733,8e6d2fcd,14056,503883,402184
+465299,Anthony,Mancini,Mancini,,,,,612,736,,,,,bda82fc2,7168,677311,363847
+465351,Matheus,Nunes,Matheus N.,,,,,,,589,566,356,407,e6af02e0,11000,601883,394933
+465390,Kaine,Kesler-Hayden,Kesler-Hayden,,,,,671,684,,793,43,,9b066938,9409,626888,411201
+465527,Hannibal,Mejbri,Hannibal,,,,,712,706,,383,373,207,ca22ccb0,9558,607224,416207
+465551,Nigel,Lonwijk,Lonwijk,,,,,629,,,,,,17be8dc3,9248,566043,409128
+465572,Reda,Khadra,Khadra,,,,,630,,,,,,88acf83f,9250,405686,409093
+465607,Anssumane,Fati Vieira,Ansu Fati,,,,,,,,700,,,0ba976e4,7967,466810,382234
+465642,Malick,Thiaw,Thiaw,,,,,,,,,,684,ff5ea0bf,8378,521964,393355
+465680,Arnaud,Kalimuendo,Kalimuendo,,,,,,,,,,696,bf4c41f9,8056,585959,384005
+465694,Nico,González Iglesias,N.Gonzalez,,,,,,,,,765,423,2c56a792,9802,466805,422939
+465702,Timothée,Pembélé,Pembele,,,,,,,,,,540,f8ce97ca,8701,538998,
+465730,Maxim,De Cuyper,De Cuyper,,,,,,,,,,145,d494882e,13711,429915,392647
+465920,Mykhailo,Mudryk,Mudryk,,,,,,,699,210,179,245,049a888d,11305,537860,409376
+466052,Rayan,Cherki,Cherki,,,,,,,,,,417,b34c63a5,8094,607223,386153
+466075,Riccardo,Calafiori,Calafiori,,,,,,,,,578,7,aded8e6f,8129,502821,386519
+466117,Naouirou,Ahamada,Ahamada,,,,,,,725,219,190,275,a6c58494,9274,538971,409440
+466404,Andrew,Omobamidele,Omobamidele,,,,,,331,,711,440,,c393a6c4,9833,621993,399490
+466525,Anton,Stach,Stach,,,,,,,,,,660,0f59a7bf,9910,344069,401073
+466955,Brandon,Pierrick,Pierrick,,,,580,147,,,,,,9a526299,8216,703470,389912
+467114,Oliver,Casey,Casey,,,,,215,,,,,,2d82641c,8724,559800,389078
+467169,Antony,dos Santos,Antony,,,,,,,609,372,365,454,99127249,11094,602105,364315
+467189,Mads,Hermansen,Hermansen,,,,,,,,,293,679,c924b17d,12910,400536,409426
+467311,Matthew,Pollock,Pollock,,,,,,454,,,,,6681bcc8,,624948,
+467779,Mats,Wieffer,Wieffer,,,,,,,,,149,173,4876c9ab,12758,415381,445059
+468243,Kamil,Conteh,Conteh,,,,,,669,,,,,1d5c9842,10208,733494,430392
+469130,Lorenzo,Lucca,Lucca,,,,,,,,,,805,83c06f3a,11936,572265,424819
+469142,Jan Paul,van Hecke,Van Hecke,,,,,,,544,150,144,151,4fd08daa,10807,576314,365402
+469247,Samuel,Iling-Junior,Iling Jr,,,,,,,,,41,51,ba492306,10616,581672,438894
+469249,Nohan,Kenneh,Kenneh,,,,,,600,,,,,bc91e227,10000,581677,425381
+469272,Loum,Tchaouna,Tchaouna,,,,,,,,,,210,a3c8b4d3,9977,607226,425118
+470255,Caleb,Taylor,Taylor,,,,,700,,,,,,4ed3f5c4,9521,671074,415367
+470294,Darko,Gyabi,Gyabi,,,,,,,247,,,361,56d838f7,10752,663264,443569
+470296,Jeremiah,Chilokoa-Mullen,Chilokoa-Mullen,,,,,,,742,,,,3b57a494,11391,719681,474334
+470313,Nick,Woltemade,Woltemade,,,,,,,,,,714,7ca196eb,8117,455661,386606
+470315,Luca,Netz,Netz,,,,,,,,,,814,e79269bd,8401,524285,394888
+471471,Imrân,Louza,Louza,,,,,,403,,,,,e1df6989,7278,635336,367217
+471798,Gabriel,Słonina,Slonina,,,,,,,,215,,223,c55a846e,13854,656316,396247
+471848,Femi,Seriki,Seriki,,,,,705,,,653,,,e4e0deaa,9540,638649,416027
+472464,Shola,Shoretire,Shoretire,,,,,673,727,660,399,,,00f0482f,9359,640026,410512
+472713,Aaron,Hickey,Hickey,,,,,,,510,104,93,116,1780bb4a,8942,591949,402367
+472739,Carl,Rushworth,Rushworth,,,,,,,,,615,141,810912d5,12760,646353,421944
+472769,Nico,O'Reilly,O'Reilly,,,,,,,774,,607,411,91ca4a16,11592,743413,468847
+473341,Caleb,Okoli,Okoli,,,,,,,,,301,,8ec109e6,7333,461833,368312
+473342,Stuart,McKinstry,McKinstry,,,,,,601,,,,,1000a059,10001,592474,425382
+474003,Leonardo,Campana,Campana,,,,652,476,,,,,,bf9c0749,8529,606872,392650
+474120,Julio,Enciso Espínola,Enciso,,,,,,,125,130,121,161,9cfbad36,11058,660867,417747
+474772,Ben,Greenwood,Greenwood,,,,,,,737,619,,,7eda24fe,11364,646333,450534
+474803,Eddie,Beach,Beach,,,,,,,,680,,,7cbd6d68,11979,732120,467967
+474907,Reece,Welch,Welch,,,,,690,623,605,,803,298,a182122b,9469,655986,413423
+474908,Jadan,Raymond,Raymond,,,,,,,,724,,,9ad8d732,12138,655815,484871
+475123,Carlos Miguel,dos Santos Pereira,C.Miguel,,,,,,,,,427,503,84454067,12764,641458,442459
+475168,João Pedro,Junqueira de Jesus,João Pedro,,,,592,,404,,135,129,249,e8832875,8272,626724,373525
+475480,Benicio,Baker-Boaitey,Baker-Boaitey,,,,,,,,742,114,,4c5835e6,12204,657817,492543
+475492,Oliver,Hammond,Hammond,,,,,,,553,,,,3766178e,10763,646214,423729
+476161,Lewis,Payne,Payne,,,,,,,647,,,,32e9d210,11190,744131,454752
+476344,Jhon,Durán,Duran,,,,,,,711,44,38,,414184f7,11366,649317,433517
+476369,Issa,Kaboré,Kaboré,,,,,,,,602,626,,c066d1a5,9619,649452,399955
+476502,Boubacar,Traoré,B.Traore,,,,,,,629,574,534,649,999ceb5f,8119,649020,386612
+476887,Dilane,Bakwa,Bakwa,,,,,,,,,,734,2b5a35e5,8920,540664,402130
+476888,Sékou,Mara,Mara,,,,,,,528,,468,,3544641e,8970,557612,402855
+476938,Ismaila,Coulibaly,Coulibaly,,,,,,,,478,,,d33e3242,11999,490224,372400
+477064,Rico,Lewis,Lewis,,,,,,,573,358,355,410,b57e066e,10847,701057,444791
+477386,Armel,Bella-Kotchap,Bella-Kotchap,,,,,,,423,,456,,a39d11bc,9710,467563,369970
+477424,Joško,Gvardiol,Gvardiol,,,,,,,,616,350,403,5ad50391,9790,475959,402664
+477547,Leo Fuhr,Hjelde,Hjelde,,,,,,608,243,,,536,d102b8a2,10028,661208,409110
+477555,Oscar,Bobb,Bobb,,,,,,,,345,343,424,eed2427e,11903,661207,430709
+477580,Illia,Zabarnyi,Zabarnyi,,,,,,,722,89,85,71,88968486,11486,659089,399826
+477717,Maxime,Estève,Estève,,,,,,,,806,,191,1a066e69,9487,842341,414233
+477733,Radek,Vítek,Vítek,,,,,,,,669,,,d617bff6,11874,622236,456623
+477851,Abdoullah,Ba,Ba,,,,,,,,,,554,3f651f34,,654412,
+478028,Kayky da Silva,Chagas,Kayky,,,,,,663,,,,,17734ea0,10203,668265,416803
+478227,Stefan,Parkes,Parkes,,,,,,,636,,,,66b290f7,11145,657724,459061
+478449,Kyron,Gordon,Gordon,,,,,646,,,,,,f4aba1af,9289,746734,409014
+478912,Carney,Chukwuemeka,Chukwuemeka,,,,,672,526,48,196,161,,b2f9c73e,9356,659459,410639
+478969,Hjalmar,Ekdal,Ekdal,,,,,,,,167,,190,f503ea63,11704,392179,399619
+479641,Sebastian,Revan,Revan,,,,,,,754,,,,8525ec2a,11497,667925,427614
+479683,Marcus,Oliveira Alencar,Marquinhos,,,,,,,27,11,,,59878425,11035,668268,419077
+480216,Mateusz,Bogusz,Bogusz,,,,,533,,,,,,a2c1d8c2,8817,431475,373457
+480455,Jarrad,Branthwaite,Branthwaite,,,,637,170,544,196,245,219,290,c1949191,8476,661053,381045
+480818,Billy,Koumetio,Koumetio,,,,,697,,,,,,866c67e9,9513,696324,386970
+481283,James,Wright,Wright,,,,,,,753,778,,688,9417a430,11488,712181,478019
+481371,Zak,Brunt,Brunt,,,,,657,,,,,,a31f0ebf,9308,746777,400732
+481405,Mads,Bidstrup,Bidstrup,,,,,,97,99,94,,,407db0d5,9682,462832,410457
+481510,Victor,Kristiansen,Kristiansen,,,,,,,709,,296,,505486d6,11367,564529,416970
+481624,Jaden,Philogene,Jaden,,,,,683,497,55,54,569,,19f4d211,9415,665390,411335
+481626,Christian,Marques,Marques,,,,,616,549,,,,,a7cf1541,9215,539807,397328
+481655,Martín,Zubimendi Ibáñez,Zubimendi,,,,,,,,,,26,3ee0dd59,7526,423440,372424
+482158,Lucas,Bergström,Bergström,,,,,,,,659,154,,b59c2a92,11809,490606,424586
+482442,Pape Matar,Sarr,P.M.Sarr,,,,,,,450,513,499,593,feb5d972,9021,568693,403859
+482609,Malo,Gusto,Gusto,,,,,,,,203,171,228,d56b9520,9017,620322,403850
+482769,Máximo,Perrone,Perrone,,,,,,,712,363,,,53552942,11378,668547,433972
+482973,Igor Jesus,Maciel da Cruz,Igor Jesus,,,,,,,,,,526,dbe24cce,13778,432164,397497
+483081,Rodrigo,Martins Gomes,R.Gomes,,,,,,,,,563,635,8dcf77c0,12756,667121,402823
+483364,Krisztián,Hegyi,Hegyi,,,,,,,740,,,602,2411c7f7,11369,543726,424270
+483365,Jonathan,Rowe,Rowe,,,,,,648,,,,,8c12f884,10172,672381,429723
+483391,Luke,McNally,McNally,,,,,,,,171,,,22a93e73,,535927,
+483398,Matthew,Whittingham,Whittingham,,,,,,,,749,,,cd84f0e3,12235,908798,510857
+484420,Enzo,Le Fée,E.Le Fée,,,,,,,,,,547,c79f7793,8651,633992,398393
+484658,Kacper,Kozłowski,Kozlowski,,,,,,,126,137,130,,3ece036c,,554284,
+485047,Felipe,Rodrigues da Silva,Morato,,,,,,,,,653,511,0f41e2ee,13068,673492,376916
+485055,Antonín,Kinský,Kinsky,,,,,,,,,716,567,b38ac6a4,13348,725912,457006
+485337,Evann,Guessand,Guessand,,,,,,,,,,677,b73f17f8,8006,500689,382587
+485711,Benjamin,Sesko,Šeško,,,,,,,,,,681,3260690c,11974,627442,424191
+486385,Norberto Bercique,Gomes Betuncal,Beto,,,,,,,,691,218,311,ed5c0319,9983,595809,380546
+486520,Ilia,Gruev,Gruev,,,,,,,,,,356,1fc4f3d1,8000,381753,382590
+486623,Sean,McAllister,McAllister,,,,,,,768,,,,66c0246b,11575,720720,482358
+486672,Moisés,Caicedo Corozo,Caicedo,,,,,664,538,120,126,157,241,16264a81,9453,687626,410175
+486870,Frederik,Alves,Alves,,,,,637,521,,,,,95827107,9254,542690,409115
+487053,Destiny,Udogie,Udogie,,,,,,,,519,505,574,7cd520e8,8831,556385,401044
+487117,Evan,Ferguson,Ferguson,,,,,,655,596,132,123,179,4596da74,10177,648046,423720
+487676,Trai,Hume,Hume,,,,,,,,,,532,4fa3a3a4,13713,515544,424514
+487693,Devan,Tanton,Tanton,,,,,,,,732,,,3c256bb1,12176,745452,507719
+487702,Luca,Koleosho,Koleosho,,,,,,,,605,,208,fc076f78,10620,745461,438959
+487818,Joe,Whitworth,Whitworth,,,,,,,590,243,,,3f847d95,11005,670840,454492
+487828,Omari,Forson,Forson,,,,,,,,632,,,1b9728b0,12340,670845,491385
+487835,Benjamin,Chrisene,Chrisene,,,,,,703,,,,,b17008fc,10406,670846,381144
+487836,Antwoine,Hackford,Hackford,,,,,618,,,656,,,a7588cdc,9222,670859,408769
+487837,Divin,Mubama,Mubama,,,,,,,669,538,698,,92868cb5,11242,670848,454820
+487838,Lewis,Hall,Hall,,,,,,671,661,204,399,473,da011f18,10216,670858,430294
+487968,Ameen,Al-Dakhil,Al-Dakhil,,,,,,,,157,,,93e08bce,11699,620598,419917
+488024,Yéremy,Pino Santos,Yeremy,,,,,,,,,,712,540ec57b,9024,568157,403865
+488213,Tolu,Arokodare,Tolu,,,,,,,,,,720,a42760bc,8875,683571,402056
+488404,Facundo,Pellistri Rebollo,Pellistri,,,,,575,,347,394,384,,ac7e7b1c,9324,676318,404086
+488439,Woyo,Coulibaly,Coulibaly,,,,,,,,,726,,beb6e3a6,12782,592975,447492
+488464,Caleb,Wiley,Wiley,,,,,,,,,575,,64796fe0,12837,746833,
+489571,Etienne,Green,Green,,,,,,,,,,184,667b65da,9294,696849,
+489580,Calvin,Ramsay,Ramsay,,,,,,,298,,,380,919acea0,11214,633652,403764
+489639,Bart,Verbruggen,Verbruggen,,,,,,,,152,146,139,cf134113,11711,565093,400138
+489706,Justin,Devenny,Devenny,,,,,,,,,645,276,6c2b66fc,13038,747009,450950
+489888,Amine,Adli,Adli,,,,,,,,,,697,dcfb17f4,8211,532776,389409
+490000,Blondy,Nna Noukeu,Nna Noukeu,,,,,,,,,,530,9b526c28,,696892,
+490094,Tim,Iroegbunam,Iroegbunam,,,,,709,638,49,46,226,304,84c5ceea,9554,696589,416208
+490095,Ty,Barnett,Barnett,,,,,,,,770,,,c68c6838,12290,751666,512928
+490098,Kaine,Hayden,Hayden,,,,659,,,,,,,9b066938,9409,626888,396316
+490138,Jakub,Ojrzynski,Ojrzynski,,,,,678,,,,,,94e5390a,9405,540630,411099
+490142,Freddie,Potts,Potts,,,,,,,,,,623,86bf27f0,13724,698164,429534
+490145,Dane,Scarlett,Scarlett,,,,,666,520,447,640,500,599,21945a9e,9332,670883,407154
+490146,Jay,Stansfield,Stansfield,,,,,,,219,651,256,,b2626673,10718,696346,390214
+490150,Michael,Ndiweni,Ndiweni,,,,,,,,745,,,8aff2b51,12215,698151,495904
+490161,Abu,Kamara,Kamara,,,,,,715,,,,,a6fbfa77,10526,696764,435987
+490180,Aribim,Pepple,Pepple,,,,,,,,331,,,94c53a55,,696502,
+490503,Samuel,Edozie,Edozie,,,,,,508,624,,459,,007414dd,10072,680806,421974
+490721,Hugo,Bueno López,H.Bueno,,,,,649,635,558,548,549,633,bfc3b3a0,10140,698678,409730
+490881,Toby,Collyer,Collyer,,,,,,,,826,613,460,4f9091bc,12461,654253,491384
+490885,George,Earthy,Earthy,,,,,,,,829,519,620,123d2733,12474,697280,491564
+490887,Zach,Awe,Awe,,,,,,705,,,,,7a0ae4f0,10407,697282,432338
+491007,Dário,Luís Essugo,D.Essugo,,,,,,,,,,247,1e4319ac,13094,670717,411914
+491008,Diogo,Pinheiro Monteiro,Monteiro,,,,,,,743,,,,17850779,11390,670713,474333
+491011,Diego Manuel Jadon,da Silva Moreira,Diego Moreira,,,,,,,,681,,,12de1b0d,11978,655006,438349
+491012,Youssef,Ramalho Chermiti,Y.Chermiti,,,,,,,,645,237,312,890f108d,11984,670688,447229
+491279,Micky,van de Ven,Van de Ven,,,,,,,,639,506,575,8fe2a392,10050,557459,425229
+491287,Enzo,Barrenechea,Barrenechea,,,,,,,,,30,56,6caffe81,11140,671915,
+491501,James,McConnell,McConnell,,,,,,,,629,330,394,bf973eeb,11811,845289,492375
+491551,Thierry,Small,Small,,,,,,667,,,,,6f487e5d,10206,746554,409496
+491556,Charlie,Whitaker,Whitaker,,,,,,613,,,,,08288a57,10033,726992,425969
+491557,Jenson,Metcalfe,Metcalfe,,,,,,,,760,614,309,5c2595e2,12269,855890,512228
+491559,Isaac,Price,Price,,,,,691,718,678,,,,b9403c99,9470,612749,413424
+491598,Cameron,Peupion,Peupion,,,,,,,762,786,140,,0bdeb013,11544,703626,454792
+491745,Elijah,Campbell,Campbell,,,,,,,,761,,705,48ba3f58,12270,747598,512227
+491785,Harvey,Vale,Vale,,,,,,672,606,,,,a70182a5,10215,581675,427102
+491970,Bobby,Clark,Clark,,,,,,,584,627,315,,73341ace,10997,712117,450021
+492066,Niall,Huggins,Huggins,,,,,619,,,,,537,6d646ff7,9219,559801,383320
+492368,Isaac,Schmidt,Schmidt,,,,,,,,,,349,f8b9b94d,13974,449597,
+492373,Charlie,Cresswell,Cresswell,,,,,620,563,,,,,4654e5f5,9220,597659,400646
+492374,Jack,Jenkins,Jenkins,,,,,599,631,,,,,3d46127c,9102,734375,405475
+492776,Dexter,Lembikisa,Lembikisa,,,,,,,664,,,,0bdda685,11233,712099,430871
+492777,Conor,Bradley,Bradley,,,,,,626,,757,313,375,bbd67769,10120,624258,424945
+492779,Yago,de Santiago Alonso,Yago Santiago,,,,,,,777,754,,,88b3215c,11617,706947,468089
+492831,Zeki,Amdouni,Amdouni,,,,,,,,594,,216,2ee5b0c9,11701,548729,424624
+492859,Wilfried,Gnonto,Gnonto,,,,,,,619,,,351,75fdd638,11155,627626,439636
+493105,Alejandro,Garnacho Ferreyra,Garnacho,,,,,,723,569,382,372,453,7aa8adfe,10552,811779,437022
+493121,Roshaun,Mathurin,Mathurin,,,,,,,,842,,,c036048e,12548,706822,520826
+493125,Radu,Drăgușin,Dragusin,,,,,,,,777,486,572,620922ed,9105,568559,400097
+493250,Amad,Diallo,Amad,,,,,640,636,550,371,364,452,9dc96f10,8127,536835,386634
+493347,Denis,Franchi,Franchi,,,,,,,,169,,,aab362e6,9475,606576,
+493362,Xavi,Simons,Xavi,,,,,,,,,,717,da4d670f,8700,566931,399772
+493736,Jimmy,Morgan,Morgan,,,,,,,671,,,,f9d409a1,11239,936867,464283
+493837,Jay,Matete,Matete,,,,,,,,,,558,7748a7c5,,535479,
+493928,Marcelo,Flores,Flores,,,,,,720,,,,,937b36b1,10540,668495,436286
+493934,Kwadwo,Baah,Baah,,,,,,405,,,,,f240e4f2,9846,711247,384353
+494041,Ethan,Brierley,Brierley,,,,,,,,684,87,,c2c5ecda,11986,718250,388487
+494307,Max,Alleyne,Alleyne,,,,,,,,,703,794,5383979b,13298,843595,468845
+494521,Adrien,Truffert,Truffert,,,,,,,,,,74,5d0e0a1f,8640,654539,398301
+494541,Kamari,Doyle,Doyle,,,,,,,769,,,,65983e4d,11582,864480,475756
+494543,Dominic,Ballard,Ballard,,,,,,,770,,,,ed8d597c,11583,864496,454751
+494551,Jayden,Moore,Moore,,,,,,,,,804,,ed23d14e,13648,1122027,538254
+494595,Florian,Wirtz,Wirtz,,,,,,,,,,382,e7fcf289,8397,598577,394786
+494779,Albert,Grønbæk,Grønbæk,,,,,,,,,734,,0da5076f,12880,503866,424809
+494960,Quilindschy,Hartman,Hartman,,,,,,,,,,192,39e1138f,13727,514285,444739
+495024,Jay,Robinson,Jay Robinson,,,,,,,,,798,,2a616c85,13582,1045124,538255
+495145,Alex,Paulsen,Paulsen,,,,,,,,,75,70,2da46a72,,617009,
+495161,Marko,Stamenić,Stamenic,,,,,,,,,,524,690d1049,,617018,
+495542,Niels,Nkounkou,Nkounkou,,,,,559,570,198,,,,f5b281e7,8109,591193,386262
+496178,Roman,Dixon,Dixon,,,,,,,,,627,297,82e2cc75,12946,856479,535878
+496179,Alfie,Devine,Devine,,,,,650,714,452,,485,,ba08056d,9306,728734,409089
+496185,Kaide,Gordon,Gordon,,,,,,625,,783,,,19a9cb70,10118,732119,408662
+496208,Ben,Gannon-Doak,Gannon-Doak,,,,,,,665,628,318,391,733f1a7d,11231,719673,430350
+496221,Adam,Wharton,Wharton,,,,,,,,807,216,273,4b542852,12409,744149,430774
+496222,Zak,Sturge,Sturge,,,,,,,,859,,,1095aec1,12602,801472,498687
+496228,Sonny,Perkins,Perkins,,,,,,634,663,,,,87f12e30,10141,670877,428688
+496279,Isaac,Heath,Heath,,,,,,,,,773,308,b54c480e,13457,847579,552418
+496283,Mahamadou,Susoho,Susoho,,,,,,,,762,,,6cdd9d3d,12268,895074,449161
+496661,Tyler,Dibling,Dibling,,,,,,731,,,608,707,bdcc89ae,10586,866655,438067
+496683,Max,Kinsey,Kinsey,,,,,,,738,802,680,,ed46ab76,11365,939615,473163
+497605,Liam,Gibbs,Gibbs,,,,,,683,,,,,e4b6d914,10285,724785,407261
+497606,Tawanda,Chirewa,Chirewa,,,,,,,,750,538,650,34721c11,12234,724783,437381
+497894,Rasmus,Højlund,Højlund,,,,,,,,617,375,465,491a433d,11055,610442,439584
+497949,David,Møller Wolfe,Møller Wolfe,,,,,,,,,,682,9affc5f2,13740,661427,415341
+498016,Robin,Roefs,Roefs,,,,,,,,,,670,349fa918,13712,646991,422814
+498046,Salah-Eddine,Oulad M'hand,Oulad M'hand,,,,,,693,,,638,,b85c3273,10351,559330,427103
+499167,Josh,Nichols,Nichols,,,,,,,,,662,15,676cf55d,13115,964554,534236
+499169,Myles,Lewis-Skelly,Lewis-Skelly,,,,,,,,764,597,10,5dff6c28,12272,890721,467918
+499175,Ethan,Nwaneri,Nwaneri,,,,,,,630,772,12,25,7f94982c,11132,890719,456771
+499300,Adam,Aznou,Aznou,,,,,,,,,,667,e678d983,12371,938146,513607
+499309,Marc,Guiu Paz,Marc Guiu,,,,,,,,,178,252,d3d774cc,11633,938158,483208
+499604,Rayan Vitor,Simplício Rocha,Rayan,,,,,,,,,,807,288647fc,14395,1012564,472122
+499716,James,Rowswell,Rowswell,,,,,,,,,,750,419147f7,14176,999743,572656
+499717,Jayden,Meghoma,Meghoma,,,,,,,,,649,118,07382f6c,13067,954104,496356
+499721,Mikey,Moore,Moore,,,,,,,,860,610,592,00953a9d,12603,1011147,526481
+499724,Samuel,Amo-Ameyaw,Amo-Ameyaw,,,,,,,778,,451,,9eedf0e0,11618,933900,482895
+499726,Callum,Olusesi,Olusesi,,,,,,,,,683,595,d6455444,13224,985546,545661
+499857,Teddy,Sharman-Lowe,Sharman-Lowe,,,,,,,,847,,803,7cd31238,12561,731466,389093
+500016,Welington Damascena,Santos,Welington,,,,,,,,,718,,a7f95b1f,13403,729264,389158
+500040,Cristhian,Mosquera,Mosquera,,,,,,,,,,662,dc1ce4f5,10024,646750,425591
+500052,Luca,Barrington,Barrington,,,,,,,,755,,,85d7679f,12246,745689,511059
+500058,Jayden,Danns,Danns,,,,,,,,824,709,398,003cf4d1,12455,939290,517340
+500151,Nicolò,Savona,Savona,,,,,,,,,,716,e041497d,12905,708072,450289
+500267,Loïc,Badé,Badé,,,,,,,621,,,,114bbdee,8665,730581,398416
+500696,Nectarios,Triantis,Triantis,,,,,,,,,,559,73d58203,,957224,
+500926,Ronnie,Edwards,Edwards,,,,,,,,,460,,be90c4b0,13239,732165,405526
+501284,Michael,Olakigbe,Olakigbe,,,,,,,752,620,,,cdd70dc0,11487,734425,477987
+501468,Tayo,Adaramola,Adaramola,,,,,,709,766,763,,,c150b220,10429,724529,432086
+501620,Dante,Cassanova,Cassanova,,,,,,,,,760,,0b8373bb,13409,738269,476828
+501770,Ben,Nelson,Nelson,,,,,,645,,,616,,7be10897,10167,714458,407585
+501837,Yerson,Mosquera Valdelamar,Mosquera,,,,,,446,494,788,558,634,1e159d70,9958,716276,425060
+502222,Ramón,Sosa,Sosa,,,,,,,,,620,,2d3417a1,13021,745191,432672
+502500,Igor Thiago,Nascimento Rodrigues,Thiago,,,,,,,,,107,136,dc45ac24,13222,739443,443784
+502697,Carlos,Alcaraz Durán,Alcaraz,,,,,,,693,,450,301,4abac767,11297,748319,391348
+502988,Danny,Imray,Imray,,,,,,,,,,798,c1395580,14355,862109,518796
+503139,Alex,Scott,Scott,,,,,,,,644,77,90,104d0bb8,12149,855256,410998
+503300,Matthew,Cox,Cox,,,,,,619,633,97,,103,fea06849,10093,741236,399935
+503301,Omari,Hutchinson,Hutchinson,,,,,,692,653,,274,693,bd9553e6,10348,741238,430908
+503308,James,Sweet,Sweet,,,,,,,,817,,,d4632cfa,12444,583952,504127
+503714,Lesley,Ugochukwu,Ugochukwu,,,,,,,,613,188,676,1df4a109,9451,711999,404616
+503724,Lorenz,Assignon,Assignon,,,,,,,,805,,,b026bbf6,8973,711969,402874
+504198,Anis,Slimane,Slimane,,,,,,,,587,,,9ade9ce1,11730,546712,425353
+504296,Coby,Ebere,Ebere,,,,,,,,,775,307,61a42f10,13462,1018714,553206
+504598,Daniel,Gore,Gore,,,,,,,,685,,,861e9b3b,11987,747153,467768
+504750,Justin,Hubner,Hubner,,,,,,,,751,,,f233ed69,12236,678641,510856
+504751,Mauro,Bandeira,Bandeira,,,,,,,767,815,,,9b67eca8,11578,745846,476167
+504783,Kamaldeen,Sulemana,Kamaldeen,,,,,,,731,,462,,a62f8bf1,9630,746695,422135
+505079,Alfie,McNally,McNally,,,,,,,,,,786,419fba9c,14308,747950,605442
+505187,Cesare,Casadei,Casadei,,,,,,,,791,158,,fb920f3a,10433,622380,433219
+505265,Cheikh,Diaby,Diaby,,,,,621,,,,,,45787ffa,9224,592988,408808
+507433,Hákon Rafn,Valdimarsson,Valdimarsson,,,,,,,,789,109,105,57a34cf4,12595,488935,412313
+508395,Yehor,Yarmoliuk,Yarmoliuk,,,,,,,,120,111,129,907a5d7c,11772,717411,444304
+508479,Filip,Jörgensen,Jörgensen,,,,,,,,,581,221,0107757e,9272,585323,404749
+509291,André,Trindade da Costa Neto,André,,,,,,,,,642,643,ec604e2c,13022,800176,397585
+509416,Yasin,Ayari,Ayari,,,,,,,719,124,600,166,f173303a,11385,667287,470690
+510281,Sávio,Moreira de Oliveira,Savinho,,,,,,,,,571,415,fe6e7156,11735,743591,397821
+510328,Stanley,Mills,Mills,,,,,,,560,,,,c0a454d5,10776,801005,444617
+510362,Toti,Gomes,Toti,,,,,,685,489,573,567,637,f0caab96,10293,606718,431283
+510363,Francisco Jorge,Tomás Oliveira,Chiquinho,,,,,,689,490,549,537,,dc6c2f02,10327,695454,421894
+510500,João Pedro,Ferreira da Silva,Jota,,,,,,,,,596,518,4d77e622,12766,663244,444826
+510663,Hugo,Ekitiké,Ekitiké,,,,,,,,,,661,5b92d896,8995,709726,403784
+511499,Mathys,Tel,Tel,,,,,,,,,768,584,829aa60c,9780,801734,422885
+511504,Kristian,Sekularac,Sekularac,,,,,,,667,796,,,e20a28ce,11237,539810,454748
+511783,Anass,Zaroury,Zaroury,,,,,,,,184,,,07d65234,11703,491296,420145
+512462,Jake,O'Brien,O'Brien,,,,,,,,235,582,293,25f2ef01,12014,711544,424495
+513046,Danilo,dos Santos de Oliveira,Danilo,,,,,,,703,442,429,,a816dbfb,11317,808509,399250
+513418,Kevin,Schade,Schade,,,,,,,688,115,106,120,52afb588,9156,473050,407260
+513433,Brajan,Gruda,Gruda,,,,,,,,,595,162,ae9b998d,11310,700106,471784
+513466,Merlin,Röhl,Röhl,,,,,,,,,,728,1f2c7b55,11331,608832,419945
+513527,Bilal,El Khannouss,El Khannouss,,,,,,,,,635,,f7042636,13020,654982,433572
+513588,Jamie,Donley,Donley,,,,,,,,722,,,5e4d9b48,12118,796305,468090
+513789,Thanawat,Suengchitthawon,Suengchitthawon,,,,,687,,,,,,7a6bb9ed,9446,427691,412836
+513834,Andrew,Moran,Moran,,,,,,,651,,601,177,c4720845,11193,724537,423722
+513836,Leigh,Kavanagh,Kavanagh,,,,,,,,753,,,e16986b1,12242,724530,510737
+513840,Samy,Chouchane,Chouchane,,,,,,,,843,,,6c1ebbc8,12554,756591,499173
+513852,Kris,Moore,Moore,,,,,,657,,,,,b660a486,10185,746067,429923
+514154,Ben,Jackson,Jackson,,,,,,,,746,,,0cd9c796,12216,801474,510510
+514229,Sam,Waller,Waller,,,,,,708,,,,,8ee48565,10428,733430,433101
+514254,Diego,Gómez Amarilla,Gomez,,,,,,,,,714,169,916728da,13364,996897,446133
+514277,Jimi,Tauriainen,Tauriainen,,,,,,,,830,,,cac9e583,12497,681615,517600
+514280,Alfie,Gilchrist,Gilchrist,,,,,,,775,716,170,,d91f104d,11595,790992,467969
+514284,Joe,Wormleighton,Wormleighton,,,,,,,645,,,,59d2e6bb,11181,814524,443574
+514287,Sil,Swinkels,Swinkels,,,,,,,744,,640,,a42f6058,11393,646710,408953
+514307,Jack,Henry-Francis,Jack Henry-Francis,,,,,,,,,793,,e93d8ed1,13587,796024,450742
+514315,Lino,da Cruz Sousa,Sousa,,,,,,,631,,56,45,e09d77a2,11133,743414,450073
+514356,Roméo,Lavia,Lavia,,,,,,605,321,667,174,244,ecad9aa5,10004,628451,425319
+514362,Temple,Ojinnaka,Ojinnaka,,,,,,,,853,,777,4e93ceb2,12575,813142,524089
+514514,Lewis,Koumas,Koumas,,,,,,,,812,,,d77edba6,12434,922462,492374
+514613,Zak,Johnson,Johnson,,,,,,,,,,538,67cd6d8d,,827440,
+515023,Matthew,Dibley-Dias,Dibley-Dias,,,,,,,763,652,,,979cb300,11553,817611,481276
+515024,Luke,Harris,Harris,,,,,,,546,683,246,334,42dd1b56,10719,817612,444538
+515046,Melker,Ellborg,Ellborg,,,,,,,,,,812,013d348e,,605426,425235
+515496,Owen,Goodman,Goodman,,,,,,,644,,,,8074e66f,11180,814848,460442
+515500,Rhys,Bennett,Bennett,,,,,,,674,768,,,50c7de8f,11244,794816,467765
+515501,Álvaro,Fernández Carreras,Fernandez,,,,,,728,,380,,,f127d782,5191,453704,437583
+515503,Jack,Wells-Morrison,Wells-Morrison,,,,,,,654,,,,a71ebcc8,11192,814811,430750
+515504,Joe,Hugill,Hugill,,,,,,,,748,,,49134eb2,12224,726859,467770
+515571,Juan,Larios López,Larios,,,,,,,622,,464,,cf7fb13a,11078,646738,455537
+515597,Lamare,Bogarde,Bogarde,,,,,,610,638,,598,44,bca5c4a7,10025,645686,408946
+515599,Tommi,O'Reilly,O'Reilly,,,,,,713,761,767,,,345fc437,10454,818237,433464
+515621,Chadi,Riad Dnanou,Chadi Riad,,,,,,,,,195,262,b3b9b8b8,11167,689637,454342
+516159,Oliwier,Zych,Zych,,,,,,,745,686,641,,be18d79f,11394,555074,408957
+516211,Abdallah,Sima,Sima,,,,,,,,,,165,fdbde523,11046,776798,
+516234,Charlie,Gray,Gray,,,,,,,,,,763,59429fa1,14255,1033103,604494
+516250,Jacob,Wright,Wright,,,,,,,,814,671,,b6db05c3,12427,983702,513616
+516432,Valintino,Adedokun,Adedokun,,,,,,,,733,,,1b5344ef,12179,747996,451136
+516874,Charles,Sagoe,Sagoe,,,,,,,,735,,,187ab096,12195,796037,467920
+516875,Ronnie,Hollingshead,Hollingshead,,,,,,,,,,757,74ab11a7,14218,667490,499948
+516895,Kobbie,Mainoo,Mainoo,,,,,,,643,388,378,458,c6220452,11174,820374,460260
+516939,Emmanuel,Agbadou,Agbadou,,,,,,,,,720,631,75f1ed80,10856,683895,402810
+517052,Nicolas,Jackson,N.Jackson,,,,,,,,211,180,251,9c36ed83,10048,776890,426050
+517178,Elkan,Baggott,Baggott,,,,,,,,,261,,a0e00e23,,758030,
+517179,Alfie,Pond,Pond,,,,,,,,,664,641,039c3d96,13117,821522,437383
+517995,Leo,Castledine,Castledine,,,,,,,,758,,,1c86192d,12247,796303,508375
+517996,Ronnie,Stutter,Stutter,,,,,,,,717,,,e3f9e68a,12085,825024,502566
+518030,Max,Weiß,Weiss,,,,,,,,,,183,882228c2,13731,829299,426859
+518199,Fabian,Mrozek,Mrozek,,,,,,,,813,,,927eecf9,12433,678402,454355
+518335,Max,Merrick,Merrick,,,,,,,,,,789,420d18fe,14317,827435,515437
+518438,Kaelan,Casey,Casey,,,,,,,746,774,643,611,cd4b2c5f,11409,845321,463053
+518442,Lewis,Orford,Orford,,,,,,,,773,701,622,40aaa04c,12296,845809,463054
+518466,Willy,Kambwala,Kambwala,,,,,,,,766,,,6a7353d7,12275,780630,494120
+518467,Marc,Jurado Gomez,Jurado,,,,,,,759,,,,c1d75f69,11518,709960,467766
+518504,James,Storer,Storer,,,,,,621,,,,,257b20e1,10103,838367,427426
+518620,Ângelo Gabriel,Borges Damaceno,Ângelo,,,,,,,,589,151,,737945d9,11818,743598,
+518892,Ted,Curd,Curd,,,,,,,,858,,,d9bd6f58,12596,857792,515222
+518906,Owen,Bevan,Bevan,,,,,,,598,,,76,87966294,11034,583990,454743
+519198,Alex,Matos,Matos,,,,,,,,718,,,ed383e43,12086,670850,502567
+519223,Sammy,Braybrooke,Braybrooke,,,,,,,639,,802,,9f684e25,11160,840640,430780
+519321,Alfie,Dorrington,Dorrington,,,,,,,,740,699,,ac1ef440,12193,796300,468087
+519324,Amario,Cozier-Duberry,Cozier-Duberry,,,,,,,668,,118,,04eb7d82,11241,878150,455840
+519325,Habeeb,Ogunneye,Ogunneye,,,,,,,,833,,,d0cdc0a3,12520,864788,517767
+519327,George,Abbott,Abbott,,,,,,,758,,,,56628958,11509,907215,479809
+519328,Callum,Scanlon,Scanlon,,,,,,,,728,,,37739c71,12147,796298,492373
+519440,Wellity,Lucky,Lucky,,,,,,,,,,760,5fbafc66,14236,922461,575451
+519634,Jenson,Seelt,Seelt,,,,,,,,,,542,ec75ee25,13714,617755,428694
+519895,Oliver,Sonne,Sonne,,,,,,,,,,197,b66b8d5e,13726,541628,444334
+519913,Tyler,Fletcher,Fletcher,,,,,,,,,,771,81a92add,14272,1049911,563778
+520295,David Datro,Fofana,D.D.Fofana,,,,,,,684,200,164,,e82900ef,11295,787232,410522
+521966,Finley,Munroe,Munroe,,,,,,,,854,,,36625c27,12581,845723,515428
+523700,Daniel,Jebbison,Jebbison,,,,,699,,,483,69,,03edb878,9509,746740,415163
+523705,Jackson,Tchatchoua,Tchatchoua,,,,,,,,,,695,aeca7743,12113,848509,408580
+523957,Bénie,Traoré,T.Bénie,,,,,,,,593,,,77816c91,11729,852024,485367
+524069,Dale,Taylor,Dale Taylor,,,,,,,666,,,,d5094280,11230,624267,428123
+524070,Jamie,McDonnell,McDonnell,,,,,,,,779,,,b0df78a0,12349,694901,499044
+524180,Cameron,Humphreys,Humphreys,,,,,,,,,273,,6068431b,1061,871335,
+524196,Shaqai,Forde,Forde,,,,,,725,,,,,ebeac9e5,10553,852517,430781
+530117,Louis,Jackson,Jackson,,,,,,,,856,,,06a441c4,12590,858191,524188
+530121,Zain,Silcott-Duberry,Silcott-Duberry,,,,,,,,,728,95,2f5fa231,13351,777308,550772
+530318,Kaden,Rodney,Rodney,,,,,,,601,825,647,281,49375cdd,11033,860078,454759
+530335,Pablo Felipe,Pereira de Jesus,Pablo,,,,,,,,,,785,866ba412,14290,817665,409654
+530873,Dara,Costelloe,Costelloe,,,,,,726,,164,,,6281b7ed,10568,614700,437322
+531076,Frankie,Maguire,Maguire,,,,,670,,,,,,3e5bd5e0,9348,746753,410176
+531170,Nasser,Djiga,Djiga,,,,,,,,,769,,1a7a4d84,13463,862297,450392
+531363,Nathan,Fraser,Fraser,,,,,,,657,704,546,658,00b77ecf,11210,863741,463235
+531442,Abdul,Fatawu,A.Fatawu,,,,,,,,,570,,bceda5ff,12911,864121,430985
+531989,David,Ozoh,Ozoh,,,,,,,676,721,212,280,d00d45ab,11268,865993,464285
+531993,Ademola,Ola-Adebomi,Ola-Adebomi,,,,,,,,720,,,efacf4fd,12116,814820,504065
+531997,Henry,Cartwright,Cartwright,,,,,,,,,694,,0b6dfc4f,13273,866651,548148
+532135,Killian,Phillips,Phillips,,,,,,,604,,,,cfa9f361,11059,801420,435533
+532372,Oliver,Arblaster,Arblaster,,,,,,,,823,,,afe1a491,12449,874066,434190
+532377,Louie,Marsh,Marsh,,,,,,,,654,,,7923301c,11734,874043,470708
+532528,Joshua,Duffus,Duffus,,,,,,,,747,,,6224214f,12217,867700,507295
+532529,Jack,Hinshelwood,Hinshelwood,,,,,,,677,621,126,163,e98211e7,11269,867688,469629
+532534,Will,Alves,Alves,,,,,,,,,606,,39ef5a7b,13302,867711,430779
+532535,Thomas,Wilson-Brown,Wilson-Brown,,,,,,,,,708,,b495353c,13304,867710,443570
+532605,Andrey,Nascimento dos Santos,Andrey Santos,,,,,,,702,186,150,246,dd745366,11808,743600,451236
+533463,Dango,Ouattara,O.Dango,,,,,,,705,78,74,83,2f9e4435,9662,823231,422183
+533710,Iwan,Morgan,Morgan,,,,,,,,,780,137,ad31049a,13472,966671,533690
+533719,Adrian,Blake,Blake,,,,,,733,,,,,d9a21f02,10592,875581,438303
+534392,Mason,Burstow,Burstow,,,,,,,,623,,,dab84ad2,11810,874080,427632
+534836,Travis,Patterson,Patterson,,,,,,,755,,,710,e0b5d31b,11507,874902,479792
+535017,Julian,Eyestone,Eyestone,,,,,,,,,759,104,e839dde1,13408,1008553,535753
+535262,Reuell,Walters,Walters,,,,,,,751,736,,,501ac0cc,11475,878160,450072
+535264,Bradley,Ibrahim,Ibrahim,,,,,,,,737,,,aaab4602,12194,871837,460136
+535301,Carlos,Baleba,Baleba,,,,,,,,690,115,167,a1390d2f,10527,973085,436048
+535339,Tiago,Çukur,Çukur,,,,,,732,,,,,ca990d30,10591,594276,421921
+535818,Simon,Adingra,Adingra,,,,,,,,122,113,543,4dcec659,11710,658536,443004
+535928,Stefan,Bajčetić Maquieira,Bajcetic,,,,,,,564,292,312,393,32e8417f,10723,864799,444540
+536109,Ollie,Scarles,Scarles,,,,,,,,784,677,608,242e5e6d,12358,922563,459708
+536110,Josh,Feeney,Feeney,,,,,,670,,,,,185321d3,10211,875929,414166
+536119,Charlie,Crew,Crew,,,,,,,,,,359,e8392083,,883539,
+536134,Rio,Kyerematen,Kyerematen,,,,,,,,,,811,04a1c050,14409,882172,527813
+536238,Ishé,Samuels-Smith,Samuels-Smith,,,,,,,757,819,782,,da95fde0,11508,922698,463992
+536241,Martin,Sherif,Sherif,,,,,,,,,724,313,74c0903d,13345,922695,539925
+536661,Nilson,Angulo,Angulo,,,,,,,,,,813,a9b9d89c,,903611,443064
+536677,Detlef Esapa,Osong,Osong,,,,,,,,780,,,a42bbccc,12351,921532,470712
+536681,Joe,Gardner,Gardner,,,,,,,,781,,,f4c17979,12350,921513,513614
+536694,Matheus,França de Oliveira,M.França,,,,,,,,615,208,279,077faf72,12152,743597,428635
+536908,Alejo,Véliz,Veliz,,,,,,,,641,507,,3f7bafbe,12105,888493,414269
+536916,Facundo,Buonanotte,Buonanotte,,,,,,,679,125,117,168,468a7a91,11362,983989,432384
+537043,Kaine,Kesler Hayden,Kesler Hayden,,,,,,,537,,,,9b066938,9409,626888,
+537403,Kadan,Young,Young,,,,,,,672,865,656,63,91c75917,11240,887433,468162
+538182,Jimi,Gower,Gower,,,,,,,,,790,,4571f93e,13569,890718,534238
+538206,Jordan,Amissah,Amissah,,,,,,,,472,,,50fc4c0a,12156,385412,443541
+538207,William,Osula,Osula,,,,,711,,,490,590,500,7b355808,9556,609556,416209
+538210,Andre,Brooks,Brooks,,,,,,,,655,,,5f346071,11731,746739,456511
+539721,Ruairi,McConville,McConville,,,,,,,,,681,,1a28b886,13219,701021,458319
+541462,Matai,Akinmboni,Akinmboni,,,,,,,,,712,75,cfed08d5,13344,994604,455460
+543158,Valentín,Barco,Barco,,,,,,,,816,116,,b9f282ec,12498,849410,419341
+543295,Antoni,Milambo,Milambo,,,,,,,,,,122,b05f4787,13780,683620,422921
+544877,Milos,Kerkez,Kerkez,,,,,,,,595,70,371,0ad53bdc,11709,730861,424273
+545477,Alex,Murphy,A.Murphy,,,,,,,,634,390,481,f1c42eb3,12199,900601,492690
+545508,Joseph,O'Brien-Whitmarsh,O'Brien-Whitmarsh,,,,,,,,,693,,fd1c27b8,13258,741228,538257
+547027,Habib,Diarra,Diarra,,,,,,,,,,544,6d0fe035,9767,876631,422818
+547037,Jack,Fletcher,J.Fletcher,,,,,,,,,667,462,38a6c944,13150,1011140,533128
+547410,Harrison,Jones,H.Jones,,,,,,,,,,557,2a78981b,13722,937840,518341
+547659,Josh,Powell,Powell,,,,,,,,637,,,8129b437,,855279,
+547668,Axel,Piesold,Piesold,,,,,,,,831,,,68201bf9,12510,907219,473956
+547673,Charlie,Robinson,C.Robinson,,,,,,,750,,,,693a5e1a,11467,921992,454747
+547676,Tyler,Fredricson,Fredricson,,,,,,,,,777,446,58630379,13467,911424,455860
+547686,Luc,De Fougerolles,De Fougerolles,,,,,,,,625,,,45c427ff,12172,921995,492688
+547692,Samuel,Rak-Sakyi,Rak-Sakyi,,,,,,,,,695,,301ba71e,13286,906214,544166
+547693,Somto,Boniface,Boniface,,,,,,,,,799,,6115a18a,13595,922472,558841
+547701,Archie,Gray,Gray,,,,,,658,565,,489,591,f58515f5,10184,922693,429922
+547716,Ben,Parkinson,Parkinson,,,,,,,,739,,,32163807,12198,922764,492692
+547719,Lewis,Miley,L.Miley,,,,,,,741,635,411,497,2c6835e5,11386,922769,474264
+547720,Charlie,Tasker,Tasker,,,,,,,,,791,156,c155dd7d,13570,921662,556968
+547801,Callum,Bates,Bates,,,,,,,,,678,306,b2010f35,13204,1018716,545741
+548308,Ashley,Phillips,Phillips,,,,,,,,702,478,576,4f21d3af,12031,859951,430775
+549014,Noël,Atom,Atom,,,,,,,,861,,,966f64a3,12625,913214,527328
+549067,Zach,Abbott,Abbott,,,,,,,,,706,513,c103921a,13306,933017,454750
+549068,Omari,Kellyman,Kellyman,,,,,,,,618,173,,aa888da7,11739,926135,428531
+549074,Tom,Watson,Watson,,,,,,,,,,172,9886c32e,14029,933018,470715
+549329,Lucas,Pires Silva,Lucas Pires,,,,,,,,,,195,5d68f5b2,11824,927768,436501
+549344,Sam,Curtis,Curtis,,,,,,,,828,,,7d42865e,12465,741267,499658
+549640,Michael,Golding,Golding,,,,,,,,,292,,67c5e0e8,13606,936842,513544
+549912,Chemsdine,Talbi,Talbi,,,,,,,,,,553,645481cc,13717,743384,476110
+549939,Mike,Penders,Penders,,,,,,,,,,222,074e1710,13816,834397,
+550090,Diego,Coppola,Coppola,,,,,,,,,,144,22ae86f9,10169,660860,429683
+550141,Adrian,Mazilu,Mazilu,,,,,,,,,133,176,6029f951,,723835,
+550596,Dominic,Sadi,Sadi,,,,,,,697,811,723,94,54778940,11300,936901,454746
+550615,Tyrique,George,George,,,,,,,,851,696,243,e6f7797e,12573,936874,523597
+550833,Noha,Lemina,N.Lemina,,,,,,,,800,,,28401b55,12499,816124,492693
+550839,Wilson,Odobert,Odobert,,,,,,,,660,612,588,35516eac,10822,743498,444751
+550864,Leny,Yoro,Yoro,,,,,,,,,572,444,6763f716,10564,923831,437299
+551153,Luís Hemir,Silva Semedo,Luís Hemir,,,,,,,,,,563,95a98690,,840687,
+551206,Jaydon,Banel,Banel,,,,,,,,,,213,98e0d76c,,706889,454337
+551210,Jorrel,Hato,Hato,,,,,,,,,,672,bde35051,13776,904802,467715
+551221,Tommy,Setford,Setford,,,,,,,,,639,4,d1a2e006,13011,848753,489986
+551226,Mateus Gonçalo,Espanha Fernandes,M.Fernandes,,,,,,,,,623,708,ef491564,12948,880245,447231
+551230,Renato,Palma Veiga,Renato Veiga,,,,,,,,,184,,fc8fcbd1,11383,805714,434077
+551232,Rodrigo,Duarte Ribeiro,Ribeiro,,,,,,,,809,,,484a3eae,12418,726701,434076
+551483,Álex,Jiménez Sánchez,A.Jimenez,,,,,,,,,,713,faa13947,12168,741257,497295
+551995,Taylan,Harris,Harris,,,,,,,,848,,,96630213,12565,985717,498566
+552030,Aidan,Francis-Clarke,Francis-Clarke,,,,,,,,648,,,38c29201,11725,802230,425421
+552425,Sydie,Peck,Peck,,,,,,,,759,,,767d9605,12251,745851,464732
+552427,Will,Lankshear,Lankshear,,,,,,,,,609,598,92df535b,13127,879768,468091
+553299,Takai,Kōta,Takai,,,,,,,,,,577,9f59ff55,,671108,560833
+553746,Leo,Shahar,Shahar,,,,,,,,,,765,5536f008,13572,940858,535754
+554194,Jahmai,Simpson-Pusey,Simpson-Pusey,,,,,,,,,672,,383b10fd,13185,942497,534072
+554197,Chris,Rigg,Rigg,,,,,,,,,,551,35741fe2,13719,947411,469645
+554605,Dean,Huijsen,Huijsen,,,,,,,,,580,,87278bce,11943,890290,468852
+556637,Nehemiah,Oriola,Oriola,,,,,,,,,,744,febb2831,14127,914269,591587
+556639,Jayce,Fitzgerald,Fitzgerald,,,,,,,,,673,461,462c5660,13196,964690,544967
+559610,Luka,Bentt,Bentt,,,,,,,,,,810,331545b0,14405,1407213,607466
+559684,Jack,Moorhouse,Moorhouse,,,,,,,,,778,464,973d6049,13468,953933,553323
+559962,Jamaldeen,Jimoh-Aloba,Jimoh-Aloba,,,,,,,,,710,62,1e711234,13310,954105,540468
+559963,Kiano,Dyer,Dyer,,,,,,,,852,,,b43204f6,12574,954125,523598
+560248,Bastien,Meupiyou Menadjou,Meupiyou,,,,,,,,,637,639,dcd94cdb,11775,955253,496917
+560262,Junior,Kroupi,Kroupi.Jr,,,,,,,,,,100,b2fe86e5,11504,955357,479170
+560441,Luis Eduardo,Soares da Silva,Cuiabano,,,,,,,,,,729,7e49bdbd,,891353,
+560552,Kevin,Santos Lopes de Macedo,Kevin,,,,,,,,,,731,93508980,14030,900195,429174
+563324,Brayden,Clarke,Clarke,,,,,,,,,801,13,f9657b1b,13607,1005844,559891
+563883,Vincent,Angelini,Angelini,,,,,,642,,752,,,536e58cc,10158,736251,429599
+563934,Tyrese,Hall,Hall,,,,,,,,862,,,f2e48542,12623,965971,527306
+564406,Eliezer,Mayenda Dossou,Mayenda,,,,,,,,,,561,6a021e43,13718,967346,494670
+564505,Sam,Proctor,Proctor,,,,,,,,765,,703,b96cec48,12273,1004709,512312
+564510,Garang,Kuol,Kuol,,,,,,,683,418,406,496,a8a80be7,,967948,
+564940,Soungoutou,Magassa,S.Magassa,,,,,,,,,,718,dfc5d4fa,10770,745181,443815
+565297,Mateo,Joseph Fernández-Regatillo,Mateo Joseph,,,,,,,659,,,364,6ad43f9a,11208,834742,463233
+565431,Callum,Marshall,Marshall,,,,,,,,785,,626,3a27f1bf,12359,953135,484501
+565858,Killian,Cahill,Cahill,,,,,,,,,668,,4352b7be,13170,745716,499656
+565863,Sam,Chambers,Chambers,,,,,,,,,,787,30b33655,14306,980343,537889
+566164,Sverre,Nypan,Nypan,,,,,,,,,,428,3dde85f2,,911736,
+566213,Stephen,Mfuni,Mfuni,,,,,,,,,,740,c6685def,14054,1049020,534073
+567119,Shumaira,Mheuka,Mheuka,,,,,,,,,781,,43d0b694,13476,982097,544167
+567121,Joe,Knight,Knight,,,,,,,,,758,175,16168a0f,13399,978668,551871
+568791,Callan,McKenna,McKenna,,,,,,,,855,727,69,9d316492,12582,983248,515753
+569014,Eric,da Silva Moreira,Da Silva Moreira,,,,,,,,,428,523,0a4f579a,12765,897481,518913
+569577,Triston,Rowe,Rowe,,,,,,,,,,701,3fcc22d5,13869,984593,540464
+570241,Kim,Ji-soo,Ji-soo,,,,,,,,725,96,117,f4065d9e,12136,709767,492686
+570526,Lucas,Bergvall,Bergvall,,,,,,,,,481,586,a109e5c8,12912,866246,505295
+572702,Keiber,Lamadrid,Lamadrid,,,,,,,,,,802,5903eca2,,1004203,600774
+573062,Martial,Godo,Godo,,,,,,,641,,605,333,e0eea46f,11164,992686,454749
+573808,Jack,Grieves,Grieves,,,,,,734,,,,,2cf03378,10593,974327,438304
+574398,Franco,Umeh-Chibueze,Umeh,,,,,,,,821,644,282,8e526344,12454,943560,517286
+574402,Mark,O’Mahony,O’Mahony,,,,,,,,741,138,,a3afdd69,12205,943549,509424
+574458,Mamadou,Sarr,M.Sarr,,,,,,,,,,231,61f80c89,11253,910905,467913
+574799,Damola,Ajayi,Ajayi,,,,,,,,,729,,d3a6f5a3,13363,999745,541187
+575034,Ethan,Wheatley,Wheatley,,,,,,,,850,648,468,5c368c88,12568,888639,523346
+575204,Claudio,Echeverri,Echeverri,,,,,,,,,785,425,49a605df,13649,994536,478241
+575458,Jair,Paula da Cunha Filho,Jair Cunha,,,,,,,,,,510,ac31d35e,13779,984096,443545
+575476,Murillo,Costa dos Santos,Murillo,,,,,,,,696,436,506,1704b0b8,12123,1005649,445424
+575901,Julio,Soler Barreto,Soler,,,,,,,,,713,80,98c8559a,13474,1009658,437310
+576323,Oluwaseun,Adewumi,Adewumi,,,,,,,,,,212,4a9dfc4c,,982081,
+576620,Bendito,Mantato,Bendito Mantato,,,,,,,,,,769,e8a55b80,14266,1085591,559774
+576628,Shea,Lacey,Lacey,,,,,,,,,,755,3160e952,14198,926309,563779
+576637,Godwill,Kukonki,Kukonki,,,,,,,,,691,788,30416cc3,13259,1184841,547692
+576756,Zépiqueno,Redmond,Redmond,,,,,,,,,,65,c8365ab8,,765972,
+576980,Zach,Marsh,Marsh,,,,,,,,,676,286,6baa90d0,13203,1004679,492372
+577016,Josh,Acheampong,Acheampong,,,,,,,,838,697,233,b7e62e1d,12535,1004708,518604
+577114,Luis Guilherme,Lira dos Santos,L.Guilherme,,,,,,,,,526,619,b7672d43,13026,991800,478319
+577285,George,Hemmings,George Hemmings,,,,,,,,,,754,28795530,14193,1023191,576066
+577669,Noah,Sadiki,Sadiki,,,,,,,,,,552,645481cc,13716,727089,437449
+577725,Josh,King,King,,,,,,,,810,604,335,86109b3b,12410,1011131,515865
+577731,Ben,Broggio,Broggio,,,,,,,,,679,60,cdf9e86a,13221,985544,540466
+577974,Harry,Amass,Amass,,,,,,,,846,670,445,7b47100c,12559,1011738,470680
+578153,Abdukodir,Khusanov,Khusanov,,,,,,,,,732,406,d17ce930,11763,763079,493206
+578512,Miodrag,Pivaš,Pivas,,,,,,,,,574,483,d50ec076,,908890,
+578545,Kosta,Nedeljković,Nedeljkovic,,,,,,,,,50,,c70be9cf,12775,848682,492955
+578614,Enock,Agyei,Boateng,,,,,,,,156,,203,a1dd3b81,5563,724041,472927
+579075,Asher,Agbinone,Agbinone,,,,,,,,,646,274,6a10efb3,13039,1047256,534896
+580921,Reigan,Heskey,Heskey,,,,,,,,,,764,d4ee4622,14254,1056437,534462
+585472,Ryan,Oné,Oné,,,,,,,,730,,,d4aa4582,12158,1031293,506728
+586268,Ármin,Pécsi,Pécsi,,,,,,,,,,368,46206cf7,,933215,519492
+586309,Thierno,Barry,Barry,,,,,,,,,,310,52c3244b,12916,937941,537713
+587178,Yasin,Özcan,Yasin,,,,,,,,,,46,3c841afd,,1043003,
+588555,Elyh,Harrison,Harrison,,,,,,,,,761,433,6175ebf8,13410,1013690,492376
+588793,Maldini,Kacurri,Kacurri,,,,,,,,,657,14,7be4311f,13081,903189,539715
+588796,Ismeal,Kabia,Kabia,,,,,,,,,659,28,6b15cf32,13082,964561,539716
+589100,Jacob,Slater,Slater,,,,,,,,,685,155,a4a51de9,13238,854930,447722
+589114,Zack,Nelson,Nelson,,,,,,,,734,,,de0abf23,12188,965940,447731
+589121,Ethan,Sutherland,Sutherland,,,,,,,,,,778,a7abd792,14284,1044516,491702
+589507,Leon,Chiwome,Chiwome,,,,,,,,836,539,657,a2852b4f,12532,1043634,518340
+590012,Caleb,Kporha,Kporha,,,,,,,,,666,265,c80f8c9d,13130,1047261,534895
+590014,Rio,Cardines,Cardines,,,,,,,,,,690,702812fe,13777,1047257,561659
+590035,Yusuf,Akhamrich,Akhamrich,,,,,,,,,,751,e19dc888,14175,1047345,572661
+590039,Divine,Mukasa,Mukasa,,,,,,,,,,739,ce7ae86a,14055,1047280,576821
+590760,Daniel,Adu-Adjei,Adu-Adjei,,,,,,,695,,722,99,2093823e,11301,963878,468929
+591357,Ryan,Trevitt,Trevitt,,,,,,,632,118,602,134,732327ae,11146,874538,454756
+591382,Genesis,Antwi,Genesis Antwi,,,,,,,,,787,,aaa96db5,13527,1045121,555021
+591384,George,King,King,,,,,,,,,,793,72103498,14328,1045118,570005
+591385,Samuel,Amissah,Amissah,,,,,,,,,690,323,2835bfe1,13250,1026524,492689
+591386,Trey,Nyoni,Nyoni,,,,,,,,743,688,396,1d3b3d77,12203,1045123,509423
+591538,Owen,Hampson,Hampson,,,,,,,,857,,,081b8cac,12591,967340,525560
+591539,Billy,Blacker,Blacker,,,,,,,,822,,,2b08b6e5,12450,967318,517009
+592031,Yankuba,Minteh,Minteh,,,,,,,,,135,160,c3cf087d,12759,1012534,484175
+592436,Travis,Hernes,Hernes,,,,,,,,795,,,849e071e,12396,1053908,455133
+592661,Tristan,Crama,Crama,,,,,,,646,,,,130e085a,11189,732529,461505
+592662,Tony,Yogane,Yogane,,,,,,,,,661,,4cccbed1,13104,979064,533685
+592712,Tom,Taylor,Tom Taylor,,,,,,,,,800,,648a86b4,13603,1099929,554706
+592736,Maeson,King,King,,,,,,,,,700,,b00671f2,13287,1047342,546932
+593001,Enso,González Medina,Gonzalez,,,,,,,,698,547,652,7e5bebeb,12047,1060740,455760
+593174,Kaye,Furo,Furo,,,,,,,,,,797,9fea2579,14356,1011936,542805
+596042,Kieran,Morrison,Morrison,,,,,,,,,,746,25683300,14144,1055345,551573
+596047,Chido,Obi,Obi,,,,,,,,,776,467,0c9bfc3b,13466,1042886,553325
+596054,Tom,Edozie,Edozie,,,,,,,,,682,651,3354ea94,13220,1065227,546622
+596572,Michael,Dacosta Gonzalez,Dacosta Gonzalez,,,,,,,696,849,,,c1426015,11302,854722,471270
+596777,Patrick,Dorgu,Dorgu,,,,,,,,,766,441,e6536124,11944,926952,495260
+597320,Harry,Howell,Howell,,,,,,,,,795,795,d8a7e52c,13584,1067168,558409
+597983,Ollie,Harrison,Harrison,,,,,,,,820,,,6ce635b6,12447,1071819,516952
+599303,Sean,Neave,Neave,,,,,,,,,789,501,ff392864,13532,1071818,552461
+600882,Harry,Gray,Gray,,,,,,,,,,741,99965ed0,14073,1108476,558919
+601496,Jili,Buyabu,Buyabu,,,,,,,,731,,,15ee4bc1,12157,1072898,460778
+601956,Saheed,Olagunju,Olagunju,,,,,,,,,,766,a3aa41c2,14257,1081155,605053
+601975,Yegor,Yarmolyuk,Yarmolyuk,,,,,,,650,,,,907a5d7c,11195,717411,
+602903,Ezra,Mayers,Mayers,,,,,,,,,686,747,9a85a651,13247,1107726,547084
+602934,Fletcher,Holman,Holman,,,,,,,,840,,,de40b95a,12551,1080392,518914
+604211,Tymur,Tutierov,Tutierov,,,,,,,,,,775,7ba5d93b,14277,1079078,538450
+604988,Freddie,Simmonds,Simmonds,,,,,,,,,794,761,c1a271b9,13583,1120418,558408
+605319,Luke,Rawlings,Rawlings,,,,,,,,,,767,ba8a2a36,14256,1083691,534897
+606689,Romelle,Donovan,Donovan,,,,,,,,,,130,519db366,,1091562,471696
+606745,Ayden,Heaven,Heaven,,,,,,,,,658,447,64e17fab,13080,1078163,517341
+606774,Remy,Rees-Dottin,Rees-Dottin,,,,,,,,,707,687,1db75ccb,13307,1089802,549379
+606775,Ben,Winterburn,Winterburn,,,,,,,,,687,96,ba31eee2,13242,854721,547069
+606798,Andrés,García,A.García,,,,,,,,,731,42,40498af1,13392,1063329,469329
+606921,Romain,Esse,Esse,,,,,,,,,730,269,87189f25,13387,967319,469485
+607464,Michael,Kayode,Kayode,,,,,,,,,757,110,e19660a8,11281,823486,470031
+608060,Jayden,Luker,Luker,,,,,,,,729,,,61aed9fe,12150,1088817,470737
+608181,Stefanos,Tzimas,Tzimas,,,,,,,,,,180,a497130f,14028,950091,519565
+609640,Mathis,Amougou,Amougou,,,,,,,,,771,,f93cca97,12808,1010854,511364
+609873,Harrison,Armstrong,Armstrong,,,,,,,,,603,305,de59e609,12757,1107733,535879
+610799,Luka,Vušković,Vuskovic,,,,,,,,,,578,fd6bdbce,13725,892160,533010
+611011,Joseph,Johnson,Johnson,,,,,,,,682,,,d9e7c4da,11980,1088818,473957
+611134,Kendry,Páez Andrade,Paez,,,,,,,,,,248,f3bb9f59,13818,1052439,
+611695,Malick,Yalcouyé,Yalcouye,,,,,,,,,,174,e295402e,,1178758,
+611912,Landon,Emenalo,Emenalo,,,,,,,,,,743,e1cc82b1,14112,1108471,558697
+611917,Lucá,Williams-Barnett,Williams-Barnett,,,,,,,,,689,790,d2fe0b0b,13249,1108475,545662
+611920,Malachi,Hardy,Hardy,,,,,,,,,684,,3478fa17,13225,1108465,546642
+611922,Rio,Ngumoha,Ngumoha,,,,,,,,,,686,022eca88,13692,1108466,548566
+611926,Amara,Nallo,Nallo,,,,,,,,837,692,378,398a24f6,12534,1108049,517768
+611975,Ahmed,Abdullahi,Abdullahi,,,,,,,,,,562,8073edf4,,1015619,
+612534,Benjamin,Fredrick,Fredrick,,,,,,,,797,786,115,fde367e5,12397,1071138,513405
+612855,Ibrahim,Osman,I.Osman,,,,,,,,,127,,acdfe835,13792,1110406,
+613120,Spike,Brits,Brits,,,,,,,,,704,,d5837248,13299,1080903,549309
+613467,Wes,Okoduwa,Okoduwa,,,,,,,,832,711,,58469e7c,12500,1115502,517909
+613804,El Hadji Malick,Diouf,Diouf,,,,,,,,,,603,bd5eb2e5,13723,1111589,479288
+614574,Alex,Tóth,Tóth.A,,,,,,,,,,801,5e18c6f4,14374,998101,476166
+616059,Jack,Porter,Porter,,,,,,,,,756,,0b4ecd65,13378,1131973,540048
+616065,Marli,Salmon,Salmon,,,,,,,,,,759,3dabb62e,14220,1294399,571992
+616077,Max,Dowman,Dowman,,,,,,,,,,700,9008bb70,13872,1187629,571994
+616094,Dovydas,Sasnauskas,Sasnauskas,,,,,,,,827,,,9463c7eb,12466,1108667,517585
+616221,João Victor,de Souza Menezes,Souza,,,,,,,,,,804,10b0c6f4,14410,1086258,549079
+616222,Vitor,de Oliveira Nunes dos Reis,Vitor Reis,,,,,,,,,733,412,c4ce0ab5,13380,1005575,478314
+616288,Ryan,McAidoo,McAidoo,,,,,,,,,,742,8dd0d7c5,14097,1187640,584927
+617054,Deivid Washington,de Souza Eugênio,Deivid,,,,,,,,677,165,,95bd120d,12033,1082850,478451
+618027,TJ,Carroll,Carroll,,,,,,,,,,781,88bf137b,14288,1131945,605391
+618873,Sékou,Koné,Kone,,,,,,,,,779,463,dedb9d04,13469,1133978,553324
+619146,Olabade,Aluko,Olabade Aluko,,,,,,,,,796,,12bb637a,13586,1135364,558410
+619536,Seth,Ridgeon,Ridgeon,,,,,,,,,,770,b12ba5d9,14270,1078158,597683
+620408,Joachim,Kayi-Sanda,Kayi Sanda,,,,,,,,,719,,e2b2a181,13636,986298,511704
+620487,Veljko,Milosavljevic,Milosavljević,,,,,,,,,,721,c478319d,14027,989112,510940
+622536,Benjamin,Arthur,Arthur,,,,,,,,834,705,114,093f0923,12533,1144158,496342
+622758,Aarón,Anselmino,Anselmino,,,,,,,,,774,234,1d87670e,13460,1145504,484211
+623095,Yang,Min-hyeok,Min-hyeok,,,,,,,,,717,594,fe3db176,13362,1004327,549454
+623110,Seung-Soo,Park,Seung soo,,,,,,,,,,689,b6aabcf8,13710,1134717,573458
+624773,Estêvão,Almeida de Oliveira Gonçalves,Estêvão,,,,,,,,,,238,2eda11b1,13775,1056993,510728
+626464,Gustavo,Nunes Fernandes Gomes,Nunes,,,,,,,,,634,127,e504780f,13588,1086375,492869
+626844,Milan,Aleksić,Aleksić,,,,,,,,,,546,c79f7793,,942738,538488
+628204,Yunus Emre,Konak,Konak,,,,,,,,864,97,131,e02b5b36,12633,1141628,495584
+629068,Braiden,Graham,Graham,,,,,,,,,,779,bd1d3020,14283,1122712,582990
+630664,Jake,Evans,Jake Evans,,,,,,,,,797,,cb7bcef0,13585,1171764,558411
+630699,Mohamadou,Kanté,Mohamadou Kanté,,,,,,,,,,758,0041f3e6,14219,1081995,511560
+631106,Ben,Casey,Casey,,,,,,,,,,780,39f7c6fe,14285,1172646,603932
+631786,Jonah,Kusi-Asare,Kusi-Asare,,,,,,,,,,737,c7c26e61,13262,1069512,547830
+632822,Archie,Harris,Harris,,,,,,,,,702,,8eab81d9,13300,963879,549315
+634640,Christian,Chigozie,Chigozie,,,,,,,,844,,,2dbd5678,12557,1225825,521698
+640108,Antoñito,Cordero Campillo,Antoñito C.,,,,,,,,,,492,d9b0e57e,,1178393,
+640419,Jun'ai,Byfield,Byfield,,,,,,,,,,745,0312881b,14134,1196272,572655
+641221,Pedro,Cardoso de Lima,Pedro Lima,,,,,,,,,561,640,b2f4cad5,13156,1193867,532920
+643135,Fer,López González,Fer López,,,,,,,,,,645,675cacff,13200,1064471,544982
+643426,Dean,Benamar,Benamar,,,,,,,,,,773,b047bb3b,14278,1285021,574690
+643473,Airidas,Golambeckis,Golambeckis,,,,,,,,,,752,59149473,14179,1108668,572171
+645618,Bradley,Burrowes,Burrowes,,,,,,,,,,702,802ee5ca,13870,1202361,550064
+646243,Andre,Harriman-Annous,Harriman-Annous,,,,,,,,,,711,2d14071d,14000,1237740,571995
+646754,Lander,Emery,Emery,,,,,,,,866,,,b5f7fd45,12632,1237073,527644
+647597,Dominic,Dos Santos Martins,Martins,,,,,,,,839,,,00464670,12536,1203143,518664
+647671,Mateus,Mané,Mané,,,,,,,,,784,749,c15cb409,13484,1230661,554310
+647681,Giovanni,Leoni,Leoni,,,,,,,,,,692,570888ce,13031,1086619,516040
+647850,Charalampos,Kostoulas,Kostoulas,,,,,,,,,,181,816010c4,14118,1060087,533923
+647960,Oliver,Pimlott,Pimlott,,,,,,,,,,776,b928f19e,14282,1214634,581382
+649208,Jeremy,Monga,Monga,,,,,,,,,792,,4c168d3a,13579,1245948,552366
+651426,Jaydee,Canvot,Canvot,,,,,,,,,,723,3684108d,13091,1006411,531676
+653481,Alysson Edward Franco,da Rocha dos Santos,Alysson,,,,,,,,,,792,99b63a82,,1005583,520919
+658013,Charlie,Stevens,Stevens,,,,,,,,,,799,6c2a4c10,14367,1122668,606358
+660392,Christantus,Uche,Uche,,,,,,,,,,732,87941696,12726,1124005,531674
+661712,Diego,León Blanco,D.Leon,,,,,,,,,,439,69ea448b,14057,1283997,533375
+664015,Leon,Routh,Leon Routh,,,,,,,,,,768,e2177db5,14265,1300041,605159
+666607,Sam,Alabi,Alabi,,,,,,,,,,772,d5f1b74a,14273,1146664,601986
+672492,Joél,Drakes-Thomas,Drakes-Thomas,,,,,,,,,,762,1bd530e8,14263,1348941,603933
+678552,Malcom,DaCosta,DaCosta,,,,,,,,,,756,c96b1407,14215,1323654,602543
+685628,Jerome,Abbey,Abbey,,,,,,,,,,809,4f504fcc,14394,1370903,607348
+699989,Djiamgone Jocelin Ta,Bi,Jocelin.T,,,,,,,,,,800,,,1322090,606073
+704232,George,Brierley,Brierley,,,,,,,,,,784,a57a4ea8,14292,1352710,584317

--- a/generate_master.py
+++ b/generate_master.py
@@ -4,7 +4,7 @@ import pandas as pd
 
 seasons = [f"{season}-{season + 1}" for season in range(16, 26)]
 fpl_files = [os.path.join("FPL", f"{season}.csv") for season in seasons[::-1]]
-files = fpl_files + ["FBRef.csv", "Understat.csv", "Transfermarkt.csv"]
+files = fpl_files + ["FBRef.csv", "Understat.csv", "Transfermarkt.csv", "whoscored.csv"]
 
 master = pd.read_csv(files[0], index_col="code")
 for file in files[1:]:
@@ -12,9 +12,9 @@ for file in files[1:]:
     master = master.combine_first(df)
 
 master = master.sort_values(by="code")
-col_order = ["first_name", "second_name", "web_name"] + seasons + ["fbref", "understat", "transfermarkt"]
+col_order = ["first_name", "second_name", "web_name"] + seasons + ["fbref", "understat", "transfermarkt", "whoscored"]
 
 master = master[col_order]
-for col in seasons + ["understat", "transfermarkt"]:
+for col in seasons + ["understat", "transfermarkt", "whoscored"]:
     master[col] = master[col].astype("Int64")
 master.to_csv("Master.csv", encoding="utf-8")

--- a/whoscored.csv
+++ b/whoscored.csv
@@ -1,0 +1,2458 @@
+code,first_name,second_name,web_name,whoscored
+1243,Robert,Green,Green,7890
+1616,Alexander,Manninger,Manninger,2856
+1632,Gareth,Barry,Barry,188
+1718,John,Terry,Terry,70
+1801,Paul,Robinson,Robinson,3874
+1822,Shay,Given,Given,1034
+2404,Michael,Carrick,Carrick,2115
+2513,Jamie,Murphy,Murphy,25829
+3201,Stuart,Taylor,Taylor,2809
+3736,John,O'Shea,O'Shea,3841
+3773,Peter,Crouch,Crouch,3807
+5288,Gerhard,Tremmel,Tremmel,5487
+5589,Dean,Whitehead,Whitehead,8176
+6744,Lee,Grant,Grant,8195
+7525,Steven,Pienaar,Pienaar,3553
+7551,Joleon,Lescott,Lescott,8137
+7645,Phil,Jagielka,Jagielka,6105
+7906,Damien,Delaney,Delaney,8466
+7958,Jermain,Defoe,Defoe,2837
+8380,James,Collins,Collins,8148
+8432,José,Reina,Reina,2987
+9047,Glen,Johnson,Johnson,4574
+9089,Ben,Foster,Foster,11530
+9110,Shaun,Maloney,Maloney,4616
+9808,Zlatan,Ibrahimovic,Ibrahimovic,3281
+10318,Maarten,Stekelenburg,Stekelenburg,4065
+10460,Grant,Leadbitter,Leadbitter,12417
+10589,Brian,Murphy,Brian Murphy,9191
+11037,Rickie,Lambert,Lambert,8409
+11334,Petr,Cech,Cech,6775
+11352,Bruno,Saltor Grau,Bruno,23957
+11467,Billy,Jones,Jones,8236
+11554,Julian,Speroni,Speroni,7895
+11735,Steve,Sidwell,Sidwell,5554
+11829,Wayne,Routledge,Routledge,4759
+11948,Andy,Lonergan,Lonergan,8105
+11974,Eldin,Jakupovic,Jakupović,18310
+12002,Stewart,Downing,Downing,5641
+12086,Boaz,Myhill,Myhill,8462
+12150,Glenn,Whelan,Whelan,8505
+12413,Robert,Huth,Huth,4145
+12496,Víctor,Valdés,Valdés,9484
+12679,Michael,Dawson,Dawson,4905
+12744,David,Nugent,Nugent,7616
+12745,Leighton,Baines,Baines,8222
+12813,Jonathan,Walters,Walters,3860
+13017,Wayne,Rooney,Rooney,3859
+13152,Andy,King,King,32018
+14075,Patrice,Evra,Evra,6410
+14295,Darren,Fletcher,Fletcher,5835
+14664,Gnegneri Yaya,Touré,Yaya Touré,14053
+14937,Cristiano Ronaldo,dos Santos Aveiro,Ronaldo,5583
+15033,Wes,Morgan,Morgan,8157
+15109,Tom,Huddlestone,Huddlestone,8194
+15114,Leon,Britton,Britton,8730
+15137,Liam,Rosenior,Rosenior,11869
+15144,David,Marshall,Marshall,9002
+15149,Simon,Francis,Francis,9298
+15157,James,Milner,Milner,4511
+15208,Bastian,Schweinsteiger,Schweinsteiger,4567
+15237,Andrew,Surman,Surman,13447
+15276,Joey,Barton,Barton,4835
+15633,Alex,Baptiste,Baptiste,8806
+15749,Joe,Hart,Hart,8786
+15885,Adam,Federici,Federici,13797
+15944,Michael,Kightly,Kightly,9794
+15982,Dean,Marney,Marney,5566
+16045,Ben,Watson,Watson,10254
+17127,Per,Mertesacker,Mertesacker,6292
+17336,Gaël,Clichy,Clichy,6042
+17339,Steven,Davis,Davis,9734
+17349,Aaron,Lennon,Lennon,5625
+17476,Vincent,Kompany,Kompany,10136
+17601,Scott,Carson,Carson,8155
+17740,Jesús,Navas,Navas,9446
+17745,Kasper,Schmeichel,Schmeichel,19545
+17761,James,Tarkowski,Tarkowski,131464
+17878,Cesc,Fàbregas,Fàbregas,8040
+17997,Phil,Bardsley,Bardsley,18181
+18006,Martin,Cranie,Cranie,19114
+18008,James,Morrison,Morrison,10498
+18073,Mark,Noble,Noble,8247
+18155,Mathieu,Flamini,Flamini,6321
+18440,Leon,Clarke,Clarke,7807
+18499,Michael,McGovern,McGovern,20113
+18507,Diego,Da Silva Costa,Diego Costa,14013
+18656,Heurelho da Silva,Gomes,Gomes,10133
+18665,Alexander,Tettey,Tettey,9342
+18726,Artur,Boruc,Boruc,14111
+18759,Álvaro,Arbeloa,Arbeloa,11104
+18805,Joe,Ledley,Ledley,11020
+18832,Richard,Stearman,Stearman,11502
+18867,Billy,Sharp,Sharp,13399
+18892,Ashley,Young,Young,8166
+18987,Robert,Snodgrass,Snodgrass,9767
+19057,Sebastian,Larsson,Larsson,11235
+19071,Uwe,Hünemeier,Hünemeier,14179
+19101,Dimitrios,Konstantopoulos,Konstantopoulos,8572
+19115,Curtis,Davies,Davies,8484
+19151,Chris,Brunt,Brunt,8507
+19159,Ashley,Williams,Williams,8408
+19188,Scott,Dann,Dann,12124
+19194,David,Martin,Martin,131509
+19197,Jason,Puncheon,Puncheon,9156
+19236,John,Ruddy,Ruddy,8643
+19272,Gareth,McAuley,McAuley,8773
+19342,Ikechi,Anya,Anya,9795
+19419,Gary,Cahill,Cahill,11981
+19520,Ryan,Babel,Babel,12158
+19523,Sol,Bamba,Bamba,21370
+19524,Santiago,Cazorla,Cazorla,4522
+19556,David,Jones,Jones,12713
+19568,Ibrahim,Afellay,Afellay,12480
+19624,João Filipe Iria,Santos Moutinho,Moutinho,16161
+19760,Fernando,Llorente,Llorente,13361
+19812,Dusan,Kuciak,Kuciak,31101
+19838,Robert,Elliot,Elliot,13450
+20037,Marc,Pugh,Pugh,14000
+20046,Stefano,Okaka,Okaka,14255
+20047,Jordan,Rhodes,Rhodes,33704
+20066,Wayne,Hennessey,Hennessey,21571
+20145,Adrian,Mariappa,Mariappa,13805
+20208,Charlie,Adam,Adam,8327
+20310,Willy,Caballero,Caballero,34749
+20399,Antonio,Barragán,Barragán,14085
+20452,Shane,Long,Long,13798
+20467,Theo,Walcott,Walcott,13796
+20480,Tim,Krul,Krul,22319
+20481,Stephen,Ireland,Ireland,14169
+20487,Vito,Mannone,Mannone,21682
+20529,Glenn,Murray,Murray,21427
+20658,Pablo,Zabaleta,Zabaleta,14244
+20664,David,Silva,David Silva,14102
+20695,Antonio,Valencia,Valencia,18296
+21083,Nathan,Dyer,Dyer,13814
+21123,Valon,Behrami,Behrami,12462
+21205,Tom,Heaton,Heaton,17708
+21246,Lewis,Grabban,Grabban,19736
+26719,Rene,Gilmartin,Gilmartin,17876
+26901,Kevin,Mirallas,Mirallas,15834
+26921,Arouna,Koné,Koné,8943
+27334,Mathieu,Debuchy,Debuchy,11367
+27335,Stephan,Lichtsteiner,Lichtsteiner,15302
+27341,Yohan,Cabaye,Cabaye,12376
+27436,David,McGoldrick,McGoldrick,18501
+27462,Jesús,Gámez Duarte,Gámez,18538
+27698,Matthew,Connolly,Connolly,13939
+27707,Darron,Gibson,Gibson,30395
+27789,Fernando,Luiz Rosa,Fernandinho,19119
+28082,Ralf,Fahrmann,Fahrmann,23592
+28147,Mohamed,Diamé,Diamé,27188
+28244,George,Boyd,Boyd,13056
+28411,Keylor,Navas,Navas,65901
+28448,Lee,Cattermole,Cattermole,14268
+28462,Sam,Baldock,Baldock,19494
+28468,Craig,Gardner,Gardner,14038
+28541,Fraizer,Campbell,Campbell,29299
+28554,Samir,Nasri,Nasri,13298
+28593,Victor,Anichebe,Anichebe,14114
+28609,Adam,Legzdins,Legzdins,21814
+28654,Martin,Olsson,Olsson,33748
+28690,Pablo,Hernández Domínguez,Hernández,29571
+32259,Darren,Randolph,Randolph,19782
+32318,Marc,Wilson,Marc Wilson,23446
+33148,Claudio,Bravo,Bravo,14199
+33871,Ragnar,Klavan,Klavan,10839
+36903,Gareth,Bale,Bale,13812
+37096,Lukasz,Fabianski,Fabianski,20973
+37265,Alexis,Sánchez,Sánchez,25244
+37339,Ahmed,El Mohamady,El Mohamady,34876
+37388,Marcin,Wasilewski,Wasilewski,14621
+37402,Christian,Fuchs,Fuchs,12431
+37572,Sergio,Agüero,Agüero,14260
+37605,Mesut,Özil,Özil,13756
+37614,Mario,Vrancic,Vrancic,21562
+37642,Jonny,Evans,Evans,22079
+37742,Younes,Kaboul,Kaboul,14805
+37748,Bacary,Sagna,Sagna,19471
+37869,Ryan,Shawcross,Shawcross,29798
+37901,Dimitri,Payet,Payet,14058
+37915,Hugo,Lloris,Lloris,25604
+38038,Ben,Hamer,Hamer,29832
+38290,Danny,Rose,Rose,24711
+38411,Nacho,Monreal,Monreal,23072
+38419,Loïc,Remy,Remy,23054
+38439,Etienne,Capoue,Capoue,33590
+38454,Dejan,Lovren,Lovren,29106
+38490,Beram,Kayal,Kayal,33318
+38499,Tomer,Hemed,Hemed,28981
+38533,Rui Pedro,dos Santos Patrício,Patrício,23089
+38580,Jose,Fonte,Fonte,19859
+38588,Gaetano,Berardi,Berardi,52407
+38716,Lee,Peltier,Peltier,22654
+39104,Mousa,Dembélé,Dembélé,12187
+39155,Adam,Lallana,Lallana,21683
+39158,Scott,Arfield,Arfield,21686
+39167,Andrea,Ranocchia,Ranocchia,27421
+39187,Jeremain,Lens,Lens,27512
+39194,Jan,Vertonghen,Vertonghen,21778
+39215,Michel,Vorm,Vorm,19270
+39253,Jonas,Olsson,Olsson,6695
+39472,Dieumerci,Mbokani,Mbokani,22820
+39476,Sokratis,Papastathopoulos,Sokratis,22210
+39487,Erik,Pieters,Pieters,24148
+39725,Anders,Lindegaard,Lindegaard,10620
+39790,Francisco,Casilla Cortés,Casilla,23154
+39847,Steven,Defour,Defour,19155
+40002,Matteo,Darmian,Darmian,23220
+40142,Andy,Carroll,Carroll,23383
+40145,Jack,Cork,Cork,22847
+40146,Ryan,Bertrand,Bertrand,22846
+40202,George,Friend,Friend,34822
+40232,Gonzalo,Higuaín,Higuaín,19729
+40276,Bojan,Krkic Perez,Bojan,31402
+40346,Erwin,Mulder,Mulder,34171
+40349,Asmir,Begovic,Begovic,23122
+40383,Fraser,Forster,Forster,29796
+40386,Chris,Basham,Basham,35607
+40387,Dan,Gosling,Gosling,13846
+40399,Sam,Vokes,Vokes,13938
+40555,Joe,Allen,Allen,23444
+40559,Fabricio,Agosto Ramírez,Fabri,23474
+40564,Henri,Lansbury,Lansbury,32858
+40616,Stephen,Ward,Ward,15764
+40669,Angelo,Ogbonna,Ogbonna,23547
+40694,Roberto,Jimenez Gago,Roberto,19442
+40720,Edinson,Cavani,Cavani,24328
+40725,Danny,Simpson,Simpson,23683
+40755,Daniel,Sturridge,Sturridge,23736
+40784,Mamadou,Sakho,Sakho,29575
+40833,Jérémy,Pied,Pied,42248
+40836,Vicente,Guaita,Guaita,33866
+40845,Dale,Stephens,Stephens,24238
+40868,José,Holebas,Holebas,21499
+41135,Branislav,Ivanovic,Ivanovic,15338
+41184,Marouane,Fellaini,Fellaini,22738
+41251,Eduardo,dos Reis Carvalho,Eduardo,34098
+41270,David,Luiz Moreira Marinho,David Luiz,27586
+41320,Charlie,Daniels,Daniels,24827
+41321,Yohan,Benalouane,Benalouane,29574
+41328,César,Azpilicueta,Azpilicueta,25931
+41338,Craig,Cathcart,Cathcart,25241
+41464,Marko,Arnautovic,Arnautovic,34693
+41674,Kevin,Long,Long,74606
+41705,Bradley,Guzan,Guzan,28746
+41725,Troy,Deeney,Deeney,25832
+41727,Ryan,Bennett,Bennett,25834
+41733,Georginio,Wijnaldum,Wijnaldum,33568
+41792,Aaron,Ramsey,Ramsey,26820
+41823,Fabian,Delph,Delph,27213
+41945,Sebastian,Prödl,Prödl,27349
+42427,Kieran,Gibbs,Gibbs,27550
+42525,Stephen,Henderson,Henderson,29800
+42564,Eric Maxim,Choupo-Moting,Choupo-Moting,29809
+42593,Aleksandar,Kolarov,Kolarov,12267
+42738,Juan,Zuñiga,Zuñiga,26682
+42748,Gaëtan,Bong,Bong,32720
+42774,Morgan,Schneiderlin,Schneiderlin,29544
+42786,Eden,Hazard,Hazard,33404
+42824,Carlos,Sánchez,Carlos Sánchez,26720
+42892,Álvaro,Negredo,Negredo,23757
+42899,Sergio,Romero,Romero,33831
+42996,Angel,Rangel,Rangel,29820
+43020,Javier,Hernández Balcázar,Chicharito,35003
+43191,Leiva,Lucas,Lucas,31451
+43250,Tom,Cleverley,Cleverley,69956
+43252,James,Chester,Chester,70285
+43521,Henri,Saivet,Saivet,34949
+43626,Håvard,Nordtveit,Nordtveit,21742
+43670,Juan,Mata,Mata,25363
+43693,Martín,Cáceres,Cáceres,30635
+43808,Markus,Suttner,Suttner,33477
+44302,Adlène,Guédioura,Guédioura,64343
+44336,Sofiane,Feghouli,Feghouli,34239
+44343,Bakary,Sako,Sako,34974
+44346,Olivier,Giroud,Giroud,24444
+44413,Steve,Mandanda,Mandanda,29545
+44604,Nordin,Amrabat,Amrabat,22932
+44683,Jay,Rodriguez,Rodriguez,33891
+44699,Ashley,Barnes,Barnes,33386
+45034,Ivan,Perišić,Perišić,70524
+45076,Lamine,Koné,Koné,34214
+45124,André,Ayew,A.Ayew,30060
+45196,Gary,Madine,Madine,37050
+45220,Alex,Smithies,Smithies,132887
+45268,Moussa,Sissoko,Sissoko,29595
+46483,Adrien,Silva,Silva,32598
+47247,John,Fleck,Fleck,30448
+47390,Neil,Taylor,Taylor,31558
+47431,Willian,Borges da Silva,Willian,29463
+48332,Orestis,Karnezis,Karnezis,11624
+48615,Harry,Arter,Arter,67807
+48717,Winston,Reid,Reid,19277
+48760,Mathias,Jorgensen,Zanka,29026
+48771,Emilio,Nsue Lopez,Nsue,32224
+48844,David,Ospina,Ospina,36745
+48860,Niki,Mäenpää,Mäenpää,35565
+49013,Victor,Moses,Moses,33064
+49083,Luke,Freeman,Freeman,33290
+49195,Jefferson,Montero,Montero,28416
+49207,Rudy,Gestede,Gestede,33403
+49262,Jason,Steele,Steele,33532
+49277,Leroy,Fer,Fer,35174
+49382,Bruno,Ecuele Manga,Ecuele Manga,42573
+49384,Jack,Rodwell,Rodwell,33833
+49413,James,Tomkins,Tomkins,33930
+49438,Jordon,Mutch,Mutch,43742
+49440,Hal,Robson-Kanu,Robson-Kanu,35371
+49464,Cristhian,Stuani,Stuani,24400
+49539,Kyle,Naughton,Naughton,34131
+49579,Pedro,Rodríguez Ledesma,Pedro,44055
+49688,Alfred,N'Diaye,N'Diaye,34123
+49696,Mauro,Zárate,Zárate,14524
+49773,Albert,Adomah,Adomah,35328
+49806,David Junior,Hoilett,Hoilett,35460
+49845,Aron,Gunnarsson,Gunnarsson,35734
+49944,Jake,Livermore,Livermore,36849
+49957,Kamil,Grosicki,Grosicki,30524
+49982,Sean,Morrison,Morrison,37505
+50089,Geoff,Cameron,Cameron,38772
+50093,David,Button,Button,34388
+50175,Danny,Welbeck,Welbeck,39308
+50229,Matt,Phillips,Phillips,40036
+50232,Jonjo,Shelvey,J.Shelvey,40027
+50471,James,McArthur,McArthur,20339
+50472,James,McCarthy,McCarthy,31281
+51090,Thiago,Emiliano da Silva,T.Silva,28550
+51344,Rajiv,van La Parra,van La Parra,42947
+51507,Laurent,Koscielny,Koscielny,30051
+51917,Diego,Cavalieri,Cavalieri,40767
+51927,Ben,Mee,Mee,94935
+51934,Ron-Robert,Zieler,Zieler,67300
+51938,Marc,Albrighton,Albrighton,42147
+51940,David,De Gea Quintana,De Gea,79554
+52153,Miguel,Britos,Britos,36096
+52287,Evandro,Goebel,Evandro,121488
+52484,Leon,Balogun,Balogun,43362
+52538,Fernando Francisco,Reges,Fernando,31958
+52775,Nicolas,Nkoulou,Nkoulou,43834
+52940,Daryl,Janmaat,Janmaat,32323
+53371,David,Meyler,Meyler,41589
+54102,Jack,Wilshere,Wilshere,42686
+54284,Chris,Löwe,Löwe,101664
+54316,Leonardo,Ulloa,Ulloa,19847
+54421,Floyd,Ayité,Ayité,42572
+54469,Adam,Smith,Smith,69877
+54484,Francisco,Femenía Far,Femenía,75919
+54513,Vicente,Iborra,Iborra,34052
+54527,Loïc,Damour,Damour,294510
+54694,Pierre-Emerick,Aubameyang,Aubameyang,44120
+54738,Thomas,Kaminski,Kaminski,64342
+54756,Victor,Wanyama,Wanyama,71714
+54764,Jonathan,Kodjia,Kodjia,68862
+54771,Fabio Pereira,da Silva,Fabio,44031
+54861,Christian,Benteke,Benteke,68312
+54908,Nacer,Chadli,Chadli,34302
+55037,Cheikhou,Kouyaté,Kouyaté,66741
+55038,Kevin,McDonald,McDonald,20100
+55317,Bernardo,Espinosa Zúñiga,Bernardo,67327
+55422,Gylfi,Sigurdsson,Sigurdsson,69346
+55452,Yannick,Bolasie,Bolasie,69844
+55459,Aaron,Cresswell,Cresswell,68049
+55494,Joel,Ward,Ward,43105
+55605,Toby,Alderweireld,Alderweireld,69933
+55829,Claudio,Yacob,Yacob,35691
+55909,Chris,Smalling,Smalling,71345
+55914,Liam,Cooper,Cooper,44148
+56192,Rhu-endly,Martina,Cuco Martina,43712
+56377,Andriy,Yarmolenko,Yarmolenko,41672
+56827,Costel,Pantilimon,Pantilimon,43948
+56864,Francis,Coquelin,Coquelin,69738
+56872,Junior,Stanislas,Stanislas,69912
+56917,Steve,Cook,Cook,68662
+56979,Jordan,Henderson,Henderson,68659
+56981,Joe,Bennett,Bennett,68658
+56983,Matt,Ritchie,Ritchie,68648
+57001,Wilfried,Bony,Bony,42705
+57112,Eliaquim,Mangala,Mangala,68852
+57127,Teemu,Pukki,Pukki,25028
+57134,Salomón,Rondón,Rondón,25964
+57145,Federico,Fernández,Fernández,44847
+57187,Giedrius,Arlauskis,Arlauskis,66957
+57249,Henrikh,Mkhitaryan,Mkhitaryan,28421
+57328,Nathaniel,Clyne,Clyne,69375
+57410,Nicolás,Otamendi,Otamendi,75691
+57513,Jonas,Lössl,Lössl,131171
+57531,Michail,Antonio,Antonio,69517
+57586,Luciano,Narsingh,Narsingh,69525
+57647,Lyle,Taylor,Lyle Taylor,134189
+57736,Jan,Kirchhoff,Kirchhoff,69609
+58376,Alex,McCarthy,McCarthy,38577
+58498,Odion,Ighalo,Ighalo,31376
+58621,Kyle,Walker,Walker,69778
+58771,Jack,Colback,Colback,69867
+58786,Martin,Kelly,Kelly,44687
+58791,Ryan,Mason,Mason,69878
+58822,Cédric,Alves Soares,Cédric,69945
+58845,Ciaran,Clark,Clark,70099
+58877,Daley,Blind,Blind,70033
+58893,Marcos,Rojo,Rojo,70050
+59044,Adam,Clayton,Clayton,70140
+59115,Mile,Jedinak,Jedinak,13727
+59125,Connor,Wickham,Wickham,73382
+59735,Karl,Darlow,Darlow,70483
+59741,Max,Gradel,Gradel,29814
+59779,Pedro,Obiang,Obiang,70676
+59796,Gökhan,Töre,Töre,71015
+59846,Ander,Herrera,Herrera,71174
+59856,Abel,Hernández,Hernández,32741
+59859,İlkay,Gündoğan,Gündoğan,77464
+59940,Kyle,Bartley,Bartley,71327
+59949,Séamus,Coleman,Coleman,31826
+59966,Alexandre,Lacazette,Lacazette,73078
+60025,James,Rodríguez,James,71182
+60165,Wahbi,Khazri,Khazri,71381
+60232,Craig,Dawson,Dawson,73063
+60252,Andros,Townsend,Townsend,71522
+60270,Simone,Zaza,Zaza,71647
+60307,Pascal,Groß,Groß,71824
+60551,Ashley,Westwood,Westwood,79050
+60586,Jóhann Berg,Gudmundsson,Gudmundsson,41868
+60598,Aleksandar,Dragovic,Dragovic,40560
+60689,Chris,Wood,Wood,73380
+60706,Adrián,San Miguel del Castillo,Adrián,73399
+60772,Thibaut,Courtois,Courtois,73798
+60914,Joel,Matip,Matip,74341
+61256,Carlos Henrique,Casimiro,Casemiro,88526
+61262,Oscar,dos Santos Emboaba Junior,Oscar,41065
+61302,Ryan,Allsop,Allsop,74586
+61316,Jose Luis,Mato Sanmartín,Joselu,74603
+61366,Kevin,De Bruyne,De Bruyne,73084
+61548,Manolo,Gabbiadini,Gabbiadini,74921
+61558,Thiago,Alcántara do Nascimento,Thiago,74939
+61566,Roberto,Pereyra,Pereyra,90000
+61595,Marc,Muniesa,Muniesa,75177
+61600,Romaine,Sawyers,Sawyers,75200
+61603,Daniel,Drinkwater,Drinkwater,75138
+61604,Matty,James,James,75198
+61739,Maxime,Le Marchand,Le Marchand,236523
+61760,Kristoffer,Nordfeldt,Nordfeldt,26236
+61810,Pontus,Jansson,Jansson,121123
+61858,Mame Biram,Diouf,Diouf,26013
+61916,Stefan,Johansen,Johansen,27579
+61933,Shane,Duffy,Duffy,75692
+62398,Nemanja,Matic,Matic,38128
+62399,Dusan,Tadic,Tadic,29474
+62974,Erik,Lamela,Lamela,75830
+63370,James,McClean,McClean,76050
+63426,Enda,Stevens,Stevens,42266
+66242,Davy,Pröpper,Pröpper,77429
+66247,Marvin,Zeegelaar,Zeegelaar,78152
+66588,Luke,Ayling,Ayling,82877
+66749,Romelu,Lukaku Bolingoli,Lukaku,78498
+66797,Simon,Mignolet,Mignolet,52197
+66838,Cenk,Tosun,Tosun,77438
+66842,André,Schürrle,Schürrle,77461
+66975,Luka,Milivojevic,Milivojevic,70493
+67089,Martin,Dúbravka,Dúbravka,46092
+67527,Allan-Roméo,Nyom,Nyom,91434
+68312,Xherdan,Shaqiri,Shaqiri,76304
+68983,Matthew,Lowton,Lowton,80067
+69140,Shkodran,Mustafi,Mustafi,80921
+69143,Juraj,Kucka,Kucka,32514
+69752,Norberto,Murara Neto,Neto,76202
+69960,Philipp,Wollscheid,Wollscheid,86173
+71738,Marco,Stiepermann,Stiepermann,82699
+72147,Marco,Bizot,M.Bizot,83824
+72222,Mateusz,Klich,Klich,69638
+72681,Denis,Odoi,Odoi,68335
+73314,Willian José,Da Silva,Willian José,77636
+73426,Andre,Gray,Gray,131487
+73459,Ashley Darel Jazz,Richards,Jazz Richards,78089
+73494,Grzegorz,Krychowiak,Krychowiak,67424
+73889,Diafra,Sakho,Sakho,83297
+74033,Sam,Clucas,Clucas,134459
+74208,Paul,Pogba,Pogba,97752
+74230,Patrick,van Aanholt,van Aanholt,78221
+74297,Leandro,Bacuna,Bacuna,79967
+74375,Ezequiel,Schelotto,Schelotto,79442
+74471,Aaron,Mooy,Mooy,318153
+74854,Simon,Moore,Moore,131498
+74944,Sam,Morsy,Morsy,134666
+75115,Callum,Wilson,Wilson,134115
+75773,Chung-yong,Lee,Lee Chung-yong,42915
+75826,Danny,Ward,Ward,78471
+75880,Daniel,Ayala,Ayala,78559
+76306,Lukas,Rupp,Rupp,79533
+76357,Tom,Cairney,Cairney,79583
+76359,Phil,Jones,Jones,81726
+76360,Nathaniel,Mendez-Laing,Mendez-Laing,87393
+76542,Sung-yueng,Ki,Ki Sung-yueng,42916
+77359,Florian,Lejeune,Lejeune,80758
+77454,Fabio,Borini,Borini,80882
+77762,Bryan,Oviedo,Oviedo,83455
+77777,Ahmed El-Sayed,Hegazy,Hegazi,108724
+77794,Kieran,Trippier,Trippier,83078
+77818,James,Shea,Shea,94017
+78007,Joshua,King,King,81026
+78056,Oriol,Romeu Vidal,Romeu,90780
+78091,Gastón,Ramírez,Ramírez,82923
+78315,Joel,Robles,Robles,81681
+78356,Charlie,Austin,Austin,82102
+78412,Shinji,Okazaki,Okazaki,26222
+78607,Kenny,McLean,McLean,82917
+78830,Harry,Kane,Kane,83532
+78911,Kadeem,Harris,Harris,135772
+78916,Dan,Burn,Burn,82277
+79228,Pape,Souaré,Souaré,79970
+79602,Daniel,Bentley,Bentley,134543
+79619,Jonathan,Hogg,Hogg,82593
+79733,Scott,Malone,Malone,74077
+79852,Jed,Steer,Steer,82745
+79934,Oliver,Norwood,Norwood,90324
+80146,Jordan,Ayew,J.Ayew,67491
+80179,Adam,Forshaw,Forshaw,82972
+80183,Luke,Garbutt,Garbutt,82965
+80201,Bernd,Leno,Leno,92173
+80226,Serge,Aurier,Aurier,83683
+80254,Carl,Jenkinson,Jenkinson,91879
+80447,Maya,Yoshida,Yoshida,37204
+80607,Christian,Eriksen,Eriksen,69344
+80755,Danny,Williams,Williams,83335
+80789,Jordi,Amat,Amat,83357
+80792,Greg,Cunninghamm,Cunningham,83394
+80801,Idrissa Gana,Gueye,Gana,80464
+80935,Papy,Djilobodji,Djilobodji,83456
+80954,Rodrigo,Moreno,Rodrigo,83459
+81012,Ryan,Fredericks,Fredericks,83554
+81048,Josip,Drmic,Drmic,83588
+81061,Michael,Simões Domingues,Mika,83601
+81183,Matej,Vydra,Vydra,84129
+81205,Mislav,Orsic,Orsic,141670
+81441,Mark,Gillespie,Gillespie,134640
+81880,Alex,Oxlade-Chamberlain,Chamberlain,84146
+82078,Kenneth,Zohore,Zohore,83621
+82143,Wes,Foderingham,Foderingham,134482
+82257,Raphael,Spiegel,Spiegel,84796
+82263,Marcos,Alonso,Alonso,84008
+82403,Wilfried,Zaha,Zaha,85059
+82428,Marten,de Roon,de Roon,85070
+82514,Tim,Ream,Ream,85006
+82691,George,Baldock,Baldock,134244
+82738,Luke,Berry,Berry,139864
+82771,Markus,Henriksen,Henriksen,69090
+83091,Borja,González Tomás,Bastón,106872
+83283,Nathan,Redmond,Redmond,86425
+83299,Lewis,Dunk,Dunk,86441
+83312,Ben,Gibson,Gibson,86458
+83314,Jeff,Hendrick,Hendrick,86454
+83427,Jack,Robinson,Robinson,86594
+83428,Grant,Hanley,Hanley,86593
+83543,Anthony,Knockaert,Knockaert,86794
+84112,Collin,Quaner,Quaner,90996
+84182,Alphonse,Areola,Areola,92516
+84384,Timm,Klose,Klose,77114
+84395,Florin,Gardos,Gardos,92331
+84450,Granit,Xhaka,Xhaka,89401
+84583,Philippe,Coutinho Correia,Coutinho,80767
+84915,Michael,Hector,Hector,91840
+84939,Danny,Ings,Ings,91762
+85017,Tendayi,Darikwa,Darikwa,134668
+85128,Connor,Goldson,Goldson,134258
+85242,Conor,Hourihane,Hourihane,134172
+85352,Bruno,Martins Indi,Martins Indi,90810
+85368,Christopher,Schindler,Schindler,132360
+85624,Christian,Kabasele,Kabasele,68393
+85633,Matz,Sels,Sels,78386
+85654,Jordy,Clasie,Clasie,90802
+85955,Jorge Luiz,Frello Filho,Jorginho,106968
+85971,Son,Heung-min,Son,91909
+86129,Kalidou,Koulibaly,Koulibaly,90880
+86153,Martín,Montoya,Montoya,91387
+86173,Manuel,Agudo Durán,Nolito,91267
+86176,Tom,Ince,Ince,90918
+86417,Jeffrey,Schlupp,Schlupp,91822
+86873,Benjamin,Lecomte,Lecomte,89928
+86881,Nampalys,Mendy,Mendy,90278
+86934,Manuel,Lanzini,Lanzini,89998
+87107,Cyrus,Christie,Christie,134111
+87121,Kieron,Freeman,Freeman,91825
+87396,Moritz,Leitner,Leitner,91159
+87428,Elias,Kachunga,Kachunga,92804
+87447,Muhamed,Bešić,Bešić,90983
+87835,Matt,Doherty,Doherty,94042
+87856,Michael,Hefele,Hefele,104035
+87873,Stuart,Dallas,Dallas,134143
+88170,Jiri,Skalak,Skalak,90549
+88175,Lovre,Kalinic,Kalinic,139533
+88248,Stefan,Ortega Moreno,Ortega Moreno,133569
+88482,Álvaro,Morata,Morata,91213
+88484,Pablo,Sarabia,Sarabia,94868
+88498,Benik,Afobe,Afobe,93647
+88734,Neil,Etheridge,Etheridge,91953
+88894,Ross,Barkley,Barkley,92547
+88900,Jack,Stephens,Stephens,92550
+89068,Layvin,Kurzawa,Kurzawa,92795
+89076,Remo,Freuler,Freuler,302691
+89085,Nathaniel,Chalobah,Chalobah,92729
+89274,José Ignacio,Peleteiro Romallo,Jota,10447
+89335,Saúl,Ñíguez,Saúl,112161
+89470,Onel,Hernández,Hernández,92916
+89572,Denis,Suárez,Suárez,106525
+90105,Ryan,Fraser,Fraser,93160
+90152,Raphaël,Varane,R.Varane,93206
+90263,James,Husband,Husband,93309
+90440,Tom,Trybull,Trybull,96853
+90517,Robbie,Brady,Brady,93473
+90518,Ravel,Morrison,Morrison,93475
+90585,Willy,Boly,Boly,97587
+90714,Ahmed,Musa,Musa,93577
+91046,Cauley,Woodrow,Woodrow,138641
+91047,Stuart,Armstrong,S.Armstrong,93677
+91126,Will,Keane,Keane,107940
+91651,Mateo,Kovačić,Kovačić,93894
+91889,Niclas,Füllkrug,Füllkrug,104058
+91972,Saido,Berahino,Berahino,94024
+91979,Jon,Flanagan,Flanagan,94030
+92159,Jetro,Willems,Willems,94885
+92170,Massadio,Haidara,Haidara,94892
+92217,Roberto,Firmino,Firmino,96182
+92259,Neeskens,Kebano,Kebano,94933
+92293,Omar,Elabdellaoui,Elabdellaoui,94936
+92371,Pablo,Marí Villar,Pablo Marí,141032
+92383,Nahki,Wells,Wells,122554
+93001,Konstantinos,Stafylidis,Stafylidis,106486
+93100,Jannik,Vestergaard,Vestergaard,87182
+93127,Jesé,Rodríguez Ruiz,Jesé,106028
+93264,Eric,Dier,Dier,117973
+93284,Florin,Andone,Andone,255183
+93464,Tom,Carroll,Carroll,90907
+94147,Conor,Coady,Coady,97710
+94245,Michy,Batshuayi,Batshuayi,97803
+94248,Sergio,Rico,Rico,109338
+94924,Gerard,Deulofeu,Deulofeu,98317
+94926,Freddie,Ladapo,Ladapo,141931
+95463,Danny,Ward,Ward,99165
+95508,Fredrik,Ulvestad,Ulvestad,78193
+95658,Harry,Maguire,Maguire,99487
+95715,Lucas,Rodrigues Moura da Silva,Lucas Moura,92508
+96305,Jay,Fulton,Fulton,145999
+96306,Stephen,Kingsley,Kingsley,100718
+96764,M'Baye,Niang,Niang,58761
+96767,Dimitri,Foulquier,Foulquier,101084
+96778,Adam,Reach,Reach,101135
+96784,Jordan,Clark,Clark,100594
+96787,Mohamed,Elyounoussi,Elyounoussi,141732
+96994,Bobby,De Cordova-Reid,De Cordova-Reid,134332
+97032,Virgil,van Dijk,Virgil,95408
+97296,Tommie,Hoban,Hoban,101373
+97299,John,Stones,Stones,101374
+97485,Kevin,Wimmer,Wimmer,101550
+97615,Mike,van der Hoorn,van der Hoorn,101605
+98745,Héctor,Bellerín,Bellerín,125211
+98747,Nick,Pope,Pope,105720
+98770,Ørjan,Nyland,Nyland,39187
+98914,Guido,Carrillo,Carrillo,125379
+98980,Emiliano,Martínez Romero,Martinez,102248
+99323,Lazar,Markovic,Markovic,105577
+100059,Alberto,Moreno,Moreno,113275
+100180,Danilo Luiz,da Silva,Danilo,88300
+100412,André,Carrillo,Carrillo,97635
+100649,Bernard,Anício Caldeira Duarte,Bernard,101642
+101061,Philip,Heise,Heise,132922
+101105,Joe,Bryan,Bryan,134331
+101148,Jamaal,Lascelles,Lascelles,105171
+101178,James,Ward-Prowse,Ward-Prowse,105172
+101179,Lloyd,Isgrove,Isgrove,130330
+101184,Calum,Chambers,Chambers,124316
+101188,Lucas,Digne,Digne,89925
+101338,Marcel,Sabitzer,Sabitzer,92051
+101394,Okay,Yokuslu,Yokuslu,93805
+101537,Felipe Anderson,Pereira Gomes,Felipe Anderson,93026
+101582,Frederico,Rodrigues de Paula Santos,Fred,114397
+101668,Jamie,Vardy,Vardy,106981
+101982,Sam,Johnstone,Johnstone,105603
+102057,Raúl,Jiménez Rodríguez,Raúl,108186
+102366,Moritz,Bauer,Bauer,103536
+102380,Antonio,Rüdiger,Rüdiger,104010
+102549,Adam,Davies,A.Davies,10894
+102738,Giannelli,Imbula,Imbula,81959
+102747,Djibril,Sidibé,Sidibé,10454
+102826,Benjamin,Mendy,Mendy,105962
+102884,Paulo,Gazzaniga Farias,Gazzaniga,104732
+103025,Riyad,Mahrez,Mahrez,104749
+103123,Sébastien,Haller,Haller,236544
+103127,Molla,Wagué,Wagué,105339
+103192,Kurt,Zouma,Zouma,106086
+103912,Jordon,Ibe,Ibe,105797
+103914,Charlie,Taylor,Taylor,107462
+103955,Raheem,Sterling,Sterling,97692
+104047,Pelly Ruddock,Mpanzu,Mpanzu,135717
+104073,Joe,Ralls,Ralls,108093
+104542,Loris,Karius,Karius,107176
+104545,Tommy,Smith,Smith,135837
+104547,Dwight,Gayle,Gayle,118326
+104953,Christian,Atsu,Atsu,96257
+105377,Ezgjan,Alioski,Alioski,137161
+105666,Jack,Butland,Butland,107395
+105700,Davide,Zappacosta,Zappacosta,141312
+105717,Arthur,Masuaku,Masuaku,122980
+106449,Kevin,Stewart,Stewart,107846
+106450,Alex,Pritchard,Pritchard,107848
+106468,Álex,Moreno Lopera,Alex Moreno,135374
+106603,Ezekiel,Fryers,Fryers,107942
+106606,Massimo,Luongo,Luongo,110555
+106611,Michael,Keane,Keane,107941
+106617,Patrick,Bamford,Bamford,109670
+106618,Paul,Dummett,Dummett,112009
+106757,Jürgen,Locadia,Locadia,107622
+106760,Luke,Shaw,Shaw,118244
+106824,Memphis,Depay,Depay,110154
+106837,Dennis,Praet,Praet,106413
+106899,Roque,Mesa,Mesa,108176
+107265,Angus,Gunn,Gunn,318896
+107613,Romain,Saïss,Saïss,236519
+108053,Conor,Townsend,Townsend,108640
+108093,Luciano,Vietto,Vietto,125543
+108156,Björn,Engels,Engels,108493
+108411,Dan,Potts,Potts,108630
+108413,Will,Hughes,Hughes,108638
+108416,John,Egan,Egan,108632
+108438,Sandro,Ramírez,Sandro,135242
+108796,Tom,Lockyer,Lockyer,134360
+108813,Christian,Walton,Walton,140906
+108823,Dele,Alli,Dele,131519
+108824,Brendan,Galloway,Galloway,131523
+109065,Davy,Klaassen,Klaassen,108860
+109322,Jesse,Lingard,Lingard,109000
+109345,Solly,March,March,122926
+109434,Terence,Kongolo,Kongolo,109117
+109528,Javier,Manquillo Gaitán,Manquillo,109227
+109533,Emerson,Palmieri dos Santos,Emerson,101955
+109638,Kean,Bryan,Bryan,318890
+109646,Tosin,Adarabioyo,Tosin,136464
+109745,Kepa,Arrizabalaga Revuelta,Arrizabalaga,113880
+109788,João Mário,Naval Costa Eduardo,João Mário,125476
+109999,Ibrahima,Cissé,Cissé,109479
+110504,Bertrand,Traoré,Traoré,109807
+110735,Adam,Webster,Webster,109922
+110979,Sadio,Mané,Mané,109915
+111234,Jordan,Pickford,Pickford,110189
+111291,Fernando,Marçal,Marçal,121718
+111317,David,Brooks,Brooks,295084
+111452,Odysseas,Vlachodimos,Odysseas,110273
+111457,Sead,Kolasinac,Kolasinac,110260
+111478,Joël,Veltman,Veltman,110290
+111773,Emil,Krafth,Krafth,100599
+111782,Robin,Olsen,Olsen,41554
+111787,Modou,Barrow,Barrow,248351
+111847,Adama,Diomande,Diomande,243562
+111931,Ricardo,Barbosa Pereira,Ricardo,120763
+112316,Jakob,Haugaard,Haugaard,298599
+112338,Emre,Can,Can,111212
+112507,Jack,Rose,Rose,260780
+112516,Isaiah,Brown,Brown,127119
+112520,Alex,Palmer,Palmer,280770
+113534,Matt,Macey,Macey,254550
+113564,Sam,Byram,Byram,118303
+113688,Oumar,Niasse,Niasse,111141
+114000,George,Honeyman,Honeyman,278129
+114093,Matthew,Pennington,Pennington,141451
+114128,Jonathan,Castro Otto,J.Otto,115917
+114241,Harry,Toffolo,Toffolo,298659
+114243,Jacob,Murphy,J.Murphy,141486
+114245,Josh,Murphy,Murphy,136783
+114283,Jack,Grealish,Grealish,113069
+114536,Ryan,Inniss,Inniss,113249
+115357,Mouez,Hassen,Hassen,116615
+115382,Neal,Maupay,Maupay,119822
+115556,Ben,Davies,Davies,103837
+115854,Duncan,Watmore,Watmore,141512
+115858,Rachid,Ghezzal,Ghezzal,95423
+115918,Rúnar Alex,Rúnarsson,Rúnarsson,141841
+116216,Leandro,Trossard,Trossard,113994
+116404,Felipe Augusto,de Almeida Monteiro,Felipe,102173
+116535,Alisson,Becker,A.Becker,114147
+116543,Valentino,Lazaro,Lazaro,114323
+116594,N'Golo,Kanté,Kanté,114075
+116643,Fabio Henrique,Tavares,Fabinho,115916
+118342,Mark,Flekken,Flekken,115131
+118748,Mohamed,Salah,M.Salah,108226
+118884,Erik,Durm,Durm,115165
+119471,Fabian,Schär,Schär,82726
+119765,Allan,Marques Loureiro,Allan,82438
+120202,Wout,Weghorst,Weghorst,115479
+120250,André,Tavares Gomes,André Gomes,118123
+120447,Bradley,Smith,Brad Smith,141414
+120721,Kevin,Mbabu,Mbabu,115230
+121145,João,Cavaco Cancelo,João Cancelo,128967
+121160,Ederson,Santana de Moraes,Ederson M.,121774
+121221,Ramiro,Funes Mori,Funes Mori,121454
+121570,Julian,Jeanvier,Jeanvier,120000
+121599,Abdoulaye,Doucouré,A.Doucoure,116317
+121709,Walter,Benítez,Benitez,130304
+122074,Marcus,Bettinelli,Bettinelli,135768
+122342,Emerson,Hyndman,Hyndman,231119
+122411,Cameron,Burgess,Burgess,231118
+122775,Morgan,Sanson,Sanson,115508
+122797,Callum,Paterson,Paterson,253843
+122798,Andrew,Robertson,Robertson,115726
+122806,John,McGinn,McGinn,318449
+123125,Viktor,Fischer,Fischer,101862
+123354,Kortney,Hause,Hause,134207
+124165,Patrick,Roberts,Roberts,136462
+124183,Hakim,Ziyech,Ziyech,115868
+126184,Nathan,Aké,Aké,122945
+126187,Ruben,Loftus-Cheek,Loftus-Cheek,255777
+126407,Nabil,Bentaleb,Bentaleb,137521
+128198,Sofiane,Boufal,Boufal,234363
+128295,Christian,Nørgaard,Nørgaard,101856
+128309,Jamal,Lowe,Lowe,362126
+128340,Kieffer,Moore,Moore,133190
+128348,Ibrahim,Amadou,Amadou,118885
+128389,Aleksandar,Mitrović,Mitrović,115279
+130025,Luis,Hernández,Hernández,294139
+130036,Ozan,Tufan,Tufan,115639
+130103,Hiram,Boateng,Boateng,135732
+131304,William,Troost-Ekong,Troost-Ekong,133400
+131403,Rhys,Healey,Healey,119026
+131897,Mathew,Ryan,Ryan,81523
+132015,Pierre-Emile,Højbjerg,Højbjerg,101859
+133085,Lawrence,Vigouroux,Vigouroux,137804
+133801,Jerome,Sinclair,Sinclair,274630
+133845,Emiliano,Marcondes,Marcondes,115085
+134383,Connor,Randall,Randall,296522
+135363,Andreas,Christensen,Christensen,130331
+135365,Jeremie,Boga,Boga,280766
+135720,Kevin,Danso,Danso,330816
+138001,Tom,King,King,243164
+138009,Sullay,Kaikai,Kaikai,260451
+139110,Ondrej,Duda,Duda,115257
+140200,Thomas,Strakosha,Strakosha,121480
+141020,Max,Meyer,Meyer,124598
+141569,Léo,Bonatini,Bonatini,137269
+141746,Bruno,Borges Fernandes,B.Fernandes,123761
+143877,Alexander,Sørloth,Sørloth,302497
+144485,Ivan,Toney,Toney,134240
+144660,Didier,Ndong,Ndong,149599
+145235,José Ángel,Esmorís Tasende,Angeliño,255089
+146426,Oluwasemilogo Adesewo Ibidapo,Ajayi,Ajayi,247815
+146610,Jack,O'Connell,O'Connell,134473
+146941,Aymeric,Laporte,Laporte,122117
+147303,Laurent,Depoitre,Depoitre,106880
+147611,Paul,Onuachu,Onuachu,122182
+147612,Richairo,Zivkovic,Zivkovic,122206
+147675,Chuba,Akpom,Akpom,122294
+148179,Enner,Valencia,Valencia,83895
+148225,Anthony,Martial,Martial,122366
+148508,Mahmoud Ahmed,Ibrahim Hassan,Trézéguet,313545
+149016,Lynden,Gooch,Gooch,294849
+149051,Ethan,Robson,Ethan Robson,332124
+149065,José,Malheiro de Sá,José Sá,122714
+149266,Alfie,Mawson,Mawson,135727
+149468,Tyias,Browning,Browning,123138
+149484,Tyrone,Mings,Mings,123167
+149519,Maxwel,Cornet,Cornet,125004
+149736,Chancel,Mbemba,Mbemba,104368
+149828,Islam,Slimani,Slimani,108055
+149915,Diego,Llorente,Llorente,123232
+149929,Wes,Burns,Burns,135729
+151086,Mario,Lemina,Mario Jr.,123481
+151119,DeAndre,Yedlin,Yedlin,126958
+151589,Leander,Dendoncker,Dendoncker,124106
+152551,Jefferson,Lerma Solís,Lerma,133464
+152590,Alex,Telles,Alex Telles,125793
+152760,Divock,Origi,Origi,124688
+152898,Ben,Davies,Davies,124204
+153127,Isaac,Hayden,Hayden,136356
+153133,Alex,Iwobi,Iwobi,136824
+153256,Mohamed,Elneny,M.Elneny,125209
+153366,Harrison,Reed,Reed,135724
+153371,Sam,Gallagher,Gallagher,138027
+153373,Sam,McQueen,McQueen,142438
+153379,Josh,Sims,Sims,330916
+153477,Conor,Masterson,Masterson,302215
+153673,Jonjoe,Kenny,Kenny,255961
+153682,Harry,Wilson,Wilson,333044
+153723,John,Lundstram,Lundstram,126149
+153772,Luke,McGee,McGee,251136
+154043,Ainsley,Maitland-Niles,Maitland-Niles,255169
+154048,Stephy,Mavididi,Mavididi,318750
+154050,Olufela,Olomola,Olomola,312920
+154051,Oviemuno,Ejaria,Ejaria,327852
+154131,Jack,Stacey,Stacey,231080
+154138,Tariqe,Fosu-Henry,Fosu,240848
+154296,João Maria,Lobo Alves Palhares Costa Palhinha Gonçalves,J.Palhinha,322774
+154506,Daniel,Bachmann,Bachmann,141468
+154558,Thomas,Robson,Thomas Robson,252285
+154559,Michael,Ledger,Ledger,332418
+154561,David,Raya Martín,Raya,276366
+154566,Dominic,Solanke-Mitchell,Solanke,136459
+154976,Adnan,Januzaj,Januzaj,130334
+155197,Max,Lowe,Lowe,136452
+155405,Kalvin,Phillips,Phillips,270446
+155408,Lewis,Cook,Cook,136456
+155503,Freddie,Woodman,Woodman,136466
+155509,Greg,Olley,Olley,322594
+155511,Adam,Armstrong,Armstrong,136460
+155513,Rolando,Aarons,Aarons,235743
+155529,Marek,Rodák,Rodák,256125
+155561,Ludwig,Augustinsson,Augustinsson,282994
+155569,Daniel,Amartey,Amartey,243552
+155651,Adam,Masina,Masina,137512
+155851,Lucas,Pérez,Lucas,135663
+156069,Liam,Gibson,Gibson,303109
+156074,Rob,Holding,Holding,288795
+156658,Reece,Burke,Burke,141510
+156660,Moses,Makasi,Makasi,336236
+156683,Pierluigi,Gollini,Gollini,240990
+156685,Joe,Rothwell,Rothwell,260784
+156686,James,Weir,Weir,302386
+156687,Ben,Pearson,Pearson,302391
+156689,Andreas,Hoelgebaum Pereira,Andreas,243254
+156690,Joshua,Harrop,Harrop,338496
+156700,Carlton,Morris,Morris,263188
+157665,Filip,Lesniak,Lesniak,320639
+157668,Harry,Winks,Winks,143990
+157775,Ken,Sema,Sema,145392
+157882,Takumi,Minamino,Minamino,262838
+158074,Gabriel Armando,de Abreu,Gabriel,76810
+158499,Ryan,Christie,Christie,128882
+158534,Kyle,Walker-Peters,Walker-Peters,313672
+158544,Jake,Hesketh,Hesketh,255505
+158983,Endo,Wataru,Endo,86829
+159039,Antonio,Barreca,Barreca,143524
+159506,Ola,Aina,Aina,315543
+159533,Adama,Traoré Diarra,Adama,140088
+160190,Kasey,Palmer,Palmer,315544
+160729,Jason,Denayer,Denayer,243511
+160816,Donald,Love,Love,303379
+160817,Patrick,McNair,McNair,244565
+160987,Jean-Philippe,Gbamin,Gbamin,129758
+162651,Samir,Caetano de Souza Santos,Samir,131337
+163463,Papa Alioune,Ndiaye,Badou Ndiaye,112698
+163526,Edimilson,Fernandes,Fernandes,130964
+163776,Erdal,Rakip,Rakip,131030
+164011,Mbaye,Diagne,Diagne,142072
+164484,Zack,Steffen,Steffen,145473
+164511,Yerry,Mina,Mina,318432
+164555,Vladimír,Coufal,Coufal,111372
+165153,Timo,Werner,Werner,130903
+165183,Amari'i,Bell,Bell,141209
+165210,Alireza,Jahanbakhsh,Jahanbakhsh,133390
+165659,Diego Carlos,Santos Silva,Diego Carlos,134984
+165808,Hélder Wander,Sousa de Azevedo e Costa,Costa,118127
+165809,Bernardo,Mota Veiga de Carvalho e Silva,Bernardo,136741
+165911,Bartosz,Kapustka,Kapustka,295603
+165990,Vincent,Janssen,Janssen,133381
+166324,Ivan,Neves Abreu Cavaleiro,I.Cavaleiro,137386
+166325,Carlos,Ribeiro Dias,Cafú,118121
+166477,Timothy,Castagne,Castagne,141169
+166640,Fabián,Balbuena,Balbuena,282871
+166989,Youri,Tielemans,Tielemans,136345
+167074,Kenny,Tete,Tete,145996
+167075,Wesley,Hoedt,Hoedt,141172
+167191,Marcus,Myers-Harness,Harness,135714
+167199,Thomas,Partey,Thomas,238940
+167473,José,Izquierdo,Izquierdo,243548
+167512,Luke,O'Nien,O'Nien,134373
+167522,Jordan,Hugill,Hugill,139334
+167767,Robert Kenedy,Nunes do Nascimento,Kenedy,132838
+167789,Baily,Cargill,Cargill,140889
+167878,Ben,Osborn,Osborn,140667
+167887,Josh,Laurent,Laurent,142676
+167888,Joe,Lumley,Lumley,288788
+168035,Fred,Onyedinma,Onyedinma,141431
+168090,Mahmoud,Dahoud,Dahoud,135092
+168172,Joe,Lolley,Lolley,138785
+168196,Joel Dinis,Castro Pereira,Joel Pereira,312584
+168281,Scott,McKenna,McKenna,364624
+168287,Jonathan,Calleri,Calleri,133445
+168290,Ignacio,Pussetto,Pussetto,134698
+168399,Will,Norris,Norris,139866
+168547,Ethan,Horvath,Horvath,296544
+168566,Georges-Kévin,Nkoudou,Nkoudou,134887
+168580,Ayoze,Pérez,Pérez,135366
+168636,Enes,Ünal,Enes Ünal,134695
+168717,Maksymilian,Stryjek,Stryjek,259134
+168763,Cameron,Carter-Vickers,Carter-Vickers,301029
+168764,Luke,Amos,Amos,329492
+168765,Josh,Onomah,Onomah,136455
+168977,Joel,Coleman,Coleman,135179
+168991,Philip,Billing,Philip,145277
+169061,Dael,Fry,Fry,288989
+169102,Tiemoué,Bakayoko,Bakayoko,135211
+169130,Joel,Taylor,Taylor,332836
+169141,Steve,Mounie,Mounie,135259
+169187,Trent,Alexander-Arnold,Alexander-Arnold,318871
+169359,Matt,Targett,Targett,136776
+169432,Oliver,McBurnie,McBurnie,138695
+169527,Joe,Williams,Joe Williams,255962
+169528,Antonee,Robinson,Robinson,306581
+169535,Julien,de Sart,de Sart,136396
+169593,Remi,Matthews,Matthews,229492
+169735,Noor,Husin,Husin,331923
+169743,Connor,Mahoney,Mahoney,135773
+170137,Allan,Saint-Maximin,Saint-Maximin,135891
+170154,Pablo,Maffeo,Maffeo,294848
+170271,Jean Michaël,Seri,Seri,136262
+170851,Josh,Robson,Josh Robson,294516
+171099,Hassane,Kamara,Kamara,239881
+171101,Clément,Lenglet,Lenglet,236511
+171129,Diego,Rico,Rico,323352
+171162,Charly,Musonda,Musonda,303172
+171270,Kieran,Dowell,Dowell,136458
+171277,Demetri,Mitchell,Mitchell,136457
+171287,Joe,Gomez,Gomez,136451
+171314,Rúben,dos Santos Gato Alves Dias,Rúben,313171
+171317,Rúben,da Silva Neves,Neves,238244
+171319,Renato,Sanches,Sanches,299450
+171771,Jan,Bednarek,Bednarek,136742
+171975,Callum,Robinson,Callum Robinson,138768
+172246,Florent,Hadergjonaj,Hadergjonaj,136896
+172453,Sam,Szmodics,Szmodics,138686
+172551,Callum,Roberts,Roberts,256534
+172567,Josh,Cullen,Cullen,273292
+172632,Demarai,Gray,Gray,136945
+172649,Dean,Henderson,Henderson,304008
+172780,James,Maddison,Maddison,137015
+172782,Josh,Brownhill,Brownhill,138929
+172841,Saïd,Benrahma,Benrahma,137021
+172850,Ben,Chilwell,Chilwell,299272
+172912,Sofyan,Amrabat,Amrabat,248144
+173268,Ivo,Grbic,Grbić,377309
+173271,Duje,Caleta-Car,Caleta-Car,251134
+173514,Isaac,Success Ajayi,Success,145940
+173515,Kelechi,Iheanacho,Iheanacho,289253
+173792,Reece,Oxford,Oxford,260779
+173804,Layton,Ndukwu,Ndukwu,357426
+173807,Tom,Davies,T.Davies,316077
+173809,Jonathan,Leko,Leko,315290
+173810,Darnell,Johnson,Johnson,396318
+173818,Nathan,Broadhead,Broadhead,349671
+173821,Tyler,Roberts,Roberts,280771
+173879,Tammy,Abraham,Abraham,317506
+173904,Davinson,Sánchez,Sánchez,322655
+173954,Jairo,Riedewald,Riedewald,141246
+174248,George,Thomas,Thomas,138445
+174292,Marco,Asensio,M.Asensio,137467
+174310,Elijah,Adebayo,Adebayo,362145
+174590,Jacob,Maddox,Maddox,362196
+174592,Marcus,Edwards,Edwards,279177
+174593,Kyle,Edwards,Edwards,297020
+174594,Lukas,Nmecha,Nmecha,347340
+174874,Joachim,Andersen,Andersen,231135
+174932,Sergi,Canós Tenés,Canós,295964
+175351,Demeaco,Duhaney,Duhaney,349568
+175353,Ayotomiwa,Dele-Bashiru,Dele-Bashiru,350062
+175592,Naby,Keita,Keita,243510
+175941,Alfie,Whiteman,Whiteman,328106
+175946,Víctor,Camarasa,Camarasa,140957
+176295,Matthew,Willock,Willock,335593
+176296,Ashley,Fletcher,Fletcher,302206
+176297,Marcus,Rashford,Rashford,300299
+176413,Christian,Pulisic,Pulisic,302692
+176414,Luca,De La Torre,De La Torre,322406
+176420,Darnell,Furlong,Furlong,262401
+176706,Alfie,Jones,Jones,323793
+177815,Dominic,Calvert-Lewin,Calvert-Lewin,141469
+178186,Jarrod,Bowen,Bowen,322596
+178301,Ollie,Watkins,Watkins,148503
+178304,Lys,Mousset,Mousset,296332
+178867,Antonio,Martinez Lopez,Martínez,280060
+178871,Aleix,García Serrano,García,280663
+178876,Jesús,Vallejo Lázaro,Vallejo,238901
+179018,Miguel,Almirón Rejala,Almirón,303924
+179261,Zachary,Dearnley,Dearnley,338499
+179268,Marc,Cucurella Saseta,Cucurella,363496
+179276,Mathias,Normann,Normann,320959
+179456,Oskar,Buur,Buur,345769
+179458,Jacob,Bruun Larsen,Bruun Larsen,307202
+179519,Orel,Mangala,Mangala,344073
+179587,Dennis,Srbeny,Srbeny,142470
+179596,Elliott,Moore,Moore,338118
+179725,Carl,Stewart,Stewart,332412
+179829,Josh,Pask,Pask,284122
+179830,Grady,Diangana,Diangana,306943
+180135,Sean,Longstaff,Longstaff,342811
+180151,Nikola,Vlašić,Vlašić,343975
+180184,Donny,van de Beek,Van de Beek,275035
+180294,Karlan,Grant,Grant,244568
+180736,Trevoh,Chalobah,Chalobah,353292
+180804,Axel,Tuanzebe,Tuanzebe,299271
+180974,Joelinton Cássio,Apolinário de Lira,Joelinton,201755
+181008,Albian,Ajeti,Ajeti,143693
+181284,Gonçalo Manuel,Ganchinho Guedes,Guedes,247995
+181397,Jamie,Sterry,Sterry,276986
+181489,Alex,Pike,Pike,284123
+181911,Kyle,Scott,Scott,342565
+182156,Leroy,Sané,Sané,144711
+182436,Ben,Woodburn,Woodburn,330818
+182539,Daniel,Ceballos Fernández,Ceballos,144890
+182960,Pau,López Sabata,Pau López,145427
+183015,Cedric,Kipre,Kipre,361329
+183487,Nathan,Holland,Holland,336237
+183656,Josh,Dasilva,Dasilva,318744
+183751,Manuel,Benson Hedilazio,Benson,400244
+184029,Martin,Ødegaard,Ødegaard,247454
+184193,Jordan,Smith,Smith,322566
+184254,Guglielmo,Vicario,Vicario,147863
+184259,Richard,Nartey,Nartey,382369
+184341,Mason,Mount,Mount,343346
+184349,Ryan,Sessegnon,Sessegnon,322611
+184386,James,Bree,Bree,148474
+184667,Victor,Lindelöf,Lindelöf,100008
+184704,Marvelous,Nakamba,Nakamba,243249
+184754,Hwang,Hee-chan,Hee Chan,262854
+185056,Mateusz,Hewelt,Hewelt,329677
+185253,Gustavo Henrique,Furtado Scarpa,G.Scarpa,149738
+185431,Ali,Gabr,Gabr,333025
+185478,Jarosław,Jach,Jach,339499
+189627,Dimitris,Giannoulis,Giannoulis,296838
+191769,Jonathan,Benteke,Jonathan Benteke,326414
+191866,Kristoffer,Ajer,Ajer,321085
+192182,Kieran,O'Hara,O'Hara,295133
+192290,Connor,Roberts,Roberts,135865
+192301,Jon Gorenc,Stankovic,Stankovic,254128
+192303,Christoph,Zimmermann,Zimmermann,228569
+192895,Kieran,Tierney,Tierney,297403
+193109,Callum,Slattery,Slattery,368415
+193111,Todd,Cantwell,Cantwell,346738
+193195,Allan,Campbell,Campbell,397153
+193204,Joe,Aribo,Aribo,342877
+193488,Anwar,El Ghazi,El Ghazi,232261
+193645,Robin,Koch,Koch,276205
+194010,Rico,Henry,Henry,229562
+194126,Michael,Verrips,Verrips,298805
+194164,Mason,Holgate,Holgate,297544
+194190,Harry,Souttar,Souttar,344380
+194252,Steven,Bergwijn,Bergwijn,279425
+194401,Adalberto,Peñaranda,Peñaranda,300438
+194634,Diogo,Teixeira da Silva,Diogo J.,235755
+194794,Fikayo,Tomori,Tomori,317507
+194798,Bernard,Ashley-Seal,Ashley-Seal,363974
+194799,Jamal,Lewis,Lewis,350138
+195064,Mace,Goodridge,Goodridge,389088
+195384,Mikel,Merino Zazón,Merino,238916
+195471,Anthony,Driscoll-Glennon,Driscoll-Glennon,373461
+195473,Rhian,Brewster,Brewster,336285
+195480,Josh,Maja,Maja,325156
+195546,Emiliano,Buendía Stati,Buendía,260592
+195728,Alex,Kral,Kral,369861
+195735,Nicolas,Pépé,Pepe,239872
+195774,Gedson,Carvalho Fernandes,Fernandes,361726
+195851,Scott,McTominay,McTominay,336915
+195855,Beni,Baningime,Baningime,347436
+195859,Marcus,Browne,Browne,303387
+195860,Joe,Powell,Powell,364017
+195864,Sam,Field,Field,317243
+195899,Gianluca,Scamacca,Scamacca,302650
+196100,Gustavo,Hamer,Hamer,332143
+196118,Yoshinori,Muto,Muto,132210
+196411,Conor,Chaplin,Chaplin,256129
+197024,Guido,Rodríguez,G.Rodriguez,303876
+197030,Aboubakar,Kamara,Kamara,243076
+197365,Eric,Bailly,Bailly,243814
+197464,Nathaniel,Phillips,N.Phillips,381527
+197469,Hamza,Choudhury,Choudhury,312670
+197937,Oliver,Burke,Burke,244303
+198044,Harry,Lewis,Lewis,329820
+198501,Sead,Haksabanovic,Haksabanovic,330545
+198504,Kazaiah,Sterling,Sterling,349567
+198826,Ben,Godfrey,Godfrey,287504
+198842,Connor,Ronan,Ronan,294524
+198847,Bright,Enobakhare,Enobakhare,294003
+198849,Lucas,Torreira di Pascua,Torreira,248109
+198869,Benjamin,White,White,322036
+199056,Gabriel,Osho,Osho,366080
+199170,Moussa,Niakhaté,Niakhaté,296319
+199249,Sergio,Reguilón,Reguilón,362275
+199404,Tashan,Oakley-Boothe,Oakley-Boothe,344695
+199583,Dujon,Sterling,Sterling,345846
+199584,Japhet,Tanganga,Tanganga,384063
+199598,Ethan,Ampadu,Ampadu,322418
+199670,Odsonne,Édouard,Édouard,317504
+199796,Matty,Cash,Cash,322043
+199798,Ezri,Konsa Ngoyo,Konsa,301440
+199806,Dion,Henry,Henry,249848
+200088,Daniel,N'Lundulu,Nlundulu,382519
+200089,Joe,Willock,Willock,342563
+200370,Matt,Butcher,Butcher,300771
+200402,Nélson,Cabral Semedo,N.Semedo,296363
+200439,Che,Adams,Adams,256419
+200455,Julien,Ngoy,Ngoy,323564
+200600,Daniel,Castelo Podence,Podence,300513
+200617,Daniel,James,James,302313
+200641,Reiss,Nelson,Nelson,342564
+200720,Caoimhín,Kelleher,Kelleher,322176
+200785,Tyler,Adams,Adams,315275
+200826,Giovani,Lo Celso,Lo Celso,303908
+200834,Nordi,Mukiele,Mukiele,299077
+200878,Filip,Krovinovic,Krovinovic,322579
+200884,Tyrese,Campbell,Campbell,353665
+201057,Thilo,Kehrer,Kehrer,255167
+201084,Timothy,Fosu-Mensah,Fosu-Mensah,312739
+201410,Auston,Trusty,Trusty,298687
+201440,Hwang,Ui-jo,Ui-jo,127571
+201595,Lucas Estella,Perri,Perri,307564
+201658,Marcus,Tavernier,Tavernier,344314
+201666,Harvey,Barnes,Barnes,331382
+201667,Josh,Knight,Knight,344317
+201895,Omar,Alderete,Alderete,344639
+202174,Greg,Luer,Luer,288783
+202641,André,Onana,Onana,260843
+202993,Rodrigo,Bentancur,Bentancur,303657
+203325,André-Frank,Zambo Anguissa,Anguissa,349561
+203341,Wilfred,Ndidi,Ndidi,327683
+203368,Frédéric,Guilbert,Guilbert,260493
+203389,Nathan,Tella,Tella,395472
+204043,Arthur Henrique,Ramos de Oliveira Melo,Arthur,284114
+204120,Olivier,Boscagli,Boscagli,260809
+204214,Pervis,Estupiñán Tenorio,Estupiñan,298694
+204216,Keshi,Anderson,Anderson,297165
+204380,Juninho,Bacuna,Bacuna,261143
+204454,Isaac,Mbenza,Mbenza,296317
+204480,Declan,Rice,Rice,332325
+204481,Tyreke,Johnson,Johnson,367927
+204580,Vitaly,Janelt,Janelt,298689
+204646,Donyell,Malen,Malen,351354
+204676,Andi,Zeqiri,Zeqiri,280621
+204716,Ibrahima,Konaté,Konaté,345957
+204727,Malang,Sarr,M.Sarr,322747
+204760,Michael,Folivi,Folivi,332416
+204814,Ben,Brereton Díaz,Brereton Díaz,332839
+204819,Elliot,Embleton,Embleton,332326
+204820,George,Marsh,Marsh,365589
+204863,Ryan,Manning,Manning,332402
+204936,Gianluigi,Donnarumma,Donnarumma,262515
+204968,Ryan,Yates,Yates,342830
+205102,Ramadan,Sobhi,Sobhi,260289
+205135,Samuel,Shashoua,Shashoua,338119
+205533,Eddie,Nketiah,Nketiah,345845
+205651,Gabriel,Fernando de Jesus,G.Jesus,279379
+205836,Saman,Ghoddos,Ghoddos,320575
+206325,Oleksandr,Zinchenko,Zinchenko,273257
+206915,Curtis,Jones,C.Jones,355354
+207189,Sander,Berge,Berge,321020
+207270,Daniel,Iversen,Iversen,339672
+207283,Mathias,Jensen,Jensen,339674
+207300,Mihai-Alexandru,Dobre,Dobre,362805
+207725,Daniel,Agyei,Agyei,275887
+208706,Bruno,Guimarães Rodriguez Moura,Bruno G.,338780
+208904,Mads Juel,Andersen,Andersen,379632
+208912,Joe,Worrall,Worrall,315714
+208973,Francisco,Sierralta,Sierralta,362761
+208987,Jeff,Reine-Adelaide,Reine-Adelaide,277239
+208998,Zeze Steven,Sessegnon,Sessegnon,342888
+209036,Marc,Guéhi,Guéhi,374631
+209037,Zech,Medley,Medley,365239
+209040,Timothy,Eyoma,Eyoma,365588
+209041,Angel,Gomes,Angel,338497
+209042,Oliver,Skipp,Skipp,364215
+209043,Nya,Kirby,Kirby,353696
+209045,Taylor,Richards,Richards,369230
+209046,Callum,Hudson-Odoi,Hudson-Odoi,350088
+209212,Thomas,Edwards,Edwards,333311
+209243,Jadon,Sancho,Sancho,346300
+209244,Phil,Foden,Foden,331254
+209288,Tom,McGill,McGill,391266
+209289,Emile,Smith Rowe,Smith Rowe,363686
+209293,Daiki,Hashioka,Hashioka,411101
+209353,Patrick,Cutrone,Cutrone,329681
+209362,Bernardo,Fernandes Da Silva Junior,Bernardo,302588
+209365,Matthijs,de Ligt,De Ligt,320374
+209400,Daichi,Kamada,Kamada,344166
+209411,Joe,Tupper,Tupper,369071
+209413,Jordi,Osei-Tutu,Osei-Tutu,347048
+209418,Tobi,Omole,Omole,425052
+209419,Max,Melbourne,Melbourne,349444
+209420,Joy,Mukena,Mukena,351777
+209925,Xande,Nascimento da Costa Silva,Xande Silva,323096
+210156,Taiwo,Awoniyi,Awoniyi,281049
+210207,Fousseni,Diabaté,Diabaté,332135
+210237,Marko,Grujic,Grujic,244779
+210407,Matheus,Pereira,Pereira,297389
+210462,Ibrahim,Sangaré,Sangaré,328075
+210494,Nayef,Aguerd,N.Aguerd,362434
+211975,Manuel,Akanji,Akanji,297390
+212314,Saša,Lukić,Lukić,297395
+212319,Richarlison,de Andrade,Richarlison,317804
+212325,Pierre,Lees-Melou,Lees-Melou,301243
+212701,Denis,Zakaria,Zakaria,252419
+212721,Lyanco,Silveira Neves Vojnovic,Lyanco,284115
+212723,Milot,Rashica,Rashica,289014
+213056,Tudor,Baluta,Baluta,363200
+213198,Christopher,Nkunku,Nkunku,300945
+213280,Jake,Eastwood,Eastwood,342494
+213345,Wesley,Moraes Ferreira da Silva,Wesley,328362
+213384,Josh,Clackstone,Clackstone,322595
+213405,Filip,Benkovic,Benkovic,296451
+213482,Yan,Valery,Valery,323791
+213687,Charlie,Goode,Goode,283345
+213999,Edson,Álvarez Velázquez,Álvarez,322696
+214048,Maximilian,Kilman,Kilman,368310
+214225,Joe,Rodon,Rodon,302312
+214285,Konstantinos,Tsimikas,Tsimikas,301455
+214466,Will,Smallbone,Smallbone,390036
+214470,Jake,Vokins,Vokins,386857
+214572,Brandon,Austin,Austin,386134
+214590,Aaron,Wan-Bissaka,Wan-Bissaka,331924
+214964,George,Edmundson,Edmundson,287300
+215059,Robert,Lynch Sánchez,Sánchez,362151
+215062,Max,Sanders,Sanders,354539
+215066,Alex,Cochrane,Cochrane,382374
+215136,Neco,Williams,N.Williams,386969
+215379,Elliot,Anderson,Anderson,402596
+215407,Alfie,Lewis,Lewis,320684
+215409,Cameron,John,John,369508
+215413,Kiernan,Dewsbury-Hall,Dewsbury-Hall,391256
+215439,Tomáš,Souček,Souček,143595
+215457,Kane,Wilson,Wilson,319889
+215460,Ian,Poveda-Ocampo,Poveda,369229
+215476,Joshua,Sargent,Sargent,367480
+215531,Ionuț,Radu,Radu,296723
+215610,Marcel,Lavinier,Lavinier,410514
+215711,Leon,Bailey,Bailey,327682
+215885,Michael,Phillips,Phillips,331515
+216051,Diogo,Dalot Teixeira,Dalot,353418
+216054,Rúben,Nascimento Vinagre,Vinagre,342863
+216055,Florentino Ibrain,Morris Luís,Florentino,369712
+216058,Domingos,Quina,Quina,331582
+216094,Jeremie,Frimpong,Frimpong,392644
+216183,Brahim,Diaz,Diaz,317541
+216208,Matija,Šarkić,Šarkić,331107
+216554,Sam,Hughes,Hughes,357025
+216616,Dara,O'Shea,O'Shea,362826
+216620,Marcus,Forss,Forss,362215
+216646,Yoane,Wissa,Wissa,296240
+217331,Sam,Surridge,Surridge,296870
+217401,Josh,Benson,Benson,369466
+217487,Mbwana Ally,Samatta,Samatta,327685
+217593,Pablo,Fornals Malla,P.Fornals,297203
+217989,Rafael,Camacho,Camacho,355358
+218023,Jimmy,Dunne,Dunne,366743
+218031,Çaglar,Söyüncü,Söyüncü,317998
+218112,Jason,Lokilo,Lokilo,343270
+218218,Wout,Faes,Faes,299693
+218328,Samuel,Chukwueze,Chukwueze,363665
+218364,Borna,Sosa,Sosa,270829
+218430,Gonzalo,Montiel,G.Montiel,316883
+218997,Ellis,Simms,Simms,396483
+219002,Dodi,Lukebakio,Lukebakio,299490
+219168,Alexander,Isak,Isak,299254
+219249,Matt,O'Riley,O'Riley,342889
+219265,Felix,Nmecha,Nmecha,367783
+219279,Sugawara,Yukinari,Sugawara,379783
+219291,Claudio,Gomes,Gomes,361434
+219352,Ademola,Lookman,Lookman,299451
+219727,Joel,Asoro,Asoro,322652
+219847,Kai,Havertz,Havertz,326413
+219924,Issa,Diop,Diop,300359
+219937,Rhys,Williams,R.Williams,401782
+219961,Raphael,Dias Belloli,Raphinha,300447
+220037,Bailey,Peacock-Farrell,Peacock-Farrell,300567
+220087,Maximilian,Wöber,Wöber,301024
+220166,Marc,Navarro,Navarro,280157
+220237,Sven,Botman,Botman,379732
+220307,Arnaut,Danjuma Groeneveld,Danjuma,323625
+220362,Axel,Disasi,Disasi,300426
+220394,Tommy,Doyle,Doyle,386856
+220566,Rodrigo 'Rodri',Hernandez Cascante,Rodrigo,303139
+220583,Luke,Woolfenden,Woolfenden,356599
+220585,Flynn,Downes,Downes,337428
+220598,Michael,Obafemi,Obafemi,351355
+220627,James,Justin,Justin,301441
+220650,Thibaud,Verlinden,Verlinden,329842
+220682,Arthur,Okonkwo,Okonkwo,411834
+220684,Aji,Alese,Alese,383538
+220686,Bali,Mumba,Mumba,356473
+220688,Mason,Greenwood,Greenwood,367782
+220693,Rayhaan,Tulloch,Tulloch,349750
+220695,Paris,Maghoma,Maghoma,399525
+220738,Jayson,Molumby,Molumby,344324
+221239,Keinan,Davis,Davis,303107
+221245,Levi,Lumeka,Lumeka,345336
+221267,Josh,Tymon,Tymon,303743
+221268,Ben,Hinchcliffe,Hinchcliffe,323442
+221271,Ben,Wynter,Wynter,333888
+221272,Sam,Woods,Woods,362820
+221275,Luke,Dreher,Dreher,316536
+221286,Charlie,Rowan,Rowan,332410
+221389,John Victor,Maciel Furtado,John,318689
+221399,Jack,Harrison,Harrison,317896
+221466,Marcos,Senesi Barón,Senesi,328330
+221568,Daniel,Kemp,Kemp,338500
+221610,Jamie,Shackleton,Shackleton,361787
+221632,Cristian,Romero,Romero,323663
+221820,Lisandro,Martínez,Martinez,340105
+222017,Conor,Coventry,Coventry,364018
+222018,Ben,Johnson,Johnson,349484
+222434,Jack,Simpson,Simpson,302862
+222531,Morgan,Gibbs-White,Gibbs-White,332867
+222564,Francisco,Machado Mota de Castro Trincão,Trincão,368409
+222625,George,Hirst,Hirst,317547
+222627,João,Neves Virgínia,J.Virginia,362852
+222677,Tahith,Chong,Chong,365244
+222683,Justin,Kluivert,Kluivert,331579
+222690,Tyrell,Malacia,Malacia,345303
+222694,Pascal,Struijk,Struijk,355609
+222786,Panagiotis,Retsos,Retsos,302402
+223081,Kristoffer,Klaesson,Klaesson,335718
+223094,Erling,Haaland,Haaland,315227
+223175,Matthew,Longstaff,M.Longstaff,382434
+223332,Faustino,Anjorin,Anjorin,384133
+223335,Sylvester,Jasper,Jasper,390213
+223336,Dan,Neil,Neil,399427
+223337,Jamie,Bowden,Bowden,410513
+223340,Bukayo,Saka,Saka,367185
+223349,Indiana,Vassilev,Vassilev,390215
+223434,Igor Julio,dos Santos de Paulo,Igor,382241
+223541,Federico,Chiesa,Chiesa,322971
+223723,Tomiyasu,Takehiro,Tomiyasu,377283
+223824,Reece,Hannam,Hannam,411070
+223827,Daniel,Ballard,Ballard,371761
+223911,Chris,Mepham,Mepham,342842
+224024,Lucas,Tolentino Coelho de Lima,L.Paquetá,319756
+224068,Matt,Turner,Turner,319712
+224117,Viktor,Gyökeres,Gyökeres,362815
+224209,Rasmus,Kristensen,Kristensen,302812
+224444,Ferran,Torres,Torres,349760
+224860,Carlos,Soler,C.Soler,313542
+224946,Matthew,Worthington,Worthington,338498
+224967,Vitalii,Mykolenko,Mykolenko,345516
+224995,Luis,Sinisterra Lucumí,Sinisterra,361879
+225000,Dion,Sanderson,Sanderson,384128
+225295,Mateus,Cardoso Lemos Martins,Tetê,387417
+225321,Aaron,Ramsdale,Ramsdale,316858
+225368,Meritan,Shabani,Shabani,354599
+225702,Samuel,Kalu,Kalu,312705
+225796,Reece,James,James,361330
+225897,Fodé,Ballo-Touré,Ballo-Touré,328968
+225902,Boubakary,Soumaré,B.Soumaré,345664
+226029,Lasse,Sorenson,Sorenson,355133
+226182,Jayden,Bogle,Bogle,354291
+226597,Gabriel,dos Santos Magalhães,Gabriel,334087
+226944,Boubacar,Kamara,Kamara,331790
+226956,Mads,Roerslev Rasmussen,Roerslev,329554
+227127,Yves,Bissouma,Bissouma,303096
+227444,Nikola,Milenković,Milenković,319785
+227560,Oghenekaro Peter,Etebo,Etebo,323669
+228044,Mads,Bech Sørensen,Bech,346304
+228286,Edouard,Mendy,Mendy,321390
+228798,Cengiz,Ünder,Ünder,255071
+229164,Chiedozie,Ogbene,Ogbene,352908
+229384,Andy,Irving,Irving,451945
+229600,Mark,Travers,Travers,362806
+230001,Noussair,Mazraoui,Mazraoui,349932
+230046,Douglas Luiz,Soares de Paulo,Douglas Luiz,337883
+230127,Percy,Tau,Tau,229654
+230251,Emmanuel,Dennis,Dennis,329811
+230348,Ross,Stewart,Stewart,397143
+230376,Jhon,Arias,J.Arias,424039
+230428,Philippe,Sandler,Sandler,321959
+231057,Jean-Ricner,Bellegarde,Bellegarde,320242
+231065,Ethan,Pinnock,Pinnock,342499
+231172,Brandon,Mason,Mason,332411
+231372,Tanguy,Ndombélé Alvaro,Ndombele,321389
+231416,Ferdi,Kadıoğlu,F.Kadıoğlu,321958
+231480,Santiago,Ignacio Bueno,S.Bueno,444241
+231747,Jean-Philippe,Mateta,Mateta,328096
+231899,Jack,Taylor,Taylor,323713
+232112,Manuel,Ugarte Ribeiro,Ugarte,408962
+232185,Ismaïla,Sarr,Sarr,322670
+232223,Folarin,Balogun,Balogun,384065
+232228,Harry,Clarke,H.Clarke,404080
+232229,Vontae,Daley-Campbell,Daley-Campbell,409879
+232233,Tyreece,John-Jules,John-Jules,367184
+232241,Matthew,Smith,Smith,395690
+232245,Zak,Swanson,Swanson,433403
+232247,Dominic,Thompson,Thompson,381114
+232351,Ryan,Giles,Giles,362831
+232356,Jenson,Jones,Jenson Jones,581394
+232361,Taylor,Perry,Perry,384129
+232391,Jeremy,Ngakia,Ngakia,390700
+232398,Nathan,Trott,Trott,349485
+232413,Eberechi,Eze,Eze,332403
+232423,Nathan,Ferguson,Ferguson,349891
+232427,Rekeem,Harper,Harper,331928
+232456,Dilan,Markanday,Markanday,410796
+232571,Anthony,Patterson,Patterson,382438
+232620,Lewis,Brunt,Brunt,429681
+232653,Jacob,Ramsey,J.Ramsey,369813
+232667,Akin,Famewo,Famewo,322465
+232787,Conor,Gallagher,Gallagher,375621
+232792,Tariq,Lamptey,Lamptey,386979
+232797,Kayne,Ramsay,Ramsay,368253
+232826,Anthony,Gordon,Gordon,349669
+232829,Kyle,John,John,411125
+232859,Djed,Spence,Spence,362219
+232881,Thakgalo,Leshabela,Leshabela,367151
+232892,Calvin,Bassey,Bassey,396976
+232917,Arijanet,Muric,Muric,362426
+232928,James,Garner,Garner,367781
+232937,Brandon,Williams,B.Williams,384143
+232957,Thomas,Allan,Allan,390202
+232960,Lewis,Cass,Cass,374629
+232964,Lewis,Gibson,Gibson,391026
+232977,Kell,Watts,Watts,374630
+232979,Jack,Young,Young,396048
+232980,Max,Aarons,Aarons,362103
+233420,Renan Augusto,Lodi dos Santos,Renan Lodi,326646
+233425,Aaron,Connolly,Connolly,344325
+233489,Leighton,Clarkson,Clarkson,384123
+233497,Adama,Diakhaby,Diakhaby,322750
+233821,Anel,Ahmedhodžić,Ahmedhodžić,326642
+233849,Archie,Mair,Mair,384632
+233963,Konstantinos,Mavropanos,Mavropanos,351127
+234370,Marc,Roca Junqué,Roca,323148
+234483,Aiden,O'Neill,O'Neill,323097
+234720,Giovanni,McGregor,McGregor,362821
+234908,Juan,Foyth,Foyth,335107
+235382,Steven,Alzate,Alzate,362146
+235448,Ellery,Balcombe,Balcombe,329831
+235449,George,Wickens,Wickens,476060
+235530,Lloyd,Kelly,Kelly,332419
+235546,Jacob,Sørensen,Sørensen,404572
+235599,Nikola,Tavares,Tavares,374634
+235640,Harry,Boyes,Boyes,416026
+235674,Manor,Solomon,Solomon,345022
+235826,Joël,Piroe,Piroe,369542
+240143,Ibrahima,Diallo,Diallo,357101
+240299,Joe,Hodge,Hodge,443578
+240499,Daniel,Batty,Batty,338495
+240514,Kjell,Scherpen,Scherpen,361867
+240796,Álvaro,Fernández,Fernández,328315
+241157,Emerson,Leite de Souza Junior,E.Royal,328512
+241231,Jordan,Beyer,Jordan,353412
+241289,Ben,Wilmot,Wilmot,362851
+241519,Weston,McKennie,McKennie,338275
+241791,Ryan,Schofield,Schofield,362817
+242058,Moise,Kean,Kean,328990
+242166,Mattéo,Guendouzi,Guendouzi,328983
+242183,James,Morris,Morris,425565
+242453,Jacob,Brown,Brown,329328
+242510,Louie,Moulden,Moulden,425600
+242880,Benoît,Badiashile Mukinayi,B.Badiashile,365406
+242882,Bafodé,Diakité,Diakité,366875
+242885,Loïc,Mbe Soh,Mbe Soh,373555
+242898,Brennan,Johnson,Johnson,379688
+243016,Alexis,Mac Allister,Mac Allister,345319
+243298,Cody,Gakpo,Gakpo,352825
+243343,Jake,Cain,Cain,391820
+243345,Lewis,O'Brien,O'Brien,366083
+243505,Jakub,Moder,Moder,399378
+243526,Gabriel,Gudmundsson,Gudmundsson,330549
+243531,Andrew,Eleftheriou,Eleftheriou,331089
+243532,Dion,Pereira,Pereira,335753
+243557,Moussa,Diaby,Diaby,353397
+243568,Billy,Gilmour,Gilmour,381255
+243571,Nathan,Patterson,Patterson,396975
+243710,Bernardo,Costa Da Rosa,Rosa,390701
+244042,Rodrigo,Muniz Carvalho,Muniz,403649
+244085,Siriki,Dembélé,Siriki,342868
+244262,Alfie,Doughty,Doughty,362246
+244560,Romain,Perraud,Perraud,331466
+244619,Luke,Thomas,Thomas,396317
+244704,Matías,Viña,Viña,397846
+244716,Juan Camilo,Hernández Suárez,Cucho,362501
+244723,Tyrick,Mitchell,Mitchell,389579
+244731,Luis,Díaz Marulanda,Luis Díaz,377168
+244845,Nathan,Wood-Gordon,Wood,361334
+244848,Teddy,Jenks,Jenks,384135
+244850,Morgan,Rogers,Rogers,362824
+244851,Cole,Palmer,Palmer,395692
+244856,Teden,Mengi,Mengi,388671
+244858,Fábio,Freitas Gouveia Carvalho,Carvalho,401385
+244930,Alex,Mighten,Mighten,381101
+244932,Ben,Knight,Knight,421976
+244954,Pau,Torres,Pau,344259
+245414,Nicolò,Zaniolo,Zaniolo,332398
+245419,Patson,Daka,Daka,345560
+245719,Taylor,Harwood-Bellis,Harwood-Bellis,384061
+245824,Carlos Vinícius,Alves Morais,Vinicius,363077
+245923,Luke,Cundle,Cundle,384130
+246301,Jorge,Cuenca Barreno,J.Cuenca,333182
+246878,Abdelhamid,Sabiri,Sabiri,333255
+247245,Hannes,Delcroix,Delcroix,367189
+247286,Kyle,Jameson,Jameson,351683
+247348,Daniel,Muñoz Mejía,Muñoz,400496
+247412,Jørgen,Strand Larsen,Strand Larsen,333048
+247632,Pedro,Lomba Neto,Neto,337916
+247664,Terry,Ablade,Ablade,426328
+247670,Valentín,Castellanos,Taty,361406
+247693,Randal,Kolo Muani,Kolo Muani,333542
+247955,Lutsharel,Geertruida,Geertruida,345441
+248056,Tanaka,Ao,Tanaka,423347
+248164,Viljami,Sinisalo,Sinisalo,406444
+248853,Dynel,Simeu,Simeu,397467
+248854,Josh,Brooking,Brooking,467970
+248857,Noni,Madueke,Madueke,389935
+248859,Amadou,Diallo,Diallo,444998
+248865,Armstrong,Oko-Flex,Oko-Flex,409111
+248875,Jérémy,Doku,Doku,388098
+248937,Sam,Greenwood,Greenwood,409078
+249231,Keane,Lewis-Potter,Lewis-Potter,368512
+250199,Nicolás,Domínguez,Dominguez,334653
+250370,Nathan,Bishop,Bishop,362214
+250604,Owen,Otasowie,Otasowie,388673
+421796,Sidnei,Tavares,Tavares,410174
+422287,Kofi,Balmer,Balmer,403113
+422303,John,McAtee,McAtee,381124
+422306,Will,Ferry,Ferry,395960
+422612,Ryan,Astley,Astley,411124
+423649,Enock,Mwepu,Mwepu,353191
+424001,Vini,de Souza Costa,Vini Souza,373964
+424044,Hamed,Traorè,H.Traorè,362551
+424876,Dominik,Szoboszlai,Szoboszlai,369875
+427420,Giovanni,Reyna,Reyna,389087
+427623,Chris,Richards,Richards,395401
+427637,Brenden,Aaronson,Aaronson,371012
+428399,João,Félix Sequeira,João Félix,362431
+428580,Frank,Onyeka,Onyeka,404109
+428610,Bruno,Cavaco Jordão,Jordão,346000
+428626,Przemyslaw,Placheta,Placheta,377190
+428971,Steven,Benda,Benda,362371
+429414,Saša,Kalajdžić,Kalajdžić,377271
+430367,Joel,Mumbongo,Mumbongo,341419
+430871,Matheus,Santos Carneiro da Cunha,Cunha,362758
+430992,Owen,Beck,Beck,424814
+431019,Karlo,Ziger,Ziger,404602
+431131,Moussa,Djenepo,Djenepo,363676
+431248,Ladislav,Krejcí,Krejčí,404245
+431639,Zian,Flemming,Flemming,361694
+431774,Kyle,Taylor,Taylor,351320
+431924,Daniel,Adshead,Adshead,344381
+432160,Shandon,Baptiste,Baptiste,362124
+432422,Sandro,Tonali,Tonali,343501
+432656,Eric,Garcia,Garcia,368091
+432705,James,Daly,Daly,355373
+432711,CJ,Egan-Riley,Egan-Riley,425574
+432712,Owen,Hesketh,Hesketh,484870
+432714,James,McAtee,McAtee,425576
+432720,James,Trafford,Trafford,404852
+432735,Adam,Idah,Idah,382368
+432793,Abd-Al-Ali Morakinyo Olaposi,Koiki,Koiki,368210
+432830,Nathan,Collins,Collins,372724
+432927,Daniel,Langley,Langley,408004
+432931,Tyrese,Francois,Francois,382367
+432987,Vítezslav,Jaros,Jaros,391831
+432990,Yasser,Larouci,Larouci,386971
+433019,Liam,Hughes,Hughes,409388
+433036,Tijjani,Reijnders,Reijnders,343382
+433138,Marc,Leonard,Leonard,423719
+433154,Dwight,McNeil,McNeil,357427
+433312,Marshall,Munetsi,Munetsi,377411
+433589,Haydon,Roberts,Roberts,382375
+433590,Cody,Drameh,Drameh,414473
+433952,Largie,Ramazani,Ramazani,447229
+433979,Cameron,Archer,Archer,382363
+434024,Patrik,Gunnarsson,Gunnarsson,370992
+434043,Alex,Robertson,Robertson,421238
+434044,Cieran,Slicker,Slicker,425320
+434399,Reinildo,Mandava,Reinildo,361812
+434662,Halil,Dervişoğlu,Dervişoğlu,357083
+434752,Jaka,Bijol,Bijol,360941
+435973,Lyle,Foster,Foster,371447
+435997,Noah,Okafor,Okafor,376090
+436234,Bryan,Gil Salvatierra,Bryan,368519
+436416,Christos,Mandas,Mandas,418171
+436680,Jakub,Stolarczyk,Stolarczyk,407587
+436893,Julián,Araujo Zúñiga,J.Araujo,371039
+437468,Sergio,Gómez,Sergio Gómez,355110
+437495,Illan,Meslier,Meslier,380580
+437499,Maxence,Lacroix,Lacroix,401130
+437505,Wilson,Isidor,Isidor,363535
+437626,Nuno,Varela Tavares,Tavares,379790
+437688,Lewis,Richards,Richards,386974
+437730,Antoine,Semenyo,Semenyo,357073
+437738,Sebastiaan,Bornauw,Bornauw,364235
+437742,Albert,Sambi Lokonga,Sambi,349102
+437748,Mike,Trésor Ndayishimiye,Trésor,383581
+437753,Giulian,Biancone,Biancone,367162
+437757,Han-Noah,Massengo,Massengo,365831
+437858,Vitor,Ferreira,Vitinha,384887
+438098,Fábio,Ferreira Vieira,Fábio Vieira,394924
+438234,Omar,Marmoush,Marmoush,394749
+438277,Ozan,Kabak,Kabak,356743
+438405,Billy,Crellin,Crellin,381103
+438464,Cheick,Doucouré,Doucouré,374993
+439135,Eiran,Cashin,Cashin,414168
+439242,Taylor,Gardner-Hickman,Gardner-Hickman,415368
+439482,Miguel,Azeez,Azeez,407112
+439483,Hubert,Graczyk,Graczyk,467915
+439485,Josh,Martin,Martin,391268
+439509,Christos,Tzolis,Tzolis,399296
+439510,Luke,Mbete-Tabu,Mbete,408822
+440089,Mikkel,Damsgaard,Damsgaard,401168
+440113,Aaron,Rowe,Rowe,371276
+440120,Daniel,Chesters,Chesters,426831
+440123,James,Furlong,Furlong,423723
+440148,Tyler,Morton,Morton,425568
+440241,Jensen,Weir,Weir,362189
+440323,Armando,Broja,Broja,393407
+440854,Jakub,Kiwior,Kiwior,424462
+440993,Iliman,Ndiaye,Ndiaye,366116
+441024,Harrison,Ashby,Ashby,400604
+441164,Pedro,Porro Sauceda,Pedro Porro,362352
+441191,Tino,Livramento,Livramento,415174
+441192,Jeremy,Sarmiento Morante,Sarmiento,425603
+441240,Romain,Faivre,Faivre,349368
+441264,Brian,Brobbey,Brobbey,404568
+441266,Ryan,Gravenberch,Gravenberch,363884
+441271,Ki-Jana,Hoever,Hoever,368547
+441302,Ian,Maatsen,Maatsen,384134
+441428,Jarell,Quansah,Quansah,430019
+441455,Victor,da Silva,Vitinho,349504
+442229,Michał,Karbownik,Karbownik,399379
+442335,Edo,Kayembe,Kayembe,363718
+443211,Rhys,Norrington-Davies,Norrington-Davies,361752
+443261,Jack,Clarke,J.Clarke,363516
+443296,Theo,Corbeanu,Corbeanu,408423
+443629,Marcelo,de Araújo Pitaluga Filho,Pitaluga,389027
+443661,Michael,Olise,Olise,371281
+443967,Junior,Firpo Adames,Firpo,351252
+444102,Francisco Evanilson,de Lima Barbosa,Evanilson,384430
+444145,Gabriel,Martinelli Silva,Martinelli,380706
+444172,Will,Dennis,Dennis,384131
+444180,Jaidon,Anthony,Anthony,400610
+444181,Nnamdi,Ofoborh,Ofoborh,362807
+444183,Gavin,Kilkenny,Kilkenny,382442
+444253,Jordan,Thomas,Thomas,395835
+444463,Wesley,Fofana,Fofana,373946
+444575,Toby,King,King,416042
+444765,Sepp,van den Berg,Van den Berg,351705
+444880,Mika,Biereth,Biereth,430909
+444884,Harvey,Elliott,Elliott,363982
+445044,Dejan,Kulusevski,Kulusevski,355855
+445122,Jurriën,Timber,J.Timber,388650
+445548,Odeluga,Offiah,Offiah,423721
+445550,Thomas,Dickson-Peters,Dickson-Peters,406950
+445896,Kgaogelo,Chauke,Chauke,408859
+446008,Bryan,Mbeumo,Mbeumo,353377
+446189,Matej,Kovár,Kovár,388668
+446281,Tony,Springett,Springett,435986
+447093,Allan,Tchaptchet,Tchaptchet,409246
+447107,Ethan,Wady,Wady,460643
+447203,Darwin,Núñez Ribeiro,Darwin,400828
+447235,Troy,Parrott,Parrott,384064
+447261,Mackenzie,Hunt,Hunt,450748
+447325,Harry,Tyrer,Tyrer,410179
+447372,Ryan,Finnigan,Finnigan,409323
+447373,Shane,Flynn,Flynn,407586
+447715,Aaron,Ramsey,A.Ramsey,423732
+447720,Imari,Samuels,Samuels,399475
+447879,Joseph,Anang,Anang,390006
+447880,Josh,Wilson-Esbrand,Wilson-Esbrand,425406
+447932,Jordan,Zemura,Zemura,400609
+448047,Enzo,Fernández,Enzo,369430
+448089,João Victor,Gomes da Silva,J.Gomes,403693
+448104,Piero,Hincapié,Hincapie,404832
+448482,Robert,Street,Street,422721
+448487,Andreas,Söndergaard,Söndergaard,389362
+448496,Ed,Turns,Turns,425602
+448514,Rayan,Aït-Nouri,Aït-Nouri,355401
+448791,Harvey,White,White,395511
+449027,Giorgi,Mamardashvili,Mamardashvili,401633
+449133,Harvey,Griffiths,Griffiths,443579
+449429,Jacob,Greaves,Greaves,381161
+449434,Anthony,Elanga,Elanga,413211
+449444,Mazeed,Ogungbo,Ogungbo,436287
+449781,Alexandre,Jankewitz,Jankewitz,395769
+449871,Amadou,Onana,Onana,400815
+449926,Adrián,Bernabé,Bernabé,363978
+449974,Lukas,Jensen,Jensen,395617
+449988,Fábio,Soares Silva,Fábio Silva,380655
+450070,Crysencio,Summerville,Summerville,382564
+450197,George,Shelvey,G.Shelvey,390265
+450314,Matthew,Daly,Daly,370989
+450434,Deniz,Undav,Undav,357091
+450527,Mohammed,Salisu,Salisu,362357
+450529,Lewis,Bate,Bate,396114
+450535,Malcolm,Ebiowei,Ebiowei,431867
+450539,Myles,Peart-Harris,Peart-Harris,423730
+450541,Luke,Plange,Plange,429310
+450542,Jesurun,Rak-Sakyi,J.Rak-Sakyi,413291
+450544,Charlie,Patino,Patino,430270
+450550,Fin,Stevens,Stevens,399526
+450553,Alex,Kirk,Kirk,437776
+451302,Altay,Bayındır,Bayindir,361707
+451310,Jonathan,Tomkinson,Tomkinson,429651
+451340,Mitoma,Kaoru,Mitoma,425142
+454667,Jens,Cajuste,Cajuste,404108
+455084,Leif,Davis,Davis,366211
+456350,Gavin,Bazunu,Bazunu,384868
+456512,Dan,Ndoye,Ndoye,398414
+456966,Caleb,Watts,Watts,409245
+457569,Đorđe,Petrović,Petrović,406564
+458249,Joshua,Zirkzee,Zirkzee,383956
+458297,Pierre,Ekwah Elimby,Ekwah,431184
+459373,Gonçalo Bento,Soares Cardoso,Cardoso,363057
+460028,Levi,Samuels Colwill,Colwill,421351
+460029,Nathan,Young-Coombes,Young-Coombes,429388
+460842,Mohammed,Kudus,Kudus,400166
+461012,Cameron,Plain,Plain,462130
+461013,Euan,Pollock,Pollock,471873
+461017,Christian,Saydee,Saydee,388716
+461023,Ryan,Alebiosu,Alebiosu,431521
+461025,Nathan,Butler-Oyedeji,Butler-Oyedeji,467919
+461026,Chem,Campbell,Campbell,386973
+461080,Joseph,McGlynn,McGlynn,430746
+461096,Lewis,Richardson,Richardson,382437
+461102,Bobby,Thomas,Thomas,395615
+461188,Bashir,Humphreys,Humphreys,467968
+461195,Dennis,Cirkin,Cirkin,390876
+461199,Romaine,Mundle,Mundle,450254
+461201,Matthew,Craig,Craig,437758
+461212,Nile,John,John,410795
+461358,Julián,Álvarez,J.Alvarez,365409
+461382,John-Kymani,Gordon,Gordon,396485
+461416,Tom,Cannon,Cannon,463991
+461421,Lewis,Dobbin,Dobbin,425711
+461446,Tyler,Onyango,Onyango,409497
+461450,Max,Thompson,Thompson,395616
+461453,Lewis,Warrington,Warrington,432082
+461484,Joe,White,White,425059
+461508,Lucas,De Bolle,De Bolle,432569
+461529,Charlie,Savage,Savage,429512
+461533,Ademipo,Odubeko,Odubeko,409116
+461537,Dermot,Mee,Mee,439471
+461548,Zidane,Iqbal,Iqbal,429514
+461558,Maxwell,Haygarth,Haygarth,408006
+461566,William,Fish,Fish,413631
+461567,Owen,Dodgson,Dodgson,423378
+461584,Wanya,Marçal-Madivádua,Marcal,427133
+461585,Tawanda,Maswanhise,Maswanhise,415595
+461587,Kasey,McAteer,McAteer,429531
+461682,Brandon,Aguilera Zamora,B.Aguilera,447270
+462116,Jean-Clair,Todibo,Todibo,361710
+462381,Filip,Marschall,Marschall,429724
+462384,Jamal,Baptiste,Baptiste,409114
+462387,Ali,Al-Hamadi,Al-Hamadi,429636
+462424,William,Saliba,Saliba,361822
+462438,Micah,Hamilton,Hamilton,450769
+462491,Luke,Chambers,Chambers,444539
+462492,Joe,Gauci,Gauci,476543
+462635,Joe,Gelhardt,Gelhardt,362192
+462831,Scott,Banks,Banks,422722
+463034,Liam,Delap,Delap,401254
+463067,Georginio,Rutter,Georginio,362433
+463210,Shea,Charles,Charles,428060
+463212,Carlos Roberto,Forbs Borges,Forbs,468850
+463748,Karl,Hein,Hein,399501
+463903,Jesper,Lindstrøm,Lindstrøm,403646
+463912,Elia,Caprile,Caprile,362780
+463936,Jamie,Bynoe-Gittens,Gittens,436425
+463981,James,Hill,Hill,362837
+464353,Harvey,Davies,Davies,411519
+464618,Liam,McCarron,McCarron,366056
+465247,Senne,Lammens,Lammens,402184
+465299,Anthony,Mancini,Mancini,363847
+465351,Matheus,Nunes,Matheus N.,394933
+465390,Kaine,Kesler-Hayden,Kesler-Hayden,411201
+465527,Hannibal,Mejbri,Hannibal,416207
+465551,Nigel,Lonwijk,Lonwijk,409128
+465572,Reda,Khadra,Khadra,409093
+465607,Anssumane,Fati Vieira,Ansu Fati,382234
+465642,Malick,Thiaw,Thiaw,393355
+465680,Arnaud,Kalimuendo,Kalimuendo,384005
+465694,Nico,González Iglesias,N.Gonzalez,422939
+465730,Maxim,De Cuyper,De Cuyper,392647
+465920,Mykhailo,Mudryk,Mudryk,409376
+466052,Rayan,Cherki,Cherki,386153
+466075,Riccardo,Calafiori,Calafiori,386519
+466117,Naouirou,Ahamada,Ahamada,409440
+466404,Andrew,Omobamidele,Omobamidele,399490
+466525,Anton,Stach,Stach,401073
+466955,Brandon,Pierrick,Pierrick,389912
+467114,Oliver,Casey,Casey,389078
+467169,Antony,dos Santos,Antony,364315
+467189,Mads,Hermansen,Hermansen,409426
+467779,Mats,Wieffer,Wieffer,445059
+468243,Kamil,Conteh,Conteh,430392
+469130,Lorenzo,Lucca,Lucca,424819
+469142,Jan Paul,van Hecke,Van Hecke,365402
+469247,Samuel,Iling-Junior,Iling Jr,438894
+469249,Nohan,Kenneh,Kenneh,425381
+469272,Loum,Tchaouna,Tchaouna,425118
+470255,Caleb,Taylor,Taylor,415367
+470294,Darko,Gyabi,Gyabi,443569
+470296,Jeremiah,Chilokoa-Mullen,Chilokoa-Mullen,474334
+470313,Nick,Woltemade,Woltemade,386606
+470315,Luca,Netz,Netz,394888
+471471,Imrân,Louza,Louza,367217
+471798,Gabriel,Słonina,Slonina,396247
+471848,Femi,Seriki,Seriki,416027
+472464,Shola,Shoretire,Shoretire,410512
+472713,Aaron,Hickey,Hickey,402367
+472739,Carl,Rushworth,Rushworth,421944
+472769,Nico,O'Reilly,O'Reilly,468847
+473341,Caleb,Okoli,Okoli,368312
+473342,Stuart,McKinstry,McKinstry,425382
+474003,Leonardo,Campana,Campana,392650
+474120,Julio,Enciso Espínola,Enciso,417747
+474772,Ben,Greenwood,Greenwood,450534
+474803,Eddie,Beach,Beach,467967
+474907,Reece,Welch,Welch,413423
+474908,Jadan,Raymond,Raymond,484871
+475123,Carlos Miguel,dos Santos Pereira,C.Miguel,442459
+475168,João Pedro,Junqueira de Jesus,João Pedro,373525
+475480,Benicio,Baker-Boaitey,Baker-Boaitey,492543
+475492,Oliver,Hammond,Hammond,423729
+476161,Lewis,Payne,Payne,454752
+476344,Jhon,Durán,Duran,433517
+476369,Issa,Kaboré,Kaboré,399955
+476502,Boubacar,Traoré,B.Traore,386612
+476887,Dilane,Bakwa,Bakwa,402130
+476888,Sékou,Mara,Mara,402855
+476938,Ismaila,Coulibaly,Coulibaly,372400
+477064,Rico,Lewis,Lewis,444791
+477386,Armel,Bella-Kotchap,Bella-Kotchap,369970
+477424,Joško,Gvardiol,Gvardiol,402664
+477547,Leo Fuhr,Hjelde,Hjelde,409110
+477555,Oscar,Bobb,Bobb,430709
+477580,Illia,Zabarnyi,Zabarnyi,399826
+477717,Maxime,Estève,Estève,414233
+477733,Radek,Vítek,Vítek,456623
+478028,Kayky da Silva,Chagas,Kayky,416803
+478227,Stefan,Parkes,Parkes,459061
+478449,Kyron,Gordon,Gordon,409014
+478912,Carney,Chukwuemeka,Chukwuemeka,410639
+478969,Hjalmar,Ekdal,Ekdal,399619
+479641,Sebastian,Revan,Revan,427614
+479683,Marcus,Oliveira Alencar,Marquinhos,419077
+480216,Mateusz,Bogusz,Bogusz,373457
+480455,Jarrad,Branthwaite,Branthwaite,381045
+480818,Billy,Koumetio,Koumetio,386970
+481283,James,Wright,Wright,478019
+481371,Zak,Brunt,Brunt,400732
+481405,Mads,Bidstrup,Bidstrup,410457
+481510,Victor,Kristiansen,Kristiansen,416970
+481624,Jaden,Philogene,Jaden,411335
+481626,Christian,Marques,Marques,397328
+481655,Martín,Zubimendi Ibáñez,Zubimendi,372424
+482158,Lucas,Bergström,Bergström,424586
+482442,Pape Matar,Sarr,P.M.Sarr,403859
+482609,Malo,Gusto,Gusto,403850
+482769,Máximo,Perrone,Perrone,433972
+482973,Igor Jesus,Maciel da Cruz,Igor Jesus,397497
+483081,Rodrigo,Martins Gomes,R.Gomes,402823
+483364,Krisztián,Hegyi,Hegyi,424270
+483365,Jonathan,Rowe,Rowe,429723
+483398,Matthew,Whittingham,Whittingham,510857
+484420,Enzo,Le Fée,E.Le Fée,398393
+485047,Felipe,Rodrigues da Silva,Morato,376916
+485055,Antonín,Kinský,Kinsky,457006
+485337,Evann,Guessand,Guessand,382587
+485711,Benjamin,Sesko,Šeško,424191
+486385,Norberto Bercique,Gomes Betuncal,Beto,380546
+486520,Ilia,Gruev,Gruev,382590
+486623,Sean,McAllister,McAllister,482358
+486672,Moisés,Caicedo Corozo,Caicedo,410175
+486870,Frederik,Alves,Alves,409115
+487053,Destiny,Udogie,Udogie,401044
+487117,Evan,Ferguson,Ferguson,423720
+487676,Trai,Hume,Hume,424514
+487693,Devan,Tanton,Tanton,507719
+487702,Luca,Koleosho,Koleosho,438959
+487818,Joe,Whitworth,Whitworth,454492
+487828,Omari,Forson,Forson,491385
+487835,Benjamin,Chrisene,Chrisene,381144
+487836,Antwoine,Hackford,Hackford,408769
+487837,Divin,Mubama,Mubama,454820
+487838,Lewis,Hall,Hall,430294
+487968,Ameen,Al-Dakhil,Al-Dakhil,419917
+488024,Yéremy,Pino Santos,Yeremy,403865
+488213,Tolu,Arokodare,Tolu,402056
+488404,Facundo,Pellistri Rebollo,Pellistri,404086
+488439,Woyo,Coulibaly,Coulibaly,447492
+489580,Calvin,Ramsay,Ramsay,403764
+489639,Bart,Verbruggen,Verbruggen,400138
+489706,Justin,Devenny,Devenny,450950
+489888,Amine,Adli,Adli,389409
+490094,Tim,Iroegbunam,Iroegbunam,416208
+490095,Ty,Barnett,Barnett,512928
+490098,Kaine,Hayden,Hayden,396316
+490138,Jakub,Ojrzynski,Ojrzynski,411099
+490142,Freddie,Potts,Potts,429534
+490145,Dane,Scarlett,Scarlett,407154
+490146,Jay,Stansfield,Stansfield,390214
+490150,Michael,Ndiweni,Ndiweni,495904
+490161,Abu,Kamara,Kamara,435987
+490503,Samuel,Edozie,Edozie,421974
+490721,Hugo,Bueno López,H.Bueno,409730
+490881,Toby,Collyer,Collyer,491384
+490885,George,Earthy,Earthy,491564
+490887,Zach,Awe,Awe,432338
+491007,Dário,Luís Essugo,D.Essugo,411914
+491008,Diogo,Pinheiro Monteiro,Monteiro,474333
+491011,Diego Manuel Jadon,da Silva Moreira,Diego Moreira,438349
+491012,Youssef,Ramalho Chermiti,Y.Chermiti,447229
+491279,Micky,van de Ven,Van de Ven,425229
+491501,James,McConnell,McConnell,492375
+491551,Thierry,Small,Small,409496
+491556,Charlie,Whitaker,Whitaker,425969
+491557,Jenson,Metcalfe,Metcalfe,512228
+491559,Isaac,Price,Price,413424
+491598,Cameron,Peupion,Peupion,454792
+491745,Elijah,Campbell,Campbell,512227
+491785,Harvey,Vale,Vale,427102
+491970,Bobby,Clark,Clark,450021
+492066,Niall,Huggins,Huggins,383320
+492373,Charlie,Cresswell,Cresswell,400646
+492374,Jack,Jenkins,Jenkins,405475
+492776,Dexter,Lembikisa,Lembikisa,430871
+492777,Conor,Bradley,Bradley,424945
+492779,Yago,de Santiago Alonso,Yago Santiago,468089
+492831,Zeki,Amdouni,Amdouni,424624
+492859,Wilfried,Gnonto,Gnonto,439636
+493105,Alejandro,Garnacho Ferreyra,Garnacho,437022
+493121,Roshaun,Mathurin,Mathurin,520826
+493125,Radu,Drăgușin,Dragusin,400097
+493250,Amad,Diallo,Amad,386634
+493362,Xavi,Simons,Xavi,399772
+493736,Jimmy,Morgan,Morgan,464283
+493928,Marcelo,Flores,Flores,436286
+493934,Kwadwo,Baah,Baah,384353
+494041,Ethan,Brierley,Brierley,388487
+494307,Max,Alleyne,Alleyne,468845
+494521,Adrien,Truffert,Truffert,398301
+494541,Kamari,Doyle,Doyle,475756
+494543,Dominic,Ballard,Ballard,454751
+494551,Jayden,Moore,Moore,538254
+494595,Florian,Wirtz,Wirtz,394786
+494779,Albert,Grønbæk,Grønbæk,424809
+494960,Quilindschy,Hartman,Hartman,444739
+495024,Jay,Robinson,Jay Robinson,538255
+495542,Niels,Nkounkou,Nkounkou,386262
+496178,Roman,Dixon,Dixon,535878
+496179,Alfie,Devine,Devine,409089
+496185,Kaide,Gordon,Gordon,408662
+496208,Ben,Gannon-Doak,Gannon-Doak,430350
+496221,Adam,Wharton,Wharton,430774
+496222,Zak,Sturge,Sturge,498687
+496228,Sonny,Perkins,Perkins,428688
+496279,Isaac,Heath,Heath,552418
+496283,Mahamadou,Susoho,Susoho,449161
+496661,Tyler,Dibling,Dibling,438067
+496683,Max,Kinsey,Kinsey,473163
+497605,Liam,Gibbs,Gibbs,407261
+497606,Tawanda,Chirewa,Chirewa,437381
+497894,Rasmus,Højlund,Højlund,439584
+497949,David,Møller Wolfe,Møller Wolfe,415341
+498016,Robin,Roefs,Roefs,422814
+498046,Salah-Eddine,Oulad M'hand,Oulad M'hand,427103
+499167,Josh,Nichols,Nichols,534236
+499169,Myles,Lewis-Skelly,Lewis-Skelly,467918
+499175,Ethan,Nwaneri,Nwaneri,456771
+499300,Adam,Aznou,Aznou,513607
+499309,Marc,Guiu Paz,Marc Guiu,483208
+499604,Rayan Vitor,Simplício Rocha,Rayan,472122
+499716,James,Rowswell,Rowswell,572656
+499717,Jayden,Meghoma,Meghoma,496356
+499721,Mikey,Moore,Moore,526481
+499724,Samuel,Amo-Ameyaw,Amo-Ameyaw,482895
+499726,Callum,Olusesi,Olusesi,545661
+499857,Teddy,Sharman-Lowe,Sharman-Lowe,389093
+500016,Welington Damascena,Santos,Welington,389158
+500040,Cristhian,Mosquera,Mosquera,425591
+500052,Luca,Barrington,Barrington,511059
+500058,Jayden,Danns,Danns,517340
+500151,Nicolò,Savona,Savona,450289
+500267,Loïc,Badé,Badé,398416
+500926,Ronnie,Edwards,Edwards,405526
+501284,Michael,Olakigbe,Olakigbe,477987
+501468,Tayo,Adaramola,Adaramola,432086
+501620,Dante,Cassanova,Cassanova,476828
+501770,Ben,Nelson,Nelson,407585
+501837,Yerson,Mosquera Valdelamar,Mosquera,425060
+502222,Ramón,Sosa,Sosa,432672
+502500,Igor Thiago,Nascimento Rodrigues,Thiago,443784
+502697,Carlos,Alcaraz Durán,Alcaraz,391348
+502988,Danny,Imray,Imray,518796
+503139,Alex,Scott,Scott,410998
+503300,Matthew,Cox,Cox,399935
+503301,Omari,Hutchinson,Hutchinson,430908
+503308,James,Sweet,Sweet,504127
+503714,Lesley,Ugochukwu,Ugochukwu,404616
+503724,Lorenz,Assignon,Assignon,402874
+504198,Anis,Slimane,Slimane,425353
+504296,Coby,Ebere,Ebere,553206
+504598,Daniel,Gore,Gore,467768
+504750,Justin,Hubner,Hubner,510856
+504751,Mauro,Bandeira,Bandeira,476167
+504783,Kamaldeen,Sulemana,Kamaldeen,422135
+505079,Alfie,McNally,McNally,605442
+505187,Cesare,Casadei,Casadei,433219
+505265,Cheikh,Diaby,Diaby,408808
+507433,Hákon Rafn,Valdimarsson,Valdimarsson,412313
+508395,Yehor,Yarmoliuk,Yarmoliuk,444304
+508479,Filip,Jörgensen,Jörgensen,404749
+509291,André,Trindade da Costa Neto,André,397585
+509416,Yasin,Ayari,Ayari,470690
+510281,Sávio,Moreira de Oliveira,Savinho,397821
+510328,Stanley,Mills,Mills,444617
+510362,Toti,Gomes,Toti,431283
+510363,Francisco Jorge,Tomás Oliveira,Chiquinho,421894
+510500,João Pedro,Ferreira da Silva,Jota,444826
+510663,Hugo,Ekitiké,Ekitiké,403784
+511499,Mathys,Tel,Tel,422885
+511504,Kristian,Sekularac,Sekularac,454748
+511783,Anass,Zaroury,Zaroury,420145
+512462,Jake,O'Brien,O'Brien,424495
+513046,Danilo,dos Santos de Oliveira,Danilo,399250
+513418,Kevin,Schade,Schade,407260
+513433,Brajan,Gruda,Gruda,471784
+513466,Merlin,Röhl,Röhl,419945
+513527,Bilal,El Khannouss,El Khannouss,433572
+513588,Jamie,Donley,Donley,468090
+513789,Thanawat,Suengchitthawon,Suengchitthawon,412836
+513834,Andrew,Moran,Moran,423722
+513836,Leigh,Kavanagh,Kavanagh,510737
+513840,Samy,Chouchane,Chouchane,499173
+513852,Kris,Moore,Moore,429923
+514154,Ben,Jackson,Jackson,510510
+514229,Sam,Waller,Waller,433101
+514254,Diego,Gómez Amarilla,Gomez,446133
+514277,Jimi,Tauriainen,Tauriainen,517600
+514280,Alfie,Gilchrist,Gilchrist,467969
+514284,Joe,Wormleighton,Wormleighton,443574
+514287,Sil,Swinkels,Swinkels,408953
+514307,Jack,Henry-Francis,Jack Henry-Francis,450742
+514315,Lino,da Cruz Sousa,Sousa,450073
+514356,Roméo,Lavia,Lavia,425319
+514362,Temple,Ojinnaka,Ojinnaka,524089
+514514,Lewis,Koumas,Koumas,492374
+515023,Matthew,Dibley-Dias,Dibley-Dias,481276
+515024,Luke,Harris,Harris,444538
+515046,Melker,Ellborg,Ellborg,425235
+515496,Owen,Goodman,Goodman,460442
+515500,Rhys,Bennett,Bennett,467765
+515501,Álvaro,Fernández Carreras,Fernandez,437583
+515503,Jack,Wells-Morrison,Wells-Morrison,430750
+515504,Joe,Hugill,Hugill,467770
+515571,Juan,Larios López,Larios,455537
+515597,Lamare,Bogarde,Bogarde,408946
+515599,Tommi,O'Reilly,O'Reilly,433464
+515621,Chadi,Riad Dnanou,Chadi Riad,454342
+516159,Oliwier,Zych,Zych,408957
+516234,Charlie,Gray,Gray,604494
+516250,Jacob,Wright,Wright,513616
+516432,Valintino,Adedokun,Adedokun,451136
+516874,Charles,Sagoe,Sagoe,467920
+516875,Ronnie,Hollingshead,Hollingshead,499948
+516895,Kobbie,Mainoo,Mainoo,460260
+516939,Emmanuel,Agbadou,Agbadou,402810
+517052,Nicolas,Jackson,N.Jackson,426050
+517179,Alfie,Pond,Pond,437383
+517995,Leo,Castledine,Castledine,508375
+517996,Ronnie,Stutter,Stutter,502566
+518030,Max,Weiß,Weiss,426859
+518199,Fabian,Mrozek,Mrozek,454355
+518335,Max,Merrick,Merrick,515437
+518438,Kaelan,Casey,Casey,463053
+518442,Lewis,Orford,Orford,463054
+518466,Willy,Kambwala,Kambwala,494120
+518467,Marc,Jurado Gomez,Jurado,467766
+518504,James,Storer,Storer,427426
+518892,Ted,Curd,Curd,515222
+518906,Owen,Bevan,Bevan,454743
+519198,Alex,Matos,Matos,502567
+519223,Sammy,Braybrooke,Braybrooke,430780
+519321,Alfie,Dorrington,Dorrington,468087
+519324,Amario,Cozier-Duberry,Cozier-Duberry,455840
+519325,Habeeb,Ogunneye,Ogunneye,517767
+519327,George,Abbott,Abbott,479809
+519328,Callum,Scanlon,Scanlon,492373
+519440,Wellity,Lucky,Lucky,575451
+519634,Jenson,Seelt,Seelt,428694
+519895,Oliver,Sonne,Sonne,444334
+519913,Tyler,Fletcher,Fletcher,563778
+520295,David Datro,Fofana,D.D.Fofana,410522
+521966,Finley,Munroe,Munroe,515428
+523700,Daniel,Jebbison,Jebbison,415163
+523705,Jackson,Tchatchoua,Tchatchoua,408580
+523957,Bénie,Traoré,T.Bénie,485367
+524069,Dale,Taylor,Dale Taylor,428123
+524070,Jamie,McDonnell,McDonnell,499044
+524196,Shaqai,Forde,Forde,430781
+530117,Louis,Jackson,Jackson,524188
+530121,Zain,Silcott-Duberry,Silcott-Duberry,550772
+530318,Kaden,Rodney,Rodney,454759
+530335,Pablo Felipe,Pereira de Jesus,Pablo,409654
+530873,Dara,Costelloe,Costelloe,437322
+531076,Frankie,Maguire,Maguire,410176
+531170,Nasser,Djiga,Djiga,450392
+531363,Nathan,Fraser,Fraser,463235
+531442,Abdul,Fatawu,A.Fatawu,430985
+531989,David,Ozoh,Ozoh,464285
+531993,Ademola,Ola-Adebomi,Ola-Adebomi,504065
+531997,Henry,Cartwright,Cartwright,548148
+532135,Killian,Phillips,Phillips,435533
+532372,Oliver,Arblaster,Arblaster,434190
+532377,Louie,Marsh,Marsh,470708
+532528,Joshua,Duffus,Duffus,507295
+532529,Jack,Hinshelwood,Hinshelwood,469629
+532534,Will,Alves,Alves,430779
+532535,Thomas,Wilson-Brown,Wilson-Brown,443570
+532605,Andrey,Nascimento dos Santos,Andrey Santos,451236
+533463,Dango,Ouattara,O.Dango,422183
+533710,Iwan,Morgan,Morgan,533690
+533719,Adrian,Blake,Blake,438303
+534392,Mason,Burstow,Burstow,427632
+534836,Travis,Patterson,Patterson,479792
+535017,Julian,Eyestone,Eyestone,535753
+535262,Reuell,Walters,Walters,450072
+535264,Bradley,Ibrahim,Ibrahim,460136
+535301,Carlos,Baleba,Baleba,436048
+535339,Tiago,Çukur,Çukur,421921
+535818,Simon,Adingra,Adingra,443004
+535928,Stefan,Bajčetić Maquieira,Bajcetic,444540
+536109,Ollie,Scarles,Scarles,459708
+536110,Josh,Feeney,Feeney,414166
+536134,Rio,Kyerematen,Kyerematen,527813
+536238,Ishé,Samuels-Smith,Samuels-Smith,463992
+536241,Martin,Sherif,Sherif,539925
+536661,Nilson,Angulo,Angulo,443064
+536677,Detlef Esapa,Osong,Osong,470712
+536681,Joe,Gardner,Gardner,513614
+536694,Matheus,França de Oliveira,M.França,428635
+536908,Alejo,Véliz,Veliz,414269
+536916,Facundo,Buonanotte,Buonanotte,432384
+537403,Kadan,Young,Young,468162
+538182,Jimi,Gower,Gower,534238
+538206,Jordan,Amissah,Amissah,443541
+538207,William,Osula,Osula,416209
+538210,Andre,Brooks,Brooks,456511
+539721,Ruairi,McConville,McConville,458319
+541462,Matai,Akinmboni,Akinmboni,455460
+543158,Valentín,Barco,Barco,419341
+543295,Antoni,Milambo,Milambo,422921
+544877,Milos,Kerkez,Kerkez,424273
+545477,Alex,Murphy,A.Murphy,492690
+545508,Joseph,O'Brien-Whitmarsh,O'Brien-Whitmarsh,538257
+547027,Habib,Diarra,Diarra,422818
+547037,Jack,Fletcher,J.Fletcher,533128
+547410,Harrison,Jones,H.Jones,518341
+547668,Axel,Piesold,Piesold,473956
+547673,Charlie,Robinson,C.Robinson,454747
+547676,Tyler,Fredricson,Fredricson,455860
+547686,Luc,De Fougerolles,De Fougerolles,492688
+547692,Samuel,Rak-Sakyi,Rak-Sakyi,544166
+547693,Somto,Boniface,Boniface,558841
+547701,Archie,Gray,Gray,429922
+547716,Ben,Parkinson,Parkinson,492692
+547719,Lewis,Miley,L.Miley,474264
+547720,Charlie,Tasker,Tasker,556968
+547801,Callum,Bates,Bates,545741
+548308,Ashley,Phillips,Phillips,430775
+549014,Noël,Atom,Atom,527328
+549067,Zach,Abbott,Abbott,454750
+549068,Omari,Kellyman,Kellyman,428531
+549074,Tom,Watson,Watson,470715
+549329,Lucas,Pires Silva,Lucas Pires,436501
+549344,Sam,Curtis,Curtis,499658
+549640,Michael,Golding,Golding,513544
+549912,Chemsdine,Talbi,Talbi,476110
+550090,Diego,Coppola,Coppola,429683
+550596,Dominic,Sadi,Sadi,454746
+550615,Tyrique,George,George,523597
+550833,Noha,Lemina,N.Lemina,492693
+550839,Wilson,Odobert,Odobert,444751
+550864,Leny,Yoro,Yoro,437299
+551206,Jaydon,Banel,Banel,454337
+551210,Jorrel,Hato,Hato,467715
+551221,Tommy,Setford,Setford,489986
+551226,Mateus Gonçalo,Espanha Fernandes,M.Fernandes,447231
+551230,Renato,Palma Veiga,Renato Veiga,434077
+551232,Rodrigo,Duarte Ribeiro,Ribeiro,434076
+551483,Álex,Jiménez Sánchez,A.Jimenez,497295
+551995,Taylan,Harris,Harris,498566
+552030,Aidan,Francis-Clarke,Francis-Clarke,425421
+552425,Sydie,Peck,Peck,464732
+552427,Will,Lankshear,Lankshear,468091
+553299,Takai,Kōta,Takai,560833
+553746,Leo,Shahar,Shahar,535754
+554194,Jahmai,Simpson-Pusey,Simpson-Pusey,534072
+554197,Chris,Rigg,Rigg,469645
+554605,Dean,Huijsen,Huijsen,468852
+556637,Nehemiah,Oriola,Oriola,591587
+556639,Jayce,Fitzgerald,Fitzgerald,544967
+559610,Luka,Bentt,Bentt,607466
+559684,Jack,Moorhouse,Moorhouse,553323
+559962,Jamaldeen,Jimoh-Aloba,Jimoh-Aloba,540468
+559963,Kiano,Dyer,Dyer,523598
+560248,Bastien,Meupiyou Menadjou,Meupiyou,496917
+560262,Junior,Kroupi,Kroupi.Jr,479170
+560552,Kevin,Santos Lopes de Macedo,Kevin,429174
+563324,Brayden,Clarke,Clarke,559891
+563883,Vincent,Angelini,Angelini,429599
+563934,Tyrese,Hall,Hall,527306
+564406,Eliezer,Mayenda Dossou,Mayenda,494670
+564505,Sam,Proctor,Proctor,512312
+564940,Soungoutou,Magassa,S.Magassa,443815
+565297,Mateo,Joseph Fernández-Regatillo,Mateo Joseph,463233
+565431,Callum,Marshall,Marshall,484501
+565858,Killian,Cahill,Cahill,499656
+565863,Sam,Chambers,Chambers,537889
+566213,Stephen,Mfuni,Mfuni,534073
+567119,Shumaira,Mheuka,Mheuka,544167
+567121,Joe,Knight,Knight,551871
+568791,Callan,McKenna,McKenna,515753
+569014,Eric,da Silva Moreira,Da Silva Moreira,518913
+569577,Triston,Rowe,Rowe,540464
+570241,Kim,Ji-soo,Ji-soo,492686
+570526,Lucas,Bergvall,Bergvall,505295
+572702,Keiber,Lamadrid,Lamadrid,600774
+573062,Martial,Godo,Godo,454749
+573808,Jack,Grieves,Grieves,438304
+574398,Franco,Umeh-Chibueze,Umeh,517286
+574402,Mark,O’Mahony,O’Mahony,509424
+574458,Mamadou,Sarr,M.Sarr,467913
+574799,Damola,Ajayi,Ajayi,541187
+575034,Ethan,Wheatley,Wheatley,523346
+575204,Claudio,Echeverri,Echeverri,478241
+575458,Jair,Paula da Cunha Filho,Jair Cunha,443545
+575476,Murillo,Costa dos Santos,Murillo,445424
+575901,Julio,Soler Barreto,Soler,437310
+576620,Bendito,Mantato,Bendito Mantato,559774
+576628,Shea,Lacey,Lacey,563779
+576637,Godwill,Kukonki,Kukonki,547692
+576980,Zach,Marsh,Marsh,492372
+577016,Josh,Acheampong,Acheampong,518604
+577114,Luis Guilherme,Lira dos Santos,L.Guilherme,478319
+577285,George,Hemmings,George Hemmings,576066
+577669,Noah,Sadiki,Sadiki,437449
+577725,Josh,King,King,515865
+577731,Ben,Broggio,Broggio,540466
+577974,Harry,Amass,Amass,470680
+578153,Abdukodir,Khusanov,Khusanov,493206
+578545,Kosta,Nedeljković,Nedeljkovic,492955
+578614,Enock,Agyei,Boateng,472927
+579075,Asher,Agbinone,Agbinone,534896
+580921,Reigan,Heskey,Heskey,534462
+585472,Ryan,Oné,Oné,506728
+586268,Ármin,Pécsi,Pécsi,519492
+586309,Thierno,Barry,Barry,537713
+588555,Elyh,Harrison,Harrison,492376
+588793,Maldini,Kacurri,Kacurri,539715
+588796,Ismeal,Kabia,Kabia,539716
+589100,Jacob,Slater,Slater,447722
+589114,Zack,Nelson,Nelson,447731
+589121,Ethan,Sutherland,Sutherland,491702
+589507,Leon,Chiwome,Chiwome,518340
+590012,Caleb,Kporha,Kporha,534895
+590014,Rio,Cardines,Cardines,561659
+590035,Yusuf,Akhamrich,Akhamrich,572661
+590039,Divine,Mukasa,Mukasa,576821
+590760,Daniel,Adu-Adjei,Adu-Adjei,468929
+591357,Ryan,Trevitt,Trevitt,454756
+591382,Genesis,Antwi,Genesis Antwi,555021
+591384,George,King,King,570005
+591385,Samuel,Amissah,Amissah,492689
+591386,Trey,Nyoni,Nyoni,509423
+591538,Owen,Hampson,Hampson,525560
+591539,Billy,Blacker,Blacker,517009
+592031,Yankuba,Minteh,Minteh,484175
+592436,Travis,Hernes,Hernes,455133
+592661,Tristan,Crama,Crama,461505
+592662,Tony,Yogane,Yogane,533685
+592712,Tom,Taylor,Tom Taylor,554706
+592736,Maeson,King,King,546932
+593001,Enso,González Medina,Gonzalez,455760
+593174,Kaye,Furo,Furo,542805
+596042,Kieran,Morrison,Morrison,551573
+596047,Chido,Obi,Obi,553325
+596054,Tom,Edozie,Edozie,546622
+596572,Michael,Dacosta Gonzalez,Dacosta Gonzalez,471270
+596777,Patrick,Dorgu,Dorgu,495260
+597320,Harry,Howell,Howell,558409
+597983,Ollie,Harrison,Harrison,516952
+599303,Sean,Neave,Neave,552461
+600882,Harry,Gray,Gray,558919
+601496,Jili,Buyabu,Buyabu,460778
+601956,Saheed,Olagunju,Olagunju,605053
+602903,Ezra,Mayers,Mayers,547084
+602934,Fletcher,Holman,Holman,518914
+604211,Tymur,Tutierov,Tutierov,538450
+604988,Freddie,Simmonds,Simmonds,558408
+605319,Luke,Rawlings,Rawlings,534897
+606689,Romelle,Donovan,Donovan,471696
+606745,Ayden,Heaven,Heaven,517341
+606774,Remy,Rees-Dottin,Rees-Dottin,549379
+606775,Ben,Winterburn,Winterburn,547069
+606798,Andrés,García,A.García,469329
+606921,Romain,Esse,Esse,469485
+607464,Michael,Kayode,Kayode,470031
+608060,Jayden,Luker,Luker,470737
+608181,Stefanos,Tzimas,Tzimas,519565
+609640,Mathis,Amougou,Amougou,511364
+609873,Harrison,Armstrong,Armstrong,535879
+610799,Luka,Vušković,Vuskovic,533010
+611011,Joseph,Johnson,Johnson,473957
+611912,Landon,Emenalo,Emenalo,558697
+611917,Lucá,Williams-Barnett,Williams-Barnett,545662
+611920,Malachi,Hardy,Hardy,546642
+611922,Rio,Ngumoha,Ngumoha,548566
+611926,Amara,Nallo,Nallo,517768
+612534,Benjamin,Fredrick,Fredrick,513405
+613120,Spike,Brits,Brits,549309
+613467,Wes,Okoduwa,Okoduwa,517909
+613804,El Hadji Malick,Diouf,Diouf,479288
+614574,Alex,Tóth,Tóth.A,476166
+616059,Jack,Porter,Porter,540048
+616065,Marli,Salmon,Salmon,571992
+616077,Max,Dowman,Dowman,571994
+616094,Dovydas,Sasnauskas,Sasnauskas,517585
+616221,João Victor,de Souza Menezes,Souza,549079
+616222,Vitor,de Oliveira Nunes dos Reis,Vitor Reis,478314
+616288,Ryan,McAidoo,McAidoo,584927
+617054,Deivid Washington,de Souza Eugênio,Deivid,478451
+618027,TJ,Carroll,Carroll,605391
+618873,Sékou,Koné,Kone,553324
+619146,Olabade,Aluko,Olabade Aluko,558410
+619536,Seth,Ridgeon,Ridgeon,597683
+620408,Joachim,Kayi-Sanda,Kayi Sanda,511704
+620487,Veljko,Milosavljevic,Milosavljević,510940
+622536,Benjamin,Arthur,Arthur,496342
+622758,Aarón,Anselmino,Anselmino,484211
+623095,Yang,Min-hyeok,Min-hyeok,549454
+623110,Seung-Soo,Park,Seung soo,573458
+624773,Estêvão,Almeida de Oliveira Gonçalves,Estêvão,510728
+626464,Gustavo,Nunes Fernandes Gomes,Nunes,492869
+626844,Milan,Aleksić,Aleksić,538488
+628204,Yunus Emre,Konak,Konak,495584
+629068,Braiden,Graham,Graham,582990
+630664,Jake,Evans,Jake Evans,558411
+630699,Mohamadou,Kanté,Mohamadou Kanté,511560
+631106,Ben,Casey,Casey,603932
+631786,Jonah,Kusi-Asare,Kusi-Asare,547830
+632822,Archie,Harris,Harris,549315
+634640,Christian,Chigozie,Chigozie,521698
+640419,Jun'ai,Byfield,Byfield,572655
+641221,Pedro,Cardoso de Lima,Pedro Lima,532920
+643135,Fer,López González,Fer López,544982
+643426,Dean,Benamar,Benamar,574690
+643473,Airidas,Golambeckis,Golambeckis,572171
+645618,Bradley,Burrowes,Burrowes,550064
+646243,Andre,Harriman-Annous,Harriman-Annous,571995
+646754,Lander,Emery,Emery,527644
+647597,Dominic,Dos Santos Martins,Martins,518664
+647671,Mateus,Mané,Mané,554310
+647681,Giovanni,Leoni,Leoni,516040
+647850,Charalampos,Kostoulas,Kostoulas,533923
+647960,Oliver,Pimlott,Pimlott,581382
+649208,Jeremy,Monga,Monga,552366
+651426,Jaydee,Canvot,Canvot,531676
+653481,Alysson Edward Franco,da Rocha dos Santos,Alysson,520919
+658013,Charlie,Stevens,Stevens,606358
+660392,Christantus,Uche,Uche,531674
+661712,Diego,León Blanco,D.Leon,533375
+664015,Leon,Routh,Leon Routh,605159
+666607,Sam,Alabi,Alabi,601986
+672492,Joél,Drakes-Thomas,Drakes-Thomas,603933
+678552,Malcom,DaCosta,DaCosta,602543
+685628,Jerome,Abbey,Abbey,607348
+699989,Djiamgone Jocelin Ta,Bi,Jocelin.T,606073
+704232,George,Brierley,Brierley,584317


### PR DESCRIPTION
## WhoScored player IDs — 2016-17 to 2025-26

Adds WhoScored player IDs for 2,457 players (94.5% of Master.csv).

### Files changed
- **whoscored.csv** — standalone source file matching the format of FBRef.csv / Understat.csv / Transfermarkt.csv
- **generate_master.py** — updated to include whoscored.csv and add `whoscored` to col_order with Int64 casting
- **Master.csv** — regenerated via generate_master.py

### Methodology
IDs matched via shirt number triangulation using FotMob match data as a bridge between FPL opta codes and WhoScored player IDs, covering all 10 PL seasons (2016-17 to 2025-26).

Match tiers:
1. Shirt number match confirmed across 2+ seasons — 1,231 players
2. Shirt number match in 1 season — 929 players
3. Exact name match — 193 players
4. Fuzzy token name match — 113 players

### On the missing ~5%
The unmatched players are ones I couldn't triangulate — they appear in FPL data but I couldn't find a reliable shirt number or name match in WhoScored data. This typically means they played very few minutes (appearing only as unused subs or in squad registrations), so there wasn't enough match data to make a confident link. They are not necessarily absent from WhoScored entirely — just unmatched with this approach.